### PR TITLE
Feat/kzg/multi points

### DIFF
--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -288,21 +288,10 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
 	// compute sum_i gamma**i*f(a)
 	var sumGammaiTimesEval fr.Element
@@ -348,101 +337,186 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff bls12377.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff bls12377.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai, ecc.MultiExpConfig{}); err != nil {
-		return err
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff bls12377.G1Affine
-	var t1, t2 bls12377.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls12377.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients bls12377.G1Affine
+	quotients := make([]bls12377.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff bls12377.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH bls12377.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit bls12377.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients bls12377.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
 	check, err := bls12377.PairingCheck(
-		[]bls12377.G1Affine{sumGammiDiffG1Aff, negH},
-		[]bls12377.G2Affine{srs.G2[0], xminusaG2Aff},
+		[]bls12377.G1Affine{foldedDigests, foldedQuotients},
+		[]bls12377.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
+}
+
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
 }
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form

--- a/ecc/bls12-377/fr/kzg/kzg_test.go
+++ b/ecc/bls12-377/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -288,21 +288,10 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
 	// compute sum_i gamma**i*f(a)
 	var sumGammaiTimesEval fr.Element
@@ -348,101 +337,186 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff bls12381.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff bls12381.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai, ecc.MultiExpConfig{}); err != nil {
-		return err
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff bls12381.G1Affine
-	var t1, t2 bls12381.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls12381.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients bls12381.G1Affine
+	quotients := make([]bls12381.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff bls12381.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH bls12381.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit bls12381.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients bls12381.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
 	check, err := bls12381.PairingCheck(
-		[]bls12381.G1Affine{sumGammiDiffG1Aff, negH},
-		[]bls12381.G2Affine{srs.G2[0], xminusaG2Aff},
+		[]bls12381.G1Affine{foldedDigests, foldedQuotients},
+		[]bls12381.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
+}
+
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
 }
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form

--- a/ecc/bls12-381/fr/kzg/kzg_test.go
+++ b/ecc/bls12-381/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -288,21 +288,10 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
 	// compute sum_i gamma**i*f(a)
 	var sumGammaiTimesEval fr.Element
@@ -348,101 +337,186 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff bls24315.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff bls24315.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai, ecc.MultiExpConfig{}); err != nil {
-		return err
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff bls24315.G1Affine
-	var t1, t2 bls24315.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls24315.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients bls24315.G1Affine
+	quotients := make([]bls24315.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff bls24315.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH bls24315.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit bls24315.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients bls24315.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
 	check, err := bls24315.PairingCheck(
-		[]bls24315.G1Affine{sumGammiDiffG1Aff, negH},
-		[]bls24315.G2Affine{srs.G2[0], xminusaG2Aff},
+		[]bls24315.G1Affine{foldedDigests, foldedQuotients},
+		[]bls24315.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
+}
+
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
 }
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bls24-315/fr/kzg/kzg_test.go
+++ b/ecc/bls24-315/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bn254/fr/kzg/kzg_test.go
+++ b/ecc/bn254/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -288,21 +288,10 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
 	// compute sum_i gamma**i*f(a)
 	var sumGammaiTimesEval fr.Element
@@ -348,101 +337,186 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff bw6633.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff bw6633.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai, ecc.MultiExpConfig{}); err != nil {
-		return err
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff bw6633.G1Affine
-	var t1, t2 bw6633.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bw6633.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients bw6633.G1Affine
+	quotients := make([]bw6633.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff bw6633.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH bw6633.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit bw6633.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients bw6633.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
 	check, err := bw6633.PairingCheck(
-		[]bw6633.G1Affine{sumGammiDiffG1Aff, negH},
-		[]bw6633.G2Affine{srs.G2[0], xminusaG2Aff},
+		[]bw6633.G1Affine{foldedDigests, foldedQuotients},
+		[]bw6633.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
+}
+
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
 }
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bw6-633/fr/kzg/kzg_test.go
+++ b/ecc/bw6-633/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -320,7 +320,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -516,9 +516,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -288,21 +288,10 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
 	// compute sum_i gamma**i*f(a)
 	var sumGammaiTimesEval fr.Element
@@ -348,101 +337,186 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff bw6761.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff bw6761.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai, ecc.MultiExpConfig{}); err != nil {
-		return err
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff bw6761.G1Affine
-	var t1, t2 bw6761.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bw6761.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients bw6761.G1Affine
+	quotients := make([]bw6761.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff bw6761.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH bw6761.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit bw6761.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients bw6761.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
 	check, err := bw6761.PairingCheck(
-		[]bw6761.G1Affine{sumGammiDiffG1Aff, negH},
-		[]bw6761.G2Affine{srs.G2[0], xminusaG2Aff},
+		[]bw6761.G1Affine{foldedDigests, foldedQuotients},
+		[]bw6761.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
+}
+
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
 }
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form

--- a/ecc/bw6-761/fr/kzg/kzg_test.go
+++ b/ecc/bw6-761/fr/kzg/kzg_test.go
@@ -189,7 +189,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -237,7 +237,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials

--- a/fiat-shamir/transcript.go
+++ b/fiat-shamir/transcript.go
@@ -26,20 +26,6 @@ var (
 	errPreviousChallengeNotComputed = errors.New("the previous challenge is needed and has not been computed")
 )
 
-// HashFS hash function used in Fiat Shamir. Likely snark friendly hash functions will be chosen.
-type HashFS uint
-
-// Supported hash functions for Fiat Shamir. Sha256 is arbitrary, we just need something fast non-snark friendly hash.
-const (
-	SHA256 HashFS = iota
-	MIMC_BN254
-	MIMC_BLS12_381
-	MIMC_BLS12_377
-	MIMC_BW6_761
-	MIMC_BLS24_315
-	MIMC_BW6_633
-)
-
 // Transcript handles the creation of challenges for Fiat Shamir.
 type Transcript struct {
 

--- a/fiat-shamir/transcript.go
+++ b/fiat-shamir/transcript.go
@@ -15,11 +15,8 @@
 package fiatshamir
 
 import (
-	"crypto/sha256"
 	"errors"
 	"hash"
-
-	gnark_hash "github.com/consensys/gnark-crypto/hash"
 )
 
 // errChallengeNotFound is returned when a wrong challenge name is provided.
@@ -70,7 +67,7 @@ type Transcript struct {
 // NewTranscript returns a new transcript.
 // h is the hash function that is used to compute the challenges.
 // challenges are the name of the challenges. The order is important.
-func NewTranscript(h HashFS, challenges ...string) Transcript {
+func NewTranscript(h hash.Hash, challenges ...string) Transcript {
 
 	var res Transcript
 
@@ -89,24 +86,7 @@ func NewTranscript(h HashFS, challenges ...string) Transcript {
 
 	res.isComputed = make([]bool, res.nbChallenges)
 
-	switch h {
-	case SHA256:
-		res.h = sha256.New()
-	case MIMC_BN254:
-		res.h = gnark_hash.MIMC_BN254.New("seed")
-	case MIMC_BLS12_381:
-		res.h = gnark_hash.MIMC_BLS12_381.New("seed")
-	case MIMC_BLS12_377:
-		res.h = gnark_hash.MIMC_BLS12_377.New("seed")
-	case MIMC_BW6_761:
-		res.h = gnark_hash.MIMC_BW6_761.New("seed")
-	case MIMC_BLS24_315:
-		res.h = gnark_hash.MIMC_BLS24_315.New("seed")
-	case MIMC_BW6_633:
-		res.h = gnark_hash.MIMC_BW6_633.New("seed")
-	default:
-		panic("the chosen hash function is not available")
-	}
+	res.h = h
 
 	return res
 }

--- a/fiat-shamir/transcript.go
+++ b/fiat-shamir/transcript.go
@@ -128,6 +128,7 @@ func (m *Transcript) ComputeChallenge(challenge string) ([]byte, error) {
 		return m.challenges[challengeNumber], nil
 	}
 
+	// reset before populating the internal state
 	m.h.Reset()
 
 	// write the challenge name, the purpose is to have a domain separator
@@ -158,6 +159,9 @@ func (m *Transcript) ComputeChallenge(challenge string) ([]byte, error) {
 	m.challenges[challengeNumber] = make([]byte, len(res))
 	copy(m.challenges[challengeNumber], res)
 	m.isComputed[challengeNumber] = true
+
+	// reset the hash function in case it is used for other things
+	m.h.Reset()
 
 	return res, nil
 

--- a/fiat-shamir/transcript_test.go
+++ b/fiat-shamir/transcript_test.go
@@ -16,12 +16,13 @@ package fiatshamir
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
 )
 
 func initTranscript() Transcript {
 
-	fs := NewTranscript(SHA256, "alpha", "beta", "gamma")
+	fs := NewTranscript(sha256.New(), "alpha", "beta", "gamma")
 
 	values := [][]byte{[]byte("v1"), []byte("v2"), []byte("v3"), []byte("v4"), []byte("v5"), []byte("v6")}
 	fs.Bind("alpha", values[0])

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -498,9 +498,6 @@ func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, 
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
 
-	// reset the hash in case it is reused
-	hf.Reset()
-
 	return gamma, nil
 }
 

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -22,30 +22,30 @@ var (
 )
 
 // Digest commitment of a polynomial.
-type Digest = {{ .CurvePackage }}.G1Affine
+type Digest = {{ .CurvePackage}}.G1Affine
 
 // SRS stores the result of the MPC
 type SRS struct {
-	G1 []{{ .CurvePackage }}.G1Affine  // [gen [alpha]gen , [alpha**2]gen, ... ]
-	G2 [2]{{ .CurvePackage }}.G2Affine // [gen, [alpha]gen ]
+	G1 []{{ .CurvePackage}}.G1Affine  // [gen [alpha]gen , [alpha**2]gen, ... ]
+	G2 [2]{{ .CurvePackage}}.G2Affine // [gen, [alpha]gen ]
 }
 
 // NewSRS returns a new SRS using alpha as randomness source
 //
 // In production, a SRS generated through MPC should be used.
-// 
+//
 // implements io.ReaderFrom and io.WriterTo
 func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	if size < 2 {
 		return nil, ErrMinSRSSize
 	}
 	var srs SRS
-	srs.G1 = make([]{{ .CurvePackage }}.G1Affine, size)
+	srs.G1 = make([]{{ .CurvePackage}}.G1Affine, size)
 
 	var alpha fr.Element
 	alpha.SetBigInt(bAlpha)
 
-	_, _, gen1Aff, gen2Aff := {{ .CurvePackage }}.Generators()
+	_, _, gen1Aff, gen2Aff := {{ .CurvePackage}}.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
 	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
@@ -58,18 +58,18 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := {{ .CurvePackage }}.BatchScalarMultiplicationG1(&gen1Aff, alphas)
+	g1s := {{ .CurvePackage}}.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
-	return &srs, nil 
+	return &srs, nil
 }
 
 // OpeningProof KZG proof for opening at a single point.
-// 
+//
 // implements io.ReaderFrom and io.WriterTo
 type OpeningProof struct {
 	// H quotient polynomial (f - f(z))/(x-z)
-	H {{ .CurvePackage }}.G1Affine
+	H {{ .CurvePackage}}.G1Affine
 
 	// Point at which the polynomial is evaluated
 	Point fr.Element
@@ -79,11 +79,11 @@ type OpeningProof struct {
 }
 
 // BatchOpeningProof opening proof for many polynomials at the same point
-// 
+//
 // implements io.ReaderFrom and io.WriterTo
 type BatchOpeningProof struct {
 	// H quotient polynomial Sum_i gamma**i*(f - f(z))/(x-z)
-	H {{ .CurvePackage }}.G1Affine
+	H {{ .CurvePackage}}.G1Affine
 
 	// Point at which the polynomials are evaluated
 	Point fr.Element
@@ -92,10 +92,9 @@ type BatchOpeningProof struct {
 	ClaimedValues []fr.Element
 }
 
-
 // Commit commits to a polynomial using a multi exponentiation with the SRS.
 // It is assumed that the polynomial is in canonical form, in Montgomery form.
-// 
+//
 // if a ecc.CPUSemaphore is NOT provided, this function may split the multi exponentiation
 // to use all available CPUs
 func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest, error) {
@@ -103,8 +102,8 @@ func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest
 		return Digest{}, ErrInvalidPolynomialSize
 	}
 
-	var res {{ .CurvePackage }}.G1Affine
-	
+	var res {{ .CurvePackage}}.G1Affine
+
 	config := ecc.MultiExpConfig{ScalarsMont: true}
 	if len(opt) > 0 {
 		config.CPUSemaphore = opt[0]
@@ -116,16 +115,16 @@ func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest
 		if numCpus > 16 {
 			// we split the multiExp in 2.
 			// TODO with machines with more than 32 physical cores, we may want to split in more chunks
-			m := len(p) / 2 
+			m := len(p) / 2
 			chPart1 := make(chan struct{}, 1)
 			config.CPUSemaphore = ecc.NewCPUSemaphore(numCpus)
-			var p1, p2 {{ .CurvePackage }}.G1Jac
-			var err1 error 
+			var p1, p2 {{ .CurvePackage}}.G1Jac
+			var err1 error
 			go func() {
 				_, err1 = p1.MultiExp(srs.G1[:m], p[:m], config)
 				close(chPart1)
 			}()
-			// part 2 
+			// part 2
 			if _, err := p2.MultiExp(srs.G1[m:len(p)], p[m:], config); err != nil {
 				return Digest{}, err
 			}
@@ -143,7 +142,6 @@ func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest
 		}
 	}
 
-
 	return res, nil
 }
 
@@ -159,13 +157,13 @@ func Open(p polynomial.Polynomial, point *fr.Element, domain *fft.Domain, srs *S
 
 	// build the proof
 	res := OpeningProof{
-		Point: *point,
+		Point:        *point,
 		ClaimedValue: p.Eval(point),
 	}
 
 	// compute H
 	_p := make(polynomial.Polynomial, len(p), domain.Cardinality)
-	copy(_p, p) 
+	copy(_p, p)
 	h := dividePolyByXminusA(domain, _p, res.ClaimedValue, res.Point)
 	_p = nil // h re-use this memory
 
@@ -183,23 +181,23 @@ func Open(p polynomial.Polynomial, point *fr.Element, domain *fft.Domain, srs *S
 func Verify(commitment *Digest, proof *OpeningProof, srs *SRS) error {
 
 	// comm(f(a))
-	var claimedValueG1Aff {{ .CurvePackage }}.G1Affine
+	var claimedValueG1Aff {{ .CurvePackage}}.G1Affine
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
 	claimedValueG1Aff.ScalarMultiplication(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(alpha) - f(a)]G1Jac
-	var fminusfaG1Jac, tmpG1Jac {{ .CurvePackage }}.G1Jac
+	var fminusfaG1Jac, tmpG1Jac {{ .CurvePackage}}.G1Jac
 	fminusfaG1Jac.FromAffine(commitment)
 	tmpG1Jac.FromAffine(&claimedValueG1Aff)
 	fminusfaG1Jac.SubAssign(&tmpG1Jac)
 
 	// [-H(alpha)]G1Aff
-	var negH {{ .CurvePackage }}.G1Affine
+	var negH {{ .CurvePackage}}.G1Affine
 	negH.Neg(&proof.H)
 
 	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage }}.G2Jac
+	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage}}.G2Jac
 	var pointBigInt big.Int
 	proof.Point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
@@ -209,17 +207,17 @@ func Verify(commitment *Digest, proof *OpeningProof, srs *SRS) error {
 		AddAssign(&alphaG2Jac)
 
 	// [alpha-a]G2Aff
-	var xminusaG2Aff {{ .CurvePackage }}.G2Affine
+	var xminusaG2Aff {{ .CurvePackage}}.G2Affine
 	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
 
 	// [f(alpha) - f(a)]G1Aff
-	var fminusfaG1Aff {{ .CurvePackage }}.G1Affine
+	var fminusfaG1Aff {{ .CurvePackage}}.G1Affine
 	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
 
 	// e([-H(alpha)]G1Aff, G2gen).e([-H(alpha)]G1Aff, [alpha-a]G2Aff) ==? 1
-	check, err := {{ .CurvePackage }}.PairingCheck(
-		[]{{ .CurvePackage }}.G1Affine{fminusfaG1Aff, negH},
-		[]{{ .CurvePackage }}.G2Affine{srs.G2[0], xminusaG2Aff},
+	check, err := {{ .CurvePackage}}.PairingCheck(
+		[]{{ .CurvePackage}}.G1Affine{fminusfaG1Aff, negH},
+		[]{{ .CurvePackage}}.G2Affine{srs.G2[0], xminusaG2Aff},
 	)
 	if err != nil {
 		return err
@@ -261,40 +259,28 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.ClaimedValues = make([]fr.Element, len(polynomials))
 	var wg sync.WaitGroup
 	wg.Add(len(polynomials))
-	for i := 0 ; i < len(polynomials); i++ {
+	for i := 0; i < len(polynomials); i++ {
 		go func(at int) {
 			res.ClaimedValues[at] = polynomials[at].Eval(point)
 			wg.Done()
 		}(i)
 	}
-	
+
 	// set the point at which the evaluation is done
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", res.Point.Marshal()); err != nil {
-		return BatchOpeningProof{}, err
-	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return BatchOpeningProof{}, err
-		}
-	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	gamma, err := deriveGamma(res.Point, digests)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	
 	// compute sum_i gamma**i*f(a)
-	var sumGammaiTimesEval fr.Element 
+	var sumGammaiTimesEval fr.Element
 	chSumGammai := make(chan struct{}, 1)
 	go func() {
 		// wait for polynomial evaluations to be completed (res.ClaimedValues)
-		wg.Wait() 
+		wg.Wait()
 		sumGammaiTimesEval = res.ClaimedValues[nbDigests-1]
 		for i := nbDigests - 2; i >= 0; i-- {
 			sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
@@ -302,16 +288,15 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 		}
 		close(chSumGammai)
 	}()
-	
-	
-	// compute sum_i gamma**i*f 
+
+	// compute sum_i gamma**i*f
 	// that is p0 + gamma * p1 + gamma^2 * p2 + ... gamma^n * pn
 	// note: if we are willing to paralellize that, we could clone the poly and scale them by
 	// gamma n in parallel, before reducing into sumGammaiTimesPol
 	sumGammaiTimesPol := make(polynomial.Polynomial, largestPoly, domain.Cardinality)
 	copy(sumGammaiTimesPol, polynomials[0])
 	gammaN := gamma
-	var pj fr.Element 
+	var pj fr.Element
 	for i := 1; i < len(polynomials); i++ {
 		for j := 0; j < len(polynomials[i]); j++ {
 			pj.Mul(&polynomials[i][j], &gammaN)
@@ -334,116 +319,200 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	return res, nil
 }
 
-// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
-// point: point at which the polynomials are evaluated
-// claimedValues: claimed values of the polynomials at _val
-// commitments: list of commitments to the polynomials which are opened
-// batchOpeningProof: the batched opening proof at a single point of the polynomials.
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+// FoldProof fold the digests and the proofs in batchOpeningProof using Fiat Shamir
+// to obtain an opening proof at a single point.
+//
+// * digests list of digests on which batchOpeningProof is based
+// * batchOpeningProof opening proof of digests
+// * returns the folded version of batchOpeningProof, Digest, the folded version of digests
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+
 	nbDigests := len(digests)
 
 	// check consistancy between numbers of claims vs number of digests
 	if nbDigests != len(batchOpeningProof.ClaimedValues) {
-		return ErrInvalidNbDigests
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
-	if err := fs.Bind("gamma", batchOpeningProof.Point.Marshal()); err != nil {
-		return err 
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	if err != nil {
+		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
-	for i := 0; i < len(digests); i++ {
-		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
-			return err
-		}
+
+	// fold the claimed values and digests
+	gammai := make([]fr.Element, nbDigests)
+	gammai[0].SetOne()
+	for i := 1; i < nbDigests; i++ {
+		gammai[i].Mul(&gammai[i-1], &gamma)
 	}
-	gammaByte, err := fs.ComputeChallenge("gamma")
+	foldedDigests, foldedEvaluations := fold(digests, batchOpeningProof.ClaimedValues, gammai)
+
+	// create the folded opening proof
+	var res OpeningProof
+	res.ClaimedValue.Set(&foldedEvaluations)
+	res.H.Set(&batchOpeningProof.H)
+	res.Point.Set(&batchOpeningProof.Point)
+
+	return res, foldedDigests, nil
+}
+
+// BatchVerifySinglePoint verifies a batched opening proof at a single point of a list of polynomials.
+//
+// * digests list of digests on which opening proof is done
+// * batchOpeningProof proof of correct opening on the digests
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+
+	// fold the proof
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
 	if err != nil {
 		return err
 	}
-	var gamma fr.Element
-	gamma.SetBytes(gammaByte)
 
-	var sumGammaiTimesEval fr.Element
-	sumGammaiTimesEval.Set(&batchOpeningProof.ClaimedValues[nbDigests-1])
-	for i := nbDigests - 2; i >= 0; i-- {
-		sumGammaiTimesEval.Mul(&sumGammaiTimesEval, &gamma).
-			Add(&sumGammaiTimesEval, &batchOpeningProof.ClaimedValues[i])
+	// verify the foldedProof againts the foldedDigest
+	err = Verify(&foldedDigest, &foldedProof, srs)
+	return err
+
+}
+
+// BatchVerifyMultiPoints batch verifies a list of opening proofs at different points.
+// The purpose of the batching is to have only one pairing for verifying several proofs.
+//
+// * digests list of committed polynomials which are opened
+// * proofs list of opening proofs of the digest
+func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error {
+
+	// check consistancy nb proogs vs nb digests
+	if len(digests) != len(proofs) {
+		return ErrInvalidNbDigests
 	}
 
-	var sumGammaiTimesEvalBigInt big.Int
-	sumGammaiTimesEval.ToBigIntRegular(&sumGammaiTimesEvalBigInt)
-	var sumGammaiTimesEvalG1Aff {{ .CurvePackage }}.G1Affine
-	sumGammaiTimesEvalG1Aff.ScalarMultiplication(&srs.G1[0], &sumGammaiTimesEvalBigInt)
-
-	var acc fr.Element
-	acc.SetOne()
-	gammai := make([]fr.Element, len(digests))
-	gammai[0][0] = 1 // 1 in regular form
-	for i := 1; i < len(digests); i++ {
-		acc.Mul(&acc, &gamma)
-		gammai[i] = acc 
-		gammai[i].FromMont()
-	}
-	var sumGammaiTimesDigestsG1Aff {{ .CurvePackage }}.G1Affine
-
-	if _, err := sumGammaiTimesDigestsG1Aff.MultiExp(digests, gammai,  ecc.MultiExpConfig{}); err != nil {
-		return err 
+	// if only one digest, call Verify
+	if len(digests) == 1 {
+		return Verify(&digests[0], &proofs[0], srs)
 	}
 
-	// sum_i [gamma**i * (f-f(a))]G1
-	var sumGammiDiffG1Aff {{ .CurvePackage }}.G1Affine
-	var t1, t2 {{ .CurvePackage }}.G1Jac
-	t1.FromAffine(&sumGammaiTimesDigestsG1Aff)
-	t2.FromAffine(&sumGammaiTimesEvalG1Aff)
-	t1.SubAssign(&t2)
-	sumGammiDiffG1Aff.FromJacobian(&t1)
+	// sample random numbers for sampling
+	randomNumbers := make([]fr.Element, len(digests))
+	randomNumbers[0].SetOne()
+	for i := 1; i < len(randomNumbers); i++ {
+		randomNumbers[i].SetRandom()
+	}
 
-	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage }}.G2Jac
-	var pointBigInt big.Int
-	batchOpeningProof.Point.ToBigIntRegular(&pointBigInt)
-	genG2Jac.FromAffine(&srs.G2[0])
-	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	// combine random_i*quotient_i
+	var foldedQuotients {{ .CurvePackage}}.G1Affine
+	quotients := make([]{{ .CurvePackage}}.G1Affine, len(proofs))
+	for i := 0; i < len(randomNumbers); i++ {
+		quotients[i].Set(&proofs[i].H)
+	}
+	config := ecc.MultiExpConfig{ScalarsMont: true}
+	foldedQuotients.MultiExp(quotients, randomNumbers, config)
 
-	// [alpha-a]G2Aff
-	var xminusaG2Aff {{ .CurvePackage }}.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
+	// fold digests and evals
+	evals := make([]fr.Element, len(digests))
+	for i := 0; i < len(randomNumbers); i++ {
+		evals[i].Set(&proofs[i].ClaimedValue)
+	}
+	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
-	// [-H(alpha)]G1Aff
-	var negH {{ .CurvePackage }}.G1Affine
-	negH.Neg(&batchOpeningProof.H)
+	// compute commitment to folded Eval
+	var foldedEvalsCommit {{ .CurvePackage}}.G1Affine
+	var foldedEvalsBigInt big.Int
+	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
-	// check the pairing equation
-	check, err := {{ .CurvePackage }}.PairingCheck(
-		[]{{ .CurvePackage }}.G1Affine{sumGammiDiffG1Aff, negH},
-		[]{{ .CurvePackage }}.G2Affine{srs.G2[0], xminusaG2Aff},
+	// compute F = foldedDigests - foldedEvalsCommit
+	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
+
+	// combine random_i*(point_i*quotient_i)
+	var foldedPointsQuotients {{ .CurvePackage}}.G1Affine
+	for i := 0; i < len(randomNumbers); i++ {
+		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
+	}
+	foldedPointsQuotients.MultiExp(quotients, randomNumbers, config)
+
+	// lhs first pairing
+	foldedDigests.Add(&foldedDigests, &foldedPointsQuotients)
+
+	// lhs second pairing
+	foldedQuotients.Neg(&foldedQuotients)
+
+	// pairing check
+	check, err := {{ .CurvePackage}}.PairingCheck(
+		[]{{ .CurvePackage}}.G1Affine{foldedDigests, foldedQuotients},
+		[]{{ .CurvePackage}}.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
 	}
 	if !check {
-		return ErrVerifyBatchOpeningSinglePoint
+		return ErrVerifyOpeningProof
 	}
 	return nil
+
 }
 
+// fold folds digests and evaluations using the list of factors as random numbers.
+//
+// * digests list of digests to fold
+// * evaluations list of evaluations to fold
+// * factors list of multiplicative factors used for the folding (in Montgomery form)
+func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Digest, fr.Element) {
+
+	// length inconsistancy between digests and evaluations should have been done before calling this function
+	nbDigests := len(digests)
+
+	// fold the claimed values
+	var foldedEvaluations, tmp fr.Element
+	for i := 0; i < nbDigests; i++ {
+		tmp.Mul(&evaluations[i], &factors[i])
+		foldedEvaluations.Add(&foldedEvaluations, &tmp)
+	}
+
+	// fold the digests
+	var foldedDigests Digest
+	foldedDigests.MultiExp(digests, factors, ecc.MultiExpConfig{ScalarsMont: true})
+
+	// folding done
+	return foldedDigests, foldedEvaluations
+
+}
+
+// deriveGamma derives a challenge using Fiat Shamir to fold proofs.
+func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+
+	// derive the challenge gamma, binded to the point and the commitments
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	if err := fs.Bind("gamma", point.Marshal()); err != nil {
+		return fr.Element{}, err
+	}
+	for i := 0; i < len(digests); i++ {
+		if err := fs.Bind("gamma", digests[i].Marshal()); err != nil {
+			return fr.Element{}, err
+		}
+	}
+	gammaByte, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return fr.Element{}, err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(gammaByte)
+
+	return gamma, nil
+}
 
 // dividePolyByXminusA computes (f-f(a))/(x-a), in canonical basis, in regular form
 // f memory is re-used for the result
 // @precondition: cap(f) must be d.Cardinality or this will panic
 func dividePolyByXminusA(d *fft.Domain, f polynomial.Polynomial, fa, a fr.Element) polynomial.Polynomial {
-	degree  := len(f) - 1 // the result if of degree  deg(f)-1
+	degree := len(f) - 1 // the result if of degree  deg(f)-1
 
 	// first we compute f-f(a)
 	f = f[:d.Cardinality]
 	f[0].Sub(&f[0], &fa)
 
 	// now we use syntetic division to divide by x-a
-	// TODO check with large polynomials, we may want to parallelize this 
+	// TODO check with large polynomials, we may want to parallelize this
 	var c, t fr.Element
 	for i := len(f) - 1; i >= 0; i-- {
 		t.Mul(&c, &a)
@@ -454,5 +523,3 @@ func dividePolyByXminusA(d *fft.Domain, f polynomial.Polynomial, fa, a fr.Elemen
 	// the result is of degree deg(f)-1
 	return f[:degree]
 }
-
-

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -302,7 +302,6 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 			pj.Mul(&polynomials[i][j], &gammaN)
 			sumGammaiTimesPol[j].Add(&sumGammaiTimesPol[j], &pj)
 		}
-		// TODO @thomas check that we don't need to scale by gamma if polynmials[i] < largestPoly
 		gammaN.Mul(&gammaN, &gamma)
 	}
 

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -1,5 +1,6 @@
 import (
 	"errors"
+	"hash"
 	"math/big"
 	"runtime"
 	"sync"
@@ -13,21 +14,21 @@ import (
 )
 
 var (
-	ErrInvalidNbDigests 			 = errors.New("number of digests is not the same as the number of polynomials")
+	ErrInvalidNbDigests              = errors.New("number of digests is not the same as the number of polynomials")
 	ErrInvalidPolynomialSize         = errors.New("invalid polynomial size (larger than SRS or == 0)")
 	ErrVerifyOpeningProof            = errors.New("can't verify opening proof")
 	ErrVerifyBatchOpeningSinglePoint = errors.New("can't verify batch opening proof at single point")
-	ErrInvalidDomain 				 = errors.New("domain cardinality is smaller than polynomial degree")
-	ErrMinSRSSize		 			 = errors.New("minimum srs size is 2")
+	ErrInvalidDomain                 = errors.New("domain cardinality is smaller than polynomial degree")
+	ErrMinSRSSize                    = errors.New("minimum srs size is 2")
 )
 
 // Digest commitment of a polynomial.
-type Digest = {{ .CurvePackage}}.G1Affine
+type Digest = {{ .CurvePackage }}.G1Affine
 
 // SRS stores the result of the MPC
 type SRS struct {
-	G1 []{{ .CurvePackage}}.G1Affine  // [gen [alpha]gen , [alpha**2]gen, ... ]
-	G2 [2]{{ .CurvePackage}}.G2Affine // [gen, [alpha]gen ]
+	G1 []{{ .CurvePackage }}.G1Affine  // [gen [alpha]gen , [alpha**2]gen, ... ]
+	G2 [2]{{ .CurvePackage }}.G2Affine // [gen, [alpha]gen ]
 }
 
 // NewSRS returns a new SRS using alpha as randomness source
@@ -40,12 +41,12 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 		return nil, ErrMinSRSSize
 	}
 	var srs SRS
-	srs.G1 = make([]{{ .CurvePackage}}.G1Affine, size)
+	srs.G1 = make([]{{ .CurvePackage }}.G1Affine, size)
 
 	var alpha fr.Element
 	alpha.SetBigInt(bAlpha)
 
-	_, _, gen1Aff, gen2Aff := {{ .CurvePackage}}.Generators()
+	_, _, gen1Aff, gen2Aff := {{ .CurvePackage }}.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
 	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
@@ -58,7 +59,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := {{ .CurvePackage}}.BatchScalarMultiplicationG1(&gen1Aff, alphas)
+	g1s := {{ .CurvePackage }}.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil
@@ -69,7 +70,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 // implements io.ReaderFrom and io.WriterTo
 type OpeningProof struct {
 	// H quotient polynomial (f - f(z))/(x-z)
-	H {{ .CurvePackage}}.G1Affine
+	H {{ .CurvePackage }}.G1Affine
 
 	// Point at which the polynomial is evaluated
 	Point fr.Element
@@ -83,7 +84,7 @@ type OpeningProof struct {
 // implements io.ReaderFrom and io.WriterTo
 type BatchOpeningProof struct {
 	// H quotient polynomial Sum_i gamma**i*(f - f(z))/(x-z)
-	H {{ .CurvePackage}}.G1Affine
+	H {{ .CurvePackage }}.G1Affine
 
 	// Point at which the polynomials are evaluated
 	Point fr.Element
@@ -102,7 +103,7 @@ func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest
 		return Digest{}, ErrInvalidPolynomialSize
 	}
 
-	var res {{ .CurvePackage}}.G1Affine
+	var res {{ .CurvePackage }}.G1Affine
 
 	config := ecc.MultiExpConfig{ScalarsMont: true}
 	if len(opt) > 0 {
@@ -118,7 +119,7 @@ func Commit(p polynomial.Polynomial, srs *SRS, opt ...*ecc.CPUSemaphore) (Digest
 			m := len(p) / 2
 			chPart1 := make(chan struct{}, 1)
 			config.CPUSemaphore = ecc.NewCPUSemaphore(numCpus)
-			var p1, p2 {{ .CurvePackage}}.G1Jac
+			var p1, p2 {{ .CurvePackage }}.G1Jac
 			var err1 error
 			go func() {
 				_, err1 = p1.MultiExp(srs.G1[:m], p[:m], config)
@@ -181,23 +182,23 @@ func Open(p polynomial.Polynomial, point *fr.Element, domain *fft.Domain, srs *S
 func Verify(commitment *Digest, proof *OpeningProof, srs *SRS) error {
 
 	// comm(f(a))
-	var claimedValueG1Aff {{ .CurvePackage}}.G1Affine
+	var claimedValueG1Aff {{ .CurvePackage }}.G1Affine
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
 	claimedValueG1Aff.ScalarMultiplication(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(alpha) - f(a)]G1Jac
-	var fminusfaG1Jac, tmpG1Jac {{ .CurvePackage}}.G1Jac
+	var fminusfaG1Jac, tmpG1Jac {{ .CurvePackage }}.G1Jac
 	fminusfaG1Jac.FromAffine(commitment)
 	tmpG1Jac.FromAffine(&claimedValueG1Aff)
 	fminusfaG1Jac.SubAssign(&tmpG1Jac)
 
 	// [-H(alpha)]G1Aff
-	var negH {{ .CurvePackage}}.G1Affine
+	var negH {{ .CurvePackage }}.G1Affine
 	negH.Neg(&proof.H)
 
 	// [alpha-a]G2Jac
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage}}.G2Jac
+	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage }}.G2Jac
 	var pointBigInt big.Int
 	proof.Point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
@@ -207,17 +208,17 @@ func Verify(commitment *Digest, proof *OpeningProof, srs *SRS) error {
 		AddAssign(&alphaG2Jac)
 
 	// [alpha-a]G2Aff
-	var xminusaG2Aff {{ .CurvePackage}}.G2Affine
+	var xminusaG2Aff {{ .CurvePackage }}.G2Affine
 	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
 
 	// [f(alpha) - f(a)]G1Aff
-	var fminusfaG1Aff {{ .CurvePackage}}.G1Affine
+	var fminusfaG1Aff {{ .CurvePackage }}.G1Affine
 	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
 
 	// e([-H(alpha)]G1Aff, G2gen).e([-H(alpha)]G1Aff, [alpha-a]G2Aff) ==? 1
-	check, err := {{ .CurvePackage}}.PairingCheck(
-		[]{{ .CurvePackage}}.G1Affine{fminusfaG1Aff, negH},
-		[]{{ .CurvePackage}}.G2Affine{srs.G2[0], xminusaG2Aff},
+	check, err := {{ .CurvePackage }}.PairingCheck(
+		[]{{ .CurvePackage }}.G1Affine{fminusfaG1Aff, negH},
+		[]{{ .CurvePackage }}.G2Affine{srs.G2[0], xminusaG2Aff},
 	)
 	if err != nil {
 		return err
@@ -233,7 +234,7 @@ func Verify(commitment *Digest, proof *OpeningProof, srs *SRS) error {
 // point is the point at which the polynomials are opened.
 // digests is the list of committed polynomials to open, need to derive the challenge using Fiat Shamir.
 // polynomials is the list of polynomials to open.
-func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest, point *fr.Element, domain *fft.Domain, srs *SRS) (BatchOpeningProof, error) {
+func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest, point *fr.Element, hf hash.Hash, domain *fft.Domain, srs *SRS) (BatchOpeningProof, error) {
 
 	// check for invalid sizes
 	nbDigests := len(digests)
@@ -270,7 +271,7 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 	res.Point = *point
 
 	// derive the challenge gamma, binded to the point and the commitments
-	gamma, err := deriveGamma(res.Point, digests)
+	gamma, err := deriveGamma(res.Point, digests, hf)
 	if err != nil {
 		return BatchOpeningProof{}, err
 	}
@@ -324,7 +325,7 @@ func BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest,
 // * digests list of digests on which batchOpeningProof is based
 // * batchOpeningProof opening proof of digests
 // * returns the folded version of batchOpeningProof, Digest, the folded version of digests
-func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningProof, Digest, error) {
+func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof, hf hash.Hash) (OpeningProof, Digest, error) {
 
 	nbDigests := len(digests)
 
@@ -334,7 +335,7 @@ func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningP
 	}
 
 	// derive the challenge gamma, binded to the point and the commitments
-	gamma, err := deriveGamma(batchOpeningProof.Point, digests)
+	gamma, err := deriveGamma(batchOpeningProof.Point, digests, hf)
 	if err != nil {
 		return OpeningProof{}, Digest{}, ErrInvalidNbDigests
 	}
@@ -360,10 +361,10 @@ func FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof) (OpeningP
 //
 // * digests list of digests on which opening proof is done
 // * batchOpeningProof proof of correct opening on the digests
-func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS) error {
+func BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, hf hash.Hash, srs *SRS) error {
 
 	// fold the proof
-	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof)
+	foldedProof, foldedDigest, err := FoldProof(digests, batchOpeningProof, hf)
 	if err != nil {
 		return err
 	}
@@ -399,8 +400,8 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) e
 	}
 
 	// combine random_i*quotient_i
-	var foldedQuotients {{ .CurvePackage}}.G1Affine
-	quotients := make([]{{ .CurvePackage}}.G1Affine, len(proofs))
+	var foldedQuotients {{ .CurvePackage }}.G1Affine
+	quotients := make([]{{ .CurvePackage }}.G1Affine, len(proofs))
 	for i := 0; i < len(randomNumbers); i++ {
 		quotients[i].Set(&proofs[i].H)
 	}
@@ -415,7 +416,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) e
 	foldedDigests, foldedEvals := fold(digests, evals, randomNumbers)
 
 	// compute commitment to folded Eval
-	var foldedEvalsCommit {{ .CurvePackage}}.G1Affine
+	var foldedEvalsCommit {{ .CurvePackage }}.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
 	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
@@ -424,7 +425,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) e
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)
 
 	// combine random_i*(point_i*quotient_i)
-	var foldedPointsQuotients {{ .CurvePackage}}.G1Affine
+	var foldedPointsQuotients {{ .CurvePackage }}.G1Affine
 	for i := 0; i < len(randomNumbers); i++ {
 		randomNumbers[i].Mul(&randomNumbers[i], &proofs[i].Point)
 	}
@@ -437,9 +438,9 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) e
 	foldedQuotients.Neg(&foldedQuotients)
 
 	// pairing check
-	check, err := {{ .CurvePackage}}.PairingCheck(
-		[]{{ .CurvePackage}}.G1Affine{foldedDigests, foldedQuotients},
-		[]{{ .CurvePackage}}.G2Affine{srs.G2[0], srs.G2[1]},
+	check, err := {{ .CurvePackage }}.PairingCheck(
+		[]{{ .CurvePackage }}.G1Affine{foldedDigests, foldedQuotients},
+		[]{{ .CurvePackage }}.G2Affine{srs.G2[0], srs.G2[1]},
 	)
 	if err != nil {
 		return err
@@ -478,10 +479,10 @@ func fold(digests []Digest, evaluations []fr.Element, factors []fr.Element) (Dig
 }
 
 // deriveGamma derives a challenge using Fiat Shamir to fold proofs.
-func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
+func deriveGamma(point fr.Element, digests []Digest, hf hash.Hash) (fr.Element, error) {
 
 	// derive the challenge gamma, binded to the point and the commitments
-	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma")
+	fs := fiatshamir.NewTranscript(hf, "gamma")
 	if err := fs.Bind("gamma", point.Marshal()); err != nil {
 		return fr.Element{}, err
 	}
@@ -496,6 +497,9 @@ func deriveGamma(point fr.Element, digests []Digest) (fr.Element, error) {
 	}
 	var gamma fr.Element
 	gamma.SetBytes(gammaByte)
+
+	// reset the hash in case it is reused
+	hf.Reset()
 
 	return gamma, nil
 }

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -171,7 +171,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40+2*i)
 	}
 
 	// commit the polynomials
@@ -219,7 +219,7 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(60)
+		f[i] = randomPolynomial(40+2*i)
 	}
 
 	// commit the polynomials

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -1,5 +1,6 @@
 import (
 	"bytes"
+	"crypto/sha256"
 	"math/big"
 	"reflect"
 	"testing"
@@ -103,7 +104,7 @@ func TestCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var kzgCommit {{ .CurvePackage}}.G1Affine
+	var kzgCommit {{ .CurvePackage }}.G1Affine
 	kzgCommit.Unmarshal(_kzgCommit.Marshal())
 
 	// check commitment using manual commit
@@ -112,7 +113,7 @@ func TestCommit(t *testing.T) {
 	fx := f.Eval(&x)
 	var fxbi big.Int
 	fx.ToBigIntRegular(&fxbi)
-	var manualCommit {{ .CurvePackage}}.G1Affine
+	var manualCommit {{ .CurvePackage }}.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
 	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
@@ -171,7 +172,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(40+2*i)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
@@ -181,10 +182,13 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 
 	}
 
+	// pick a hash function
+	hf := sha256.New()
+
 	// compute opening proof at a random point
 	var point fr.Element
 	point.SetString("4321")
-	proof, err := BatchOpenSinglePoint(f, digests, &point, domain, testSRS)
+	proof, err := BatchOpenSinglePoint(f, digests, &point, hf, domain, testSRS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,14 +202,14 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 	}
 
 	// verify correct proof
-	err = BatchVerifySinglePoint(digests, &proof, testSRS)
+	err = BatchVerifySinglePoint(digests, &proof, hf, testSRS)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// verify wrong proof
 	proof.ClaimedValues[0].Double(&proof.ClaimedValues[0])
-	err = BatchVerifySinglePoint(digests, &proof, testSRS)
+	err = BatchVerifySinglePoint(digests, &proof, hf, testSRS)
 	if err == nil {
 		t.Fatal("verifying wrong proof should have failed")
 	}
@@ -219,29 +223,31 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 	// create polynomials
 	f := make([]polynomial.Polynomial, 10)
 	for i := 0; i < 10; i++ {
-		f[i] = randomPolynomial(40+2*i)
+		f[i] = randomPolynomial(40 + 2*i)
 	}
 
 	// commit the polynomials
 	digests := make([]Digest, 10)
 	for i := 0; i < 10; i++ {
 		digests[i], _ = Commit(f[i], testSRS)
-
 	}
+
+	// pick a hash function
+	hf := sha256.New()
 
 	// compute 2 batch opening proofs at 2 random points
 	points := make([]fr.Element, 2)
 	batchProofs := make([]BatchOpeningProof, 2)
 	points[0].SetRandom()
-	batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], &points[0], domain, testSRS)
+	batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], &points[0], hf, domain, testSRS)
 	points[1].SetRandom()
-	batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], &points[1], domain, testSRS)
+	batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], &points[1], hf, domain, testSRS)
 
 	// fold the 2 batch opening proofs
 	proofs := make([]OpeningProof, 2)
 	foldedDigests := make([]Digest, 2)
-	proofs[0], foldedDigests[0], _ = FoldProof(digests[:5], &batchProofs[0])
-	proofs[1], foldedDigests[1], _ = FoldProof(digests[5:], &batchProofs[1])
+	proofs[0], foldedDigests[0], _ = FoldProof(digests[:5], &batchProofs[0], hf)
+	proofs[1], foldedDigests[1], _ = FoldProof(digests[5:], &batchProofs[1], hf)
 
 	// check the the individual batch proofs are correct
 	err := Verify(&foldedDigests[0], &proofs[0], testSRS)
@@ -352,12 +358,15 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 		commitments[i], _ = Commit(ps[i], benchSRS)
 	}
 
+	// pick a hash function
+	hf := sha256.New()
+
 	var r fr.Element
 	r.SetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		BatchOpenSinglePoint(ps[:], commitments[:], &r, domain, benchSRS)
+		BatchOpenSinglePoint(ps[:], commitments[:], &r, hf, domain, benchSRS)
 	}
 }
 
@@ -380,17 +389,20 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 		commitments[i], _ = Commit(ps[i], benchSRS)
 	}
 
+	// pick a hash function
+	hf := sha256.New()
+
 	var r fr.Element
 	r.SetRandom()
 
-	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], &r, domain, benchSRS)
+	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], &r, hf, domain, benchSRS)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		BatchVerifySinglePoint(commitments[:], &proof, benchSRS)
+		BatchVerifySinglePoint(commitments[:], &proof, hf, benchSRS)
 	}
 }
 

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -12,7 +12,7 @@ import (
 )
 
 // testSRS re-used accross tests of the KZG scheme
-var testSRS *SRS 
+var testSRS *SRS
 
 func init() {
 	const srsSize = 230
@@ -30,8 +30,6 @@ func TestDividePolyByXminusA(t *testing.T) {
 	for i := 0; i < pSize; i++ {
 		pol[i].SetRandom()
 	}
-
-
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
@@ -51,7 +49,6 @@ func TestDividePolyByXminusA(t *testing.T) {
 	if len(h) != 229 {
 		t.Fatal("inconsistant size of quotient")
 	}
-
 
 	hRandPoint := h.Eval(&randPoint)
 	xminusa.Sub(&randPoint, &point) // rand-point
@@ -106,7 +103,7 @@ func TestCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var kzgCommit {{ .CurvePackage }}.G1Affine
+	var kzgCommit {{ .CurvePackage}}.G1Affine
 	kzgCommit.Unmarshal(_kzgCommit.Marshal())
 
 	// check commitment using manual commit
@@ -115,7 +112,7 @@ func TestCommit(t *testing.T) {
 	fx := f.Eval(&x)
 	var fxbi big.Int
 	fx.ToBigIntRegular(&fxbi)
-	var manualCommit {{ .CurvePackage }}.G1Affine
+	var manualCommit {{ .CurvePackage}}.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
 	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
@@ -215,8 +212,63 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 
 }
 
-const benchSize = 1 << 16
+func TestBatchVerifyMultiPoints(t *testing.T) {
 
+	domain := fft.NewDomain(64, 0, false)
+
+	// create polynomials
+	f := make([]polynomial.Polynomial, 10)
+	for i := 0; i < 10; i++ {
+		f[i] = randomPolynomial(60)
+	}
+
+	// commit the polynomials
+	digests := make([]Digest, 10)
+	for i := 0; i < 10; i++ {
+		digests[i], _ = Commit(f[i], testSRS)
+
+	}
+
+	// compute 2 batch opening proofs at 2 random points
+	points := make([]fr.Element, 2)
+	batchProofs := make([]BatchOpeningProof, 2)
+	points[0].SetRandom()
+	batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], &points[0], domain, testSRS)
+	points[1].SetRandom()
+	batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], &points[1], domain, testSRS)
+
+	// fold the 2 batch opening proofs
+	proofs := make([]OpeningProof, 2)
+	foldedDigests := make([]Digest, 2)
+	proofs[0], foldedDigests[0], _ = FoldProof(digests[:5], &batchProofs[0])
+	proofs[1], foldedDigests[1], _ = FoldProof(digests[5:], &batchProofs[1])
+
+	// check the the individual batch proofs are correct
+	err := Verify(&foldedDigests[0], &proofs[0], testSRS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Verify(&foldedDigests[1], &proofs[1], testSRS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// batch verify correct folded proofs
+	err = BatchVerifyMultiPoints(foldedDigests, proofs, testSRS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// batch verify tampered folded proofs
+	proofs[0].ClaimedValue.Double(&proofs[0].ClaimedValue)
+	err = BatchVerifyMultiPoints(foldedDigests, proofs, testSRS)
+	if err == nil {
+		t.Fatal(err)
+	}
+
+}
+
+const benchSize = 1 << 16
 
 func BenchmarkKZGCommit(b *testing.B) {
 	benchSRS, err := NewSRS(ecc.NextPowerOfTwo(benchSize), new(big.Int).SetInt64(42))
@@ -305,7 +357,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		BatchOpenSinglePoint(ps[:], commitments[:], &r, domain , benchSRS)
+		BatchOpenSinglePoint(ps[:], commitments[:], &r, domain, benchSRS)
 	}
 }
 
@@ -331,7 +383,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	var r fr.Element
 	r.SetRandom()
 
-	proof, err := BatchOpenSinglePoint(ps[:], commitments[:],&r, domain, benchSRS)
+	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], &r, domain, benchSRS)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -341,7 +393,6 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 		BatchVerifySinglePoint(commitments[:], &proof, benchSRS)
 	}
 }
-
 
 func randomPolynomial(size int) polynomial.Polynomial {
 	f := make(polynomial.Polynomial, size)


### PR DESCRIPTION
This PR adds a function in kzg for verifying opening proofs at different points.

API breaking changes:

- BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest, point *fr.Element, domain *fft.Domain, srs *SRS) --> BatchOpenSinglePoint(polynomials []polynomial.Polynomial, digests []Digest, point *fr.Element, hf hash.Hash, domain *fft.Domain, srs *SRS)
- BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, srs *SRS)  --> BatchVerifySinglePoint(digests []Digest, batchOpeningProof *BatchOpeningProof, hf hash.Hash, srs *SRS) 

New functions:
- FoldProof(digests []Digest, batchOpeningProof *BatchOpeningProof, hf hash.Hash) (OpeningProof, Digest, error) : folds a batch opening proof at single point using Fiat Shamir, returns the folded proof and the folded digest.
- BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, srs *SRS) error: given a list of (folded) digest, a list of (folded) proofs, verifies simultaneously the list of corresponding opening proofs at different points