### PR TITLE
faster GT membership

### DIFF
--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -359,10 +359,6 @@ func (z *E12) SetBytes(e []byte) error {
 
 	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
 
-	if !z.IsInSubGroup() {
-		return errors.New("subgroup check failed")
-	}
-
 	return nil
 }
 

--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"math/big"
 )
 
@@ -360,20 +359,28 @@ func (z *E12) SetBytes(e []byte) error {
 
 	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
 
-	// TODO is it the right place?
-	//if !z.IsInSubGroup() {
-	//	return errors.New("subgroup check failed")
-	//}
+	if !z.IsInSubGroup() {
+		return errors.New("subgroup check failed")
+	}
 
 	return nil
 }
 
-var frModulus = fr.Modulus()
-
 // IsInSubGroup ensures GT/E12 is in correct sugroup
 func (z *E12) IsInSubGroup() bool {
-	var one, _z E12
-	one.SetOne()
-	_z.Exp(z, *frModulus)
-	return _z.Equal(&one)
+	var a, b E12
+
+	// check z^(Phi_k(p)) == 1
+	a.FrobeniusSquare(z)
+	b.FrobeniusSquare(&a).Mul(&b, z)
+
+	if !a.Equal(&b) {
+		return false
+	}
+
+	// check z^(p+1-t) == 1
+	a.Frobenius(z)
+	b.Expt(z)
+
+	return a.Equal(&b)
 }

--- a/ecc/bls12-377/pairing_test.go
+++ b/ecc/bls12-377/pairing_test.go
@@ -52,12 +52,8 @@ func TestPairing(t *testing.T) {
 
 	properties.Property("[BLS12-377] Exponentiating FinalExpo(a) to r should output 1", prop.ForAll(
 		func(a *GT) bool {
-			var one GT
-			e := fr.Modulus()
-			one.SetOne()
-			*a = FinalExponentiation(a)
-			a.Exp(a, *e)
-			return a.Equal(&one)
+			b := FinalExponentiation(a)
+			return !a.IsInSubGroup() && b.IsInSubGroup()
 		},
 		genA,
 	))

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -359,10 +359,6 @@ func (z *E12) SetBytes(e []byte) error {
 
 	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
 
-	if !z.IsInSubGroup() {
-		return errors.New("subgroup check failed")
-	}
-
 	return nil
 }
 

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
-	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"math/big"
 )
 
@@ -360,20 +359,28 @@ func (z *E12) SetBytes(e []byte) error {
 
 	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
 
-	// TODO is it the right place?
-	//if !z.IsInSubGroup() {
-	//	return errors.New("subgroup check failed")
-	//}
+	if !z.IsInSubGroup() {
+		return errors.New("subgroup check failed")
+	}
 
 	return nil
 }
 
-var frModulus = fr.Modulus()
-
 // IsInSubGroup ensures GT/E12 is in correct sugroup
 func (z *E12) IsInSubGroup() bool {
-	var one, _z E12
-	one.SetOne()
-	_z.Exp(z, *frModulus)
-	return _z.Equal(&one)
+	var a, b E12
+
+	// check z^(Phi_k(p)) == 1
+	a.FrobeniusSquare(z)
+	b.FrobeniusSquare(&a).Mul(&b, z)
+
+	if !a.Equal(&b) {
+		return false
+	}
+
+	// check z^(p+1-t) == 1
+	a.Frobenius(z)
+	b.Expt(z)
+
+	return a.Equal(&b)
 }

--- a/ecc/bls12-381/pairing_test.go
+++ b/ecc/bls12-381/pairing_test.go
@@ -52,12 +52,8 @@ func TestPairing(t *testing.T) {
 
 	properties.Property("[BLS12-381] Exponentiating FinalExpo(a) to r should output 1", prop.ForAll(
 		func(a *GT) bool {
-			var one GT
-			e := fr.Modulus()
-			one.SetOne()
-			*a = FinalExponentiation(a)
-			a.Exp(a, *e)
-			return a.Equal(&one)
+			b := FinalExponentiation(a)
+			return !a.IsInSubGroup() && b.IsInSubGroup()
 		},
 		genA,
 	))

--- a/ecc/bn254/internal/fptower/e12.go
+++ b/ecc/bn254/internal/fptower/e12.go
@@ -335,10 +335,6 @@ func (z *E12) SetBytes(e []byte) error {
 
 	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
 
-	if !z.IsInSubGroup() {
-		return errors.New("subgroup check failed")
-	}
-
 	return nil
 }
 

--- a/ecc/bn254/pairing_test.go
+++ b/ecc/bn254/pairing_test.go
@@ -52,12 +52,8 @@ func TestPairing(t *testing.T) {
 
 	properties.Property("[BN254] Exponentiating FinalExpo(a) to r should output 1", prop.ForAll(
 		func(a *GT) bool {
-			var one GT
-			e := fr.Modulus()
-			one.SetOne()
-			*a = FinalExponentiation(a)
-			a.Exp(a, *e)
-			return a.Equal(&one)
+			b := FinalExponentiation(a)
+			return !a.IsInSubGroup() && b.IsInSubGroup()
 		},
 		genA,
 	))

--- a/ecc/bw6-761/internal/fptower/e6.go
+++ b/ecc/bw6-761/internal/fptower/e6.go
@@ -333,5 +333,71 @@ func (z *E6) SetBytes(e []byte) error {
 	z.B0.A0.SetBytes(e[offset : offset+sizeOfFp])
 	offset += sizeOfFp
 
+	if !z.IsInSubGroup() {
+		return errors.New("subgroup check failed")
+	}
+
 	return nil
+}
+
+// IsInSubGroup ensures GT/E6 is in correct sugroup
+func (z *E6) IsInSubGroup() bool {
+	var tmp, a, _a, b E6
+	var t [6]E6
+
+	// check z^(Phi_k(p)) == 1
+	a.Frobenius(z)
+	b.FrobeniusSquare(z).Mul(&b, z)
+
+	if !a.Equal(&b) {
+		return false
+	}
+
+	// check z^(p+1-t) == 1
+	_a.Frobenius(z)
+	a.CyclotomicSquare(&_a).Mul(&a, &_a) // z^(3p)
+
+	// t(x)-1 = (13x^6 − 23x^5 − 9x^4 + 35x^3 + 10x + 19)/3
+	t[0].CyclotomicSquare(z) // z^2
+	t[1].CyclotomicSquare(&t[0]).
+		CyclotomicSquare(&t[1]) // z^8
+	t[2].CyclotomicSquare(&t[1]).
+		Mul(&t[2], &t[0]).
+		Mul(&t[2], z) // z^19*
+	t[3].Mul(&t[0], &t[1]).
+		Expt(&t[3]) // z^(10u)*
+	t[4].CyclotomicSquare(&t[3]).
+		Mul(&t[4], &t[3]) // z^(30u)
+	t[0].CyclotomicSquare(&t[0]).
+		Mul(&t[0], z).
+		Expt(&t[0]) // z^(5u)
+	t[4].Mul(&t[4], &t[0]).
+		Expt(&t[4]).
+		Expt(&t[4]) // z^(35u^3)*
+	t[1].Mul(&t[1], z).
+		Expt(&t[1]).
+		Expt(&t[1]).
+		Expt(&t[1]).
+		Expt(&t[1]).
+		Conjugate(&t[1]) // z^(-9u^4)*
+	t[0].Expt(&t[0]).
+		Expt(&t[0]).
+		Expt(&t[0]).
+		Conjugate(&t[0]) // z^(-5u^4)
+	t[5].CyclotomicSquare(&t[1]).
+		Mul(&t[5], &t[0]).
+		Expt(&t[5]) // z^(-23u^5)*
+	tmp.CyclotomicSquare(&t[1]).
+		Conjugate(&tmp) // z^(18u^4)
+	t[0].Mul(&t[0], &tmp).
+		Expt(&t[0]).
+		Expt(&t[0]) // z^(13u^6)*
+
+	b.Mul(&t[2], &t[3]).
+		Mul(&b, &t[4]).
+		Mul(&b, &t[1]).
+		Mul(&b, &t[5]).
+		Mul(&b, &t[0]) // z^(3(t-1))
+
+	return a.Equal(&b)
 }

--- a/ecc/bw6-761/internal/fptower/e6.go
+++ b/ecc/bw6-761/internal/fptower/e6.go
@@ -333,10 +333,6 @@ func (z *E6) SetBytes(e []byte) error {
 	z.B0.A0.SetBytes(e[offset : offset+sizeOfFp])
 	offset += sizeOfFp
 
-	if !z.IsInSubGroup() {
-		return errors.New("subgroup check failed")
-	}
-
 	return nil
 }
 

--- a/ecc/bw6-761/pairing_test.go
+++ b/ecc/bw6-761/pairing_test.go
@@ -53,12 +53,8 @@ func TestPairing(t *testing.T) {
 
 	properties.Property("[BW6-761] Exponentiating FinalExpo(a) to r should output 1", prop.ForAll(
 		func(a *GT) bool {
-			var one GT
-			e := fr.Modulus()
-			one.SetOne()
-			*a = FinalExponentiation(a)
-			a.Exp(a, *e)
-			return a.Equal(&one)
+			b := FinalExponentiation(a)
+			return !a.IsInSubGroup() && b.IsInSubGroup()
 		},
 		genA,
 	))

--- a/internal/generator/pairing/template/tests/pairing.go.tmpl
+++ b/internal/generator/pairing/template/tests/pairing.go.tmpl
@@ -38,12 +38,8 @@ func TestPairing(t *testing.T) {
 
     properties.Property("[{{ toUpper .Name}}] Exponentiating FinalExpo(a) to r should output 1", prop.ForAll(
 		func(a *GT) bool {
-			var one GT
-			e := fr.Modulus()
-			one.SetOne()
-			*a = FinalExponentiation(a)
-			a.Exp(a, *e)
-			return a.Equal(&one)
+            b := FinalExponentiation(a)
+			return !a.IsInSubGroup() && b.IsInSubGroup()
 		},
 		genA,
 	))

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -312,10 +312,6 @@ func (z *E12) SetBytes(e []byte) error {
 	{{- $offset := mul $sizeOfFp 0}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C1.B2.A1"}}
 
-	if !z.IsInSubGroup() {
-		return errors.New("subgroup check failed")
-	}
-
 	return nil
 }
 

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -3,7 +3,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fp"
-	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
 )
 
 // E12 is a degree two finite field extension of fp6
@@ -80,12 +79,12 @@ func (z *E12) Double(x *E12) *E12 {
 // SetRandom used only in tests
 func (z *E12) SetRandom() (*E12, error) {
 	if _, err := z.C0.SetRandom(); err != nil {
-		return nil, err 
+		return nil, err
 	}
 	if _, err := z.C1.SetRandom(); err != nil {
-		return nil, err 
+		return nil, err
 	}
-	return z, nil 
+	return z, nil
 }
 
 // Mul set z=x*y in E12 and return z
@@ -199,7 +198,7 @@ func (z *E12) InverseUnitary(x *E12) *E12 {
 
 // Conjugate set z to x conjugated and return z
 func (z *E12) Conjugate(x *E12) *E12 {
-	*z = *x 
+	*z = *x
 	z.C1.Neg(&z.C1)
 	return z
 }
@@ -221,7 +220,7 @@ func (z *E12) Unmarshal(buf []byte) error {
 	return z.SetBytes(buf)
 }
 
-// Bytes returns the regular (non montgomery) value 
+// Bytes returns the regular (non montgomery) value
 // of z as a big-endian byte array.
 // z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) Bytes() (r [SizeOfGT]byte) {
@@ -230,7 +229,7 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 
 	{{- $offset := mul $sizeOfFp 11}}
 	{{- template "putFp" dict "all" . "OffSet" $offset "From" "_z.C0.B0.A0"}}
-	
+
 	{{- $offset := mul $sizeOfFp 10}}
 	{{- template "putFp" dict "all" . "OffSet" $offset "From" "_z.C0.B0.A1"}}
 
@@ -242,7 +241,7 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 
 	{{- $offset := mul $sizeOfFp 7}}
 	{{- template "putFp" dict "all" . "OffSet" $offset "From" "_z.C0.B2.A0"}}
-	
+
 	{{- $offset := mul $sizeOfFp 6}}
 	{{- template "putFp" dict "all" . "OffSet" $offset "From" "_z.C0.B2.A1"}}
 
@@ -268,7 +267,7 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 }
 
 
-// SetBytes interprets e as the bytes of a big-endian GT 
+// SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == {{ $sizeOfFp }} * 12
 // z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
@@ -279,7 +278,7 @@ func (z *E12) SetBytes(e []byte) error {
 
 	{{- $offset := mul $sizeOfFp 11}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C0.B0.A0"}}
-	
+
 	{{- $offset := mul $sizeOfFp 10}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C0.B0.A1"}}
 
@@ -291,7 +290,7 @@ func (z *E12) SetBytes(e []byte) error {
 
 	{{- $offset := mul $sizeOfFp 7}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C0.B2.A0"}}
-	
+
 	{{- $offset := mul $sizeOfFp 6}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C0.B2.A1"}}
 
@@ -313,22 +312,41 @@ func (z *E12) SetBytes(e []byte) error {
 	{{- $offset := mul $sizeOfFp 0}}
 	{{- template "readFp" dict "all" . "OffSet" $offset "To" "z.C1.B2.A1"}}
 
-	// TODO is it the right place?  
-	//if !z.IsInSubGroup() {
-	//	return errors.New("subgroup check failed")
-	//}
+	if !z.IsInSubGroup() {
+		return errors.New("subgroup check failed")
+	}
 
 	return nil
 }
 
-var frModulus = fr.Modulus()
-
 // IsInSubGroup ensures GT/E12 is in correct sugroup
 func (z *E12) IsInSubGroup() bool {
-	var one, _z E12
-	one.SetOne()
-	_z.Exp(z, *frModulus)
-	return _z.Equal(&one) 
+{{- if eq .Name "bn254"}}
+    var a, b, _b E12
+
+    a.Frobenius(z)
+    b.Expt(z).
+        Expt(&b).
+        CyclotomicSquare(&b)
+    _b.CyclotomicSquare(&b)
+    b.Mul(&b, &_b)
+{{ else }}
+    var a, b E12
+
+    // check z^(Phi_k(p)) == 1
+    a.FrobeniusSquare(z)
+    b.FrobeniusSquare(&a).Mul(&b, z)
+
+    if !a.Equal(&b) {
+        return false
+    }
+
+    // check z^(p+1-t) == 1
+    a.Frobenius(z)
+    b.Expt(z)
+{{ end }}
+
+    return a.Equal(&b)
 }
 
 {{define "putFp"}}


### PR DESCRIPTION
- BN:
`g^(6*u^2) == g^p` 
- BLS12:
`g^(p^4+1) == g^(p^2) && g^p == g^u`
- BW6:
`g^(p^2+1) == g^p && g^(3p) == g^(13u^6 − 23u^5 − 9u^4 + 35u^3 + 10u + 19)`

Using Granger-Scott `CyclotomicSquare`, and `Conjugate` for inverse once the first check is verified (`g` in the cyclotomic subgroup).