### PR TITLE
feat: subgroup check optional in decoder, parallel checks on slices

### DIFF
--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -56,14 +56,21 @@ type Encoder struct {
 
 // Decoder reads bls12-381 object values from an inbound stream
 type Decoder struct {
-	r io.Reader
-	n int64 // read bytes
+	r             io.Reader
+	n             int64 // read bytes
+	subGroupCheck bool  // default to true
 }
 
 // NewDecoder returns a binary decoder supporting curve bls12-381 objects in both
 // compressed and uncompressed (raw) forms
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+func NewDecoder(r io.Reader, options ...func(*Decoder)) *Decoder {
+	d := &Decoder{r: r, subGroupCheck: true}
+
+	for _, o := range options {
+		o(d)
+	}
+
+	return d
 }
 
 // Decode reads the binary encoding of v from the stream
@@ -157,7 +164,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *G2Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -177,7 +184,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *[]G1Affine:
 		var sliceLen uint32
@@ -207,7 +214,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -219,7 +226,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -258,7 +269,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -270,7 +281,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -352,6 +367,14 @@ func (enc *Encoder) BytesWritten() int64 {
 func RawEncoding() func(*Encoder) {
 	return func(enc *Encoder) {
 		enc.raw = true
+	}
+}
+
+// NoSubgroupChecks returns an option to use in NewDecoder(...) which disable subgroup checks on the points
+// the decoder will read. Use with caution, as crafted points from an untrusted source can lead to crypto-attacks.
+func NoSubgroupChecks() func(*Decoder) {
+	return func(dec *Decoder) {
+		dec.subGroupCheck = false
 	}
 }
 
@@ -682,6 +705,10 @@ func (p *G1Affine) RawBytes() (res [SizeOfG1AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G1Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG1AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -715,7 +742,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -757,7 +784,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -766,7 +793,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G1Affine) unsafeComputeY() error {
+func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -795,7 +822,7 @@ func (p *G1Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -916,7 +943,7 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 
 	// not compressed
 	// we store the Y coordinate
-	// p.Y.A1 | p.Y.A0
+	// p.Y.A1 | p.Y.A0
 	tmp = p.Y.A0
 	tmp.FromMont()
 	binary.BigEndian.PutUint64(res[184:192], tmp[0])
@@ -936,7 +963,7 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 	binary.BigEndian.PutUint64(res[96:104], tmp[5])
 
 	// we store X  and mask the most significant word with our metadata mask
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	tmp = p.X.A1
 	tmp.FromMont()
 	binary.BigEndian.PutUint64(res[40:48], tmp[0])
@@ -967,6 +994,10 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G2Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG2AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -996,15 +1027,15 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		// p.X.A1 | p.X.A0
+		// p.X.A1 | p.X.A0
 		p.X.A1.SetBytes(buf[:fp.Bytes])
 		p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
-		// p.Y.A1 | p.Y.A0
+		// p.Y.A1 | p.Y.A0
 		p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3])
 		p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -1021,7 +1052,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	p.X.A1.SetBytes(bufX[:fp.Bytes])
 	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
@@ -1049,7 +1080,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1058,7 +1089,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G2Affine) unsafeComputeY() error {
+func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y.A0[0])
@@ -1088,7 +1119,7 @@ func (p *G2Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1117,7 +1148,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	p.X.A1.SetBytes(bufX[:fp.Bytes])
 	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -53,14 +53,21 @@ type Encoder struct {
 
 // Decoder reads bn254 object values from an inbound stream
 type Decoder struct {
-	r io.Reader
-	n int64 // read bytes
+	r             io.Reader
+	n             int64 // read bytes
+	subGroupCheck bool  // default to true
 }
 
 // NewDecoder returns a binary decoder supporting curve bn254 objects in both
 // compressed and uncompressed (raw) forms
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+func NewDecoder(r io.Reader, options ...func(*Decoder)) *Decoder {
+	d := &Decoder{r: r, subGroupCheck: true}
+
+	for _, o := range options {
+		o(d)
+	}
+
+	return d
 }
 
 // Decode reads the binary encoding of v from the stream
@@ -154,7 +161,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *G2Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -174,7 +181,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *[]G1Affine:
 		var sliceLen uint32
@@ -204,7 +211,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -216,7 +223,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -255,7 +266,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -267,7 +278,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -349,6 +364,14 @@ func (enc *Encoder) BytesWritten() int64 {
 func RawEncoding() func(*Encoder) {
 	return func(enc *Encoder) {
 		enc.raw = true
+	}
+}
+
+// NoSubgroupChecks returns an option to use in NewDecoder(...) which disable subgroup checks on the points
+// the decoder will read. Use with caution, as crafted points from an untrusted source can lead to crypto-attacks.
+func NoSubgroupChecks() func(*Decoder) {
+	return func(dec *Decoder) {
+		dec.subGroupCheck = false
 	}
 }
 
@@ -676,6 +699,10 @@ func (p *G1Affine) RawBytes() (res [SizeOfG1AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G1Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG1AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -704,7 +731,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -746,7 +773,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -755,7 +782,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G1Affine) unsafeComputeY() error {
+func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -784,7 +811,7 @@ func (p *G1Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -904,7 +931,7 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 
 	// not compressed
 	// we store the Y coordinate
-	// p.Y.A1 | p.Y.A0
+	// p.Y.A1 | p.Y.A0
 	tmp = p.Y.A0
 	tmp.FromMont()
 	binary.BigEndian.PutUint64(res[120:128], tmp[0])
@@ -920,7 +947,7 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 	binary.BigEndian.PutUint64(res[64:72], tmp[3])
 
 	// we store X  and mask the most significant word with our metadata mask
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	tmp = p.X.A1
 	tmp.FromMont()
 	binary.BigEndian.PutUint64(res[24:32], tmp[0])
@@ -947,6 +974,10 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G2Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG2AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -971,15 +1002,15 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		// p.X.A1 | p.X.A0
+		// p.X.A1 | p.X.A0
 		p.X.A1.SetBytes(buf[:fp.Bytes])
 		p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
-		// p.Y.A1 | p.Y.A0
+		// p.Y.A1 | p.Y.A0
 		p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3])
 		p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -996,7 +1027,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	p.X.A1.SetBytes(bufX[:fp.Bytes])
 	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
@@ -1024,7 +1055,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1033,7 +1064,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G2Affine) unsafeComputeY() error {
+func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y.A0[0])
@@ -1063,7 +1094,7 @@ func (p *G2Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1092,7 +1123,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	// p.X.A1 | p.X.A0
+	// p.X.A1 | p.X.A0
 	p.X.A1.SetBytes(bufX[:fp.Bytes])
 	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -56,14 +56,21 @@ type Encoder struct {
 
 // Decoder reads bw6-633 object values from an inbound stream
 type Decoder struct {
-	r io.Reader
-	n int64 // read bytes
+	r             io.Reader
+	n             int64 // read bytes
+	subGroupCheck bool  // default to true
 }
 
 // NewDecoder returns a binary decoder supporting curve bw6-633 objects in both
 // compressed and uncompressed (raw) forms
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+func NewDecoder(r io.Reader, options ...func(*Decoder)) *Decoder {
+	d := &Decoder{r: r, subGroupCheck: true}
+
+	for _, o := range options {
+		o(d)
+	}
+
+	return d
 }
 
 // Decode reads the binary encoding of v from the stream
@@ -157,7 +164,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *G2Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -177,7 +184,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *[]G1Affine:
 		var sliceLen uint32
@@ -207,7 +214,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -219,7 +226,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -258,7 +269,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -270,7 +281,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -352,6 +367,14 @@ func (enc *Encoder) BytesWritten() int64 {
 func RawEncoding() func(*Encoder) {
 	return func(enc *Encoder) {
 		enc.raw = true
+	}
+}
+
+// NoSubgroupChecks returns an option to use in NewDecoder(...) which disable subgroup checks on the points
+// the decoder will read. Use with caution, as crafted points from an untrusted source can lead to crypto-attacks.
+func NoSubgroupChecks() func(*Decoder) {
+	return func(dec *Decoder) {
+		dec.subGroupCheck = false
 	}
 }
 
@@ -694,6 +717,10 @@ func (p *G1Affine) RawBytes() (res [SizeOfG1AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G1Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG1AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -727,7 +754,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -769,7 +796,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -778,7 +805,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G1Affine) unsafeComputeY() error {
+func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -807,7 +834,7 @@ func (p *G1Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -961,6 +988,10 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G2Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG2AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -994,7 +1025,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -1036,7 +1067,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1045,7 +1076,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G2Affine) unsafeComputeY() error {
+func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -1074,7 +1105,7 @@ func (p *G2Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -56,14 +56,21 @@ type Encoder struct {
 
 // Decoder reads bw6-761 object values from an inbound stream
 type Decoder struct {
-	r io.Reader
-	n int64 // read bytes
+	r             io.Reader
+	n             int64 // read bytes
+	subGroupCheck bool  // default to true
 }
 
 // NewDecoder returns a binary decoder supporting curve bw6-761 objects in both
 // compressed and uncompressed (raw) forms
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+func NewDecoder(r io.Reader, options ...func(*Decoder)) *Decoder {
+	d := &Decoder{r: r, subGroupCheck: true}
+
+	for _, o := range options {
+		o(d)
+	}
+
+	return d
 }
 
 // Decode reads the binary encoding of v from the stream
@@ -157,7 +164,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *G2Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -177,7 +184,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return
 	case *[]G1Affine:
 		var sliceLen uint32
@@ -207,7 +214,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -219,7 +226,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -258,7 +269,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -270,7 +281,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int) {
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -352,6 +367,14 @@ func (enc *Encoder) BytesWritten() int64 {
 func RawEncoding() func(*Encoder) {
 	return func(enc *Encoder) {
 		enc.raw = true
+	}
+}
+
+// NoSubgroupChecks returns an option to use in NewDecoder(...) which disable subgroup checks on the points
+// the decoder will read. Use with caution, as crafted points from an untrusted source can lead to crypto-attacks.
+func NoSubgroupChecks() func(*Decoder) {
+	return func(dec *Decoder) {
+		dec.subGroupCheck = false
 	}
 }
 
@@ -700,6 +723,10 @@ func (p *G1Affine) RawBytes() (res [SizeOfG1AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G1Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG1AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -733,7 +760,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -775,7 +802,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -784,7 +811,7 @@ func (p *G1Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G1Affine) unsafeComputeY() error {
+func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -813,7 +840,7 @@ func (p *G1Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -973,6 +1000,10 @@ func (p *G2Affine) RawBytes() (res [SizeOfG2AffineUncompressed]byte) {
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *G2Affine) SetBytes(buf []byte) (int, error) {
+	return p.setBytes(buf, true)
+}
+
+func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if len(buf) < SizeOfG2AffineCompressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -1006,7 +1037,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
 
 		// subgroup check
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -1048,7 +1079,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -1057,7 +1088,7 @@ func (p *G2Affine) SetBytes(buf []byte) (int, error) {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *G2Affine) unsafeComputeY() error {
+func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 	// stored in unsafeSetCompressedBytes
 
 	mData := byte(p.Y[0])
@@ -1086,7 +1117,7 @@ func (p *G2Affine) unsafeComputeY() error {
 	p.Y = Y
 
 	// subgroup check
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -63,12 +63,19 @@ type Encoder struct {
 type Decoder struct {
 	r io.Reader
 	n int64 // read bytes
+	subGroupCheck bool // default to true 
 }
 
 // NewDecoder returns a binary decoder supporting curve {{.Name}} objects in both 
 // compressed and uncompressed (raw) forms
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+func NewDecoder(r io.Reader, options ...func(*Decoder)) *Decoder {
+	d := &Decoder{r: r, subGroupCheck: true }
+
+	for _, o := range options {
+		o(d)
+	}
+
+	return d
 }
 
 
@@ -163,7 +170,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return 
 	case *G2Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -183,7 +190,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				return
 			}
 		}
-		_, err = t.SetBytes(buf[:nbBytes])
+		_, err = t.setBytes(buf[:nbBytes], dec.subGroupCheck)
 		return 
 	case *[]G1Affine:
 		var sliceLen uint32
@@ -213,7 +220,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -225,7 +232,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int){
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -264,7 +275,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				if err != nil {
 					return
 				}
-				_, err = (*t)[i].SetBytes(buf[:nbBytes])
+				_, err = (*t)[i].setBytes(buf[:nbBytes], false)
 				if err != nil {
 					return
 				}
@@ -276,7 +287,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		parallel.Execute(len(compressed), func(start, end int){
 			for i := start; i < end; i++ {
 				if compressed[i] {
-					if err := (*t)[i].unsafeComputeY(); err != nil {
+					if err := (*t)[i].unsafeComputeY(dec.subGroupCheck); err != nil {
+						atomic.AddUint64(&nbErrs, 1)
+					}
+				} else if dec.subGroupCheck {
+					if !(*t)[i].IsInSubGroup() {
 						atomic.AddUint64(&nbErrs, 1)
 					}
 				}
@@ -364,6 +379,14 @@ func (enc *Encoder) BytesWritten() int64 {
 func RawEncoding() func(*Encoder)  {
 	return func(enc *Encoder)  {
 		enc.raw = true
+	}
+}
+
+// NoSubgroupChecks returns an option to use in NewDecoder(...) which disable subgroup checks on the points 
+// the decoder will read. Use with caution, as crafted points from an untrusted source can lead to crypto-attacks. 
+func NoSubgroupChecks() func(*Decoder)  {
+	return func(dec *Decoder)  {
+		dec.subGroupCheck = false
 	}
 }
 
@@ -602,7 +625,7 @@ func (p *{{ $.TAffine }}) RawBytes() (res [SizeOf{{ $.TAffine }}Uncompressed]byt
 	// not compressed
 	// we store the Y coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
-		// p.Y.A1 | p.Y.A0
+		// p.Y.A1 | p.Y.A0
 		{{- $offset := mul $.sizeOfFp 3}}
 		{{- template "putFp" dict "all" .all "OffSet" $offset "From" "p.Y.A0"}}
 
@@ -624,7 +647,7 @@ func (p *{{ $.TAffine }}) RawBytes() (res [SizeOf{{ $.TAffine }}Uncompressed]byt
 
 	// we store X  and mask the most significant word with our metadata mask
 	{{- if eq $.CoordType "fptower.E2"}}
-		// p.X.A1 | p.X.A0
+		// p.X.A1 | p.X.A0
 		{{- $offset := $.sizeOfFp}}
 		{{- template "putFp" dict "all" .all "OffSet" 0 "From" "p.X.A1"}}
 		{{- template "putFp" dict "all" .all "OffSet" $offset "From" "p.X.A0"}}
@@ -646,6 +669,7 @@ func (p *{{ $.TAffine }}) RawBytes() (res [SizeOf{{ $.TAffine }}Uncompressed]byt
 	return 
 }
 
+
 // SetBytes sets p from binary representation in buf and returns number of consumed bytes
 // bytes in buf must match either RawBytes() or Bytes() output
 // if buf is too short io.ErrShortBuffer is returned
@@ -653,6 +677,11 @@ func (p *{{ $.TAffine }}) RawBytes() (res [SizeOf{{ $.TAffine }}Uncompressed]byt
 // the Y coordinate (i.e the square root doesn't exist) this function retunrs an error
 // this check if the resulting point is on the curve and in the correct subgroup
 func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
+	return p.setBytes(buf, true)
+}
+
+
+func (p *{{ $.TAffine }}) setBytes(buf []byte, subGroupCheck bool) (int, error)  {
 	if len(buf) < SizeOf{{ $.TAffine }}Compressed {
 		return 0, io.ErrShortBuffer
 	}
@@ -687,10 +716,10 @@ func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		{{- if eq $.CoordType "fptower.E2"}}
-			// p.X.A1 | p.X.A0
+			// p.X.A1 | p.X.A0
 			p.X.A1.SetBytes(buf[:fp.Bytes])
 			p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
-			// p.Y.A1 | p.Y.A0
+			// p.Y.A1 | p.Y.A0
 			p.Y.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3])
 			p.Y.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4])
 		{{- else if eq $.CoordType "fptower.E4"}}	
@@ -710,7 +739,7 @@ func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
 		{{- end}}
 
 		// subgroup check 
-		if !p.IsInSubGroup() {
+		if subGroupCheck && !p.IsInSubGroup() {
 			return 0, errors.New("invalid point: subgroup check failed")
 		}
 
@@ -728,7 +757,7 @@ func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
 
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
-		// p.X.A1 | p.X.A0
+		// p.X.A1 | p.X.A0
 		p.X.A1.SetBytes(bufX[:fp.Bytes])
 		p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
 	{{- else if eq $.CoordType "fptower.E4"}}
@@ -774,7 +803,7 @@ func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
 	p.Y = Y
 
 	// subgroup check 
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return 0, errors.New("invalid point: subgroup check failed")
 	}
 
@@ -785,7 +814,7 @@ func (p *{{ $.TAffine }}) SetBytes(buf []byte) (int, error)  {
 
 // unsafeComputeY called by Decoder when processing slices of compressed point in parallel (step 2)
 // it computes the Y coordinate from the already set X coordinate and is compute intensive
-func (p *{{ $.TAffine }}) unsafeComputeY() error  {
+func (p *{{ $.TAffine }}) unsafeComputeY(subGroupCheck bool) error  {
 	// stored in unsafeSetCompressedBytes
 	{{ if eq $.CoordType "fptower.E2"}}
 	mData := byte(p.Y.A0[0])
@@ -829,7 +858,7 @@ func (p *{{ $.TAffine }}) unsafeComputeY() error  {
 	p.Y = Y
 
 	// subgroup check 
-	if !p.IsInSubGroup() {
+	if subGroupCheck && !p.IsInSubGroup() {
 		return errors.New("invalid point: subgroup check failed")
 	}
 
@@ -859,7 +888,7 @@ func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool)
 
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
-		// p.X.A1 | p.X.A0
+		// p.X.A1 | p.X.A0
 		p.X.A1.SetBytes(bufX[:fp.Bytes])
 		p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
 		


### PR DESCRIPTION
New features:

Can now instantiate ecc.NewDecoder(...) with NoSubgroupCheck options which will, as it names implies, not run subgroup checks on decoded points.

Default value is to perform the subgroup checks. 

Perf: now that subgroup checks are decoupled from the setBytes() function, they are done in parallel by the decoder when decoding slices of points. 

