### PR TITLE
perf: Final exp. on BLS12-381

### DIFF
--- a/ecc/bls12-381/internal/fptower/e12_pairing.go
+++ b/ecc/bls12-381/internal/fptower/e12_pairing.go
@@ -65,3 +65,36 @@ func (z *E12) MulBy014(c0, c1, c4 *E2) *E12 {
 
 	return z
 }
+
+// Mul014By014 multiplication of sparse element (c0,c1,0,0,c4,0) by sparse element (d0,d1,0,0,d4,0)
+func (z *E12) Mul014By014(d0, d1, d4, c0, c1, c4 *E2) *E12 {
+	var tmp, x0, x1, x4, x04, x01, x14 E2
+	x0.Mul(c0, d0)
+	x1.Mul(c1, d1)
+	x4.Mul(c4, d4)
+	tmp.Add(c0, c4)
+	x04.Add(d0, d4).
+		Mul(&x04, &tmp).
+		Sub(&x04, &x0).
+		Sub(&x04, &x4)
+	tmp.Add(c0, c1)
+	x01.Add(d0, d1).
+		Mul(&x01, &tmp).
+		Sub(&x01, &x0).
+		Sub(&x01, &x1)
+	tmp.Add(c1, c4)
+	x14.Add(d1, d4).
+		Mul(&x14, &tmp).
+		Sub(&x14, &x1).
+		Sub(&x14, &x4)
+
+	z.C0.B0.MulByNonResidue(&x4).
+		Add(&z.C0.B0, &x0)
+	z.C0.B1.Set(&x01)
+	z.C0.B2.Set(&x1)
+	z.C1.B0.SetZero()
+	z.C1.B1.Set(&x04)
+	z.C1.B2.Set(&x14)
+
+	return z
+}

--- a/ecc/bls12-381/internal/fptower/e12_pairing.go
+++ b/ecc/bls12-381/internal/fptower/e12_pairing.go
@@ -16,18 +16,22 @@ func (z *E12) nSquareCompressed(n int) {
 // const t/2 uint64 = 7566188111470821376 // negative
 func (z *E12) ExptHalf(x *E12) *E12 {
 	var result E12
-	result.CyclotomicSquare(x)
-	result.Mul(&result, x)
-	result.nSquare(2)
-	result.Mul(&result, x)
-	result.nSquare(3)
-	result.Mul(&result, x)
-	result.nSquare(9)
-	result.Mul(&result, x)
+	var t [2]E12
+	result.Set(x)
+	result.nSquareCompressed(15)
+	t[0].Set(&result)
 	result.nSquareCompressed(32)
-	result.Decompress(&result)
-	result.Mul(&result, x)
-	result.nSquare(15)
+	t[1].Set(&result)
+	batch := BatchDecompress([]E12{t[0], t[1]})
+	result.Mul(&batch[0], &batch[1])
+	batch[1].nSquare(9)
+	result.Mul(&result, &batch[1])
+	batch[1].nSquare(3)
+	result.Mul(&result, &batch[1])
+	batch[1].nSquare(2)
+	result.Mul(&result, &batch[1])
+	batch[1].CyclotomicSquare(&batch[1])
+	result.Mul(&result, &batch[1])
 	return z.Conjugate(&result) // because tAbsVal is negative
 }
 

--- a/ecc/bls12-381/pairing.go
+++ b/ecc/bls12-381/pairing.go
@@ -121,47 +121,45 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		qProj[k].FromAffine(&q[k])
 	}
 
-	var result GT
+	var result, lines GT
 	result.SetOne()
 
-	var l lineEvaluation
+	var l1, l2 lineEvaluation
 
 	// i == 62
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l)
+		qProj[k].DoubleStep(&l1)
 		// line eval
-		l.r1.MulByElement(&l.r1, &p[k].X)
-		l.r2.MulByElement(&l.r2, &p[k].Y)
-		result.MulBy014(&l.r0, &l.r1, &l.r2)
+		l1.r1.MulByElement(&l1.r1, &p[k].X)
+		l1.r2.MulByElement(&l1.r2, &p[k].Y)
 
-		qProj[k].AddMixedStep(&l, &q[k])
+		qProj[k].AddMixedStep(&l2, &q[k])
 		// line eval
-		l.r1.MulByElement(&l.r1, &p[k].X)
-		l.r2.MulByElement(&l.r2, &p[k].Y)
-		result.MulBy014(&l.r0, &l.r1, &l.r2)
+		l2.r1.MulByElement(&l2.r1, &p[k].X)
+		l2.r2.MulByElement(&l2.r2, &p[k].Y)
+		lines.Mul014By014(&l1.r0, &l1.r1, &l1.r2, &l2.r0, &l2.r1, &l2.r2)
+		result.Mul(&result, &lines)
 	}
 
 	for i := 61; i >= 0; i-- {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l)
+			qProj[k].DoubleStep(&l1)
 			// line eval
-			l.r1.MulByElement(&l.r1, &p[k].X)
-			l.r2.MulByElement(&l.r2, &p[k].Y)
-			result.MulBy014(&l.r0, &l.r1, &l.r2)
-		}
+			l1.r1.MulByElement(&l1.r1, &p[k].X)
+			l1.r2.MulByElement(&l1.r2, &p[k].Y)
 
-		if loopCounter[i] == 0 {
-			continue
-		}
-
-		for k := 0; k < n; k++ {
-			qProj[k].AddMixedStep(&l, &q[k])
-			// line eval
-			l.r1.MulByElement(&l.r1, &p[k].X)
-			l.r2.MulByElement(&l.r2, &p[k].Y)
-			result.MulBy014(&l.r0, &l.r1, &l.r2)
+			if loopCounter[i] == 0 {
+				result.MulBy014(&l1.r0, &l1.r1, &l1.r2)
+			} else {
+				qProj[k].AddMixedStep(&l2, &q[k])
+				// line eval
+				l2.r1.MulByElement(&l2.r1, &p[k].X)
+				l2.r2.MulByElement(&l2.r2, &p[k].Y)
+				lines.Mul014By014(&l1.r0, &l1.r1, &l1.r2, &l2.r0, &l2.r1, &l2.r2)
+				result.Mul(&result, &lines)
+			}
 		}
 	}
 


### PR DESCRIPTION
leveraging on #106 and using Karabina's cyclotomic squaring for two series of 0 (#75) with a batch decompression, we can improve BLS12-381 final exponentiation.
```
benchmark                           old ns/op     new ns/op     delta
BenchmarkFinalExponentiation-32     424414        395896        -6.72%
```