### PR TITLE
feat: constant time Equal with tests and benchmarks

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -240,6 +240,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -235,18 +235,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -230,46 +230,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -438,26 +398,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -230,6 +230,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -269,6 +291,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -320,18 +354,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -377,6 +399,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -389,7 +459,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -235,7 +235,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -243,7 +243,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -223,18 +223,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -228,6 +228,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -226,6 +226,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -265,6 +287,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -316,18 +350,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -373,6 +395,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -385,7 +455,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -226,46 +226,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -434,26 +394,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -231,7 +231,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -239,7 +239,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -240,6 +240,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -235,18 +235,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -230,46 +230,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -438,26 +398,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -230,6 +230,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -269,6 +291,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -320,18 +354,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -377,6 +399,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -389,7 +459,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -235,7 +235,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -243,7 +243,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -223,18 +223,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -228,6 +228,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -226,6 +226,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -265,6 +287,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -316,18 +350,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -373,6 +395,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -385,7 +455,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -226,46 +226,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -434,26 +394,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -231,7 +231,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -239,7 +239,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -234,6 +234,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -229,18 +229,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -228,46 +228,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -436,26 +396,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -233,7 +233,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -241,7 +241,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -223,18 +223,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -228,6 +228,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -226,6 +226,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -265,6 +287,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -316,18 +350,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -373,6 +395,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -385,7 +455,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -226,46 +226,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -434,26 +394,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -231,7 +231,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -239,7 +239,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -223,18 +223,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -228,6 +228,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -226,6 +226,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -265,6 +287,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -316,18 +350,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -373,6 +395,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -385,7 +455,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -226,46 +226,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -434,26 +394,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -231,7 +231,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -239,7 +239,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -223,18 +223,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -228,6 +228,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -226,6 +226,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -265,6 +287,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -316,18 +350,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -373,6 +395,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -385,7 +455,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -226,46 +226,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -434,26 +394,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -231,7 +231,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -239,7 +239,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -264,6 +264,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[9] == x[9]) && (z[8] == x[8]) && (z[7] == x[7]) && (z[6] == x[6]) && (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[9] ^ x[9]) | (z[8] ^ x[8]) | (z[7] ^ x[7]) | (z[6] ^ x[6]) | (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[9] | z[8] | z[7] | z[6] | z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -259,18 +259,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[9] == x[9]) && (z[8] == x[8]) && (z[7] == x[7]) && (z[6] == x[6]) && (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[9] ^ x[9]) | (z[8] ^ x[8]) | (z[7] ^ x[7]) | (z[6] ^ x[6]) | (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -238,46 +238,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -446,26 +406,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -243,7 +243,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -251,7 +251,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -238,6 +238,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -277,6 +299,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -328,18 +362,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -385,6 +407,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -397,7 +467,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -234,6 +234,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -229,18 +229,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -228,46 +228,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -436,26 +396,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -233,7 +233,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -241,7 +241,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -271,18 +271,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[11] == x[11]) && (z[10] == x[10]) && (z[9] == x[9]) && (z[8] == x[8]) && (z[7] == x[7]) && (z[6] == x[6]) && (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[11] ^ x[11]) | (z[10] ^ x[10]) | (z[9] ^ x[9]) | (z[8] ^ x[8]) | (z[7] ^ x[7]) | (z[6] ^ x[6]) | (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -276,6 +276,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[11] == x[11]) && (z[10] == x[10]) && (z[9] == x[9]) && (z[8] == x[8]) && (z[7] == x[7]) && (z[6] == x[6]) && (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[11] ^ x[11]) | (z[10] ^ x[10]) | (z[9] ^ x[9]) | (z[8] ^ x[8]) | (z[7] ^ x[7]) | (z[6] ^ x[6]) | (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[11] | z[10] | z[9] | z[8] | z[7] | z[6] | z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -242,6 +242,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -281,6 +303,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -332,18 +366,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -389,6 +411,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -401,7 +471,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -247,7 +247,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -255,7 +255,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -242,46 +242,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -450,26 +410,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -240,6 +240,16 @@ func (z *Element) Equal(x *Element) bool {
 	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *Element) EqualCt(x *Element) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *Element) Diff(x *Element) uint64 {
+	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *Element) IsZero() bool {
 	return (z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -235,18 +235,13 @@ func (z *Element) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *Element) Equal(x *Element) bool {
-	return (z[5] == x[5]) && (z[4] == x[4]) && (z[3] == x[3]) && (z[2] == x[2]) && (z[1] == x[1]) && (z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *Element) EqualCt(x *Element) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *Element) Diff(x *Element) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *Element) EqualCt(x *Element) uint64 {
 	return (z[5] ^ x[5]) | (z[4] ^ x[4]) | (z[3] ^ x[3]) | (z[2] ^ x[2]) | (z[1] ^ x[1]) | (z[0] ^ x[0])
 }
 

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -230,46 +230,6 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
-func BenchmarkElementEqual(b *testing.B) {
-	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -438,26 +398,10 @@ func TestElementEqual(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPairElement) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -230,6 +230,28 @@ func BenchmarkElementCmp(b *testing.B) {
 	}
 }
 
+func BenchmarkElementEqual(b *testing.B) {
+	var x, y Element
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
+
 func TestElementCmp(t *testing.T) {
 	var x, y Element
 
@@ -269,6 +291,18 @@ func TestElementIsRandom(t *testing.T) {
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
+	}
+}
+
+func TestElementNegZero(t *testing.T) {
+	var a, b Element
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
 	}
 }
 
@@ -320,18 +354,6 @@ func init() {
 
 }
 
-func TestElementNegZero(t *testing.T) {
-	var a, b Element
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func TestElementReduce(t *testing.T) {
 	testValues := make([]Element, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -377,6 +399,54 @@ func TestElementReduce(t *testing.T) {
 
 }
 
+func TestElementEqual(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func TestElementBytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -389,7 +459,7 @@ func TestElementBytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPairElement) bool {
 			var b Element
 			bytes := a.element.Bytes()

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -235,7 +235,7 @@ func BenchmarkElementEqual(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -243,7 +243,25 @@ func BenchmarkElementEqual(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/field/internal/templates/element/base.go
+++ b/field/internal/templates/element/base.go
@@ -204,18 +204,13 @@ func (z *{{.ElementName}}) Bit(i uint64) uint64 {
 	return uint64(z[j] >> (i % 64) & 1)
 }
 
-// Equal returns z == x
+// Equal returns z == x; constant-time
 func (z *{{.ElementName}}) Equal(x *{{.ElementName}}) bool {
-	return {{- range $i :=  reverse .NbWordsIndexesNoZero}}(z[{{$i}}] == x[{{$i}}]) &&{{end}}(z[0] == x[0])
+	return z.EqualCt(x) == 0
 }
 
-// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
-func (z *{{.ElementName}}) EqualCt(x *{{.ElementName}}) bool {
-	return z.Diff(x) == 0
-}
-
-// Diff returns 0 if and only if z == x; constant-time
-func (z *{{.ElementName}}) Diff(x *{{.ElementName}}) uint64 {
+// EqualCt returns 0 if and only if z == x; constant-time
+func (z *{{.ElementName}}) EqualCt(x *{{.ElementName}}) uint64 {
 return {{- range $i :=  reverse .NbWordsIndexesNoZero}}(z[{{$i}}] ^ x[{{$i}}]) | {{end}}(z[0] ^ x[0])
 }
 

--- a/field/internal/templates/element/base.go
+++ b/field/internal/templates/element/base.go
@@ -209,6 +209,16 @@ func (z *{{.ElementName}}) Equal(x *{{.ElementName}}) bool {
 	return {{- range $i :=  reverse .NbWordsIndexesNoZero}}(z[{{$i}}] == x[{{$i}}]) &&{{end}}(z[0] == x[0])
 }
 
+// EqualCt returns z == x; constant-time, on average slower than Equal except on small moduli
+func (z *{{.ElementName}}) EqualCt(x *{{.ElementName}}) bool {
+	return z.Diff(x) == 0
+}
+
+// Diff returns 0 if and only if z == x; constant-time
+func (z *{{.ElementName}}) Diff(x *{{.ElementName}}) uint64 {
+return {{- range $i :=  reverse .NbWordsIndexesNoZero}}(z[{{$i}}] ^ x[{{$i}}]) | {{end}}(z[0] ^ x[0])
+}
+
 // IsZero returns z == 0
 func (z *{{.ElementName}}) IsZero() bool {
 	return ( {{- range $i :=  reverse .NbWordsIndexesNoZero}} z[{{$i}}] | {{end}}z[0]) == 0

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -213,6 +213,27 @@ func Benchmark{{toTitle .ElementName}}Cmp(b *testing.B) {
 	}
 }
 
+func Benchmark{{toTitle .ElementName}}Equal(b *testing.B) {
+	var x, y {{.ElementName}}
+	x.SetRandom()
+	y.SetRandom()
+
+	b.Run("logical", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+}
 
 func Test{{toTitle .ElementName}}Cmp(t *testing.T) {
 	var x, y {{.ElementName}}
@@ -257,6 +278,17 @@ func Test{{toTitle .ElementName}}IsRandom(t *testing.T) {
 	}
 }
 
+func Test{{toTitle .ElementName}}NegZero(t *testing.T) {
+	var a, b {{.ElementName}}
+	b.SetZero()
+	for a.IsZero() {
+		a.SetRandom()
+	}
+	a.Neg(&b)
+	if !a.IsZero() {
+		t.Fatal("neg(0) != 0")
+	}
+}
 
 // -------------------------------------------------------------------------------------------------
 // Gopter tests
@@ -313,18 +345,6 @@ func init() {
 
 }
 
-func Test{{toTitle .ElementName}}NegZero(t *testing.T) {
-	var a, b {{.ElementName}}
-	b.SetZero()
-	for a.IsZero() {
-		a.SetRandom()
-	}
-	a.Neg(&b)
-	if !a.IsZero() {
-		t.Fatal("neg(0) != 0")
-	}
-}
-
 func Test{{toTitle .ElementName}}Reduce(t *testing.T) {
 	testValues := make([]{{.ElementName}}, len(staticTestValues))
 	copy(testValues, staticTestValues)
@@ -371,6 +391,54 @@ func Test{{toTitle .ElementName}}Reduce(t *testing.T) {
 	
 }
 
+func Test{{toTitle .ElementName}}Equal(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := gen()
+	genB := gen()
+
+	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.Equal(&b.element) == (a.element == b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
+		func(a testPairElement, b testPairElement) bool {
+			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
+		func(a testPairElement) bool {
+			b := a.element
+			return a.element.EqualCt(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
 func Test{{toTitle .ElementName}}Bytes(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -383,7 +451,7 @@ func Test{{toTitle .ElementName}}Bytes(t *testing.T) {
 
 	genA := gen()
 
-	properties.Property("SetBytes(Bytes()) should stayt constant", prop.ForAll(
+	properties.Property("SetBytes(Bytes()) should stay constant", prop.ForAll(
 		func(a testPair{{.ElementName}}) bool {
 			var b {{.ElementName}}
 			bytes := a.element.Bytes()

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -405,7 +405,7 @@ func Test{{toTitle .ElementName}}Equal(t *testing.T) {
 	genB := gen()
 
 	properties.Property("x.Equal(&y) iff x == y; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
+		func(a testPair{{.ElementName}}, b testPair{{.ElementName}}) bool {
 			return a.element.Equal(&b.element) == (a.element == b.element)
 		},
 		genA,
@@ -413,7 +413,7 @@ func Test{{toTitle .ElementName}}Equal(t *testing.T) {
 	))
 
 	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPairElement, b testPairElement) bool {
+		func(a testPair{{.ElementName}}, b testPair{{.ElementName}}) bool {
 			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
 		},
 		genA,
@@ -421,7 +421,7 @@ func Test{{toTitle .ElementName}}Equal(t *testing.T) {
 	))
 
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
+		func(a testPair{{.ElementName}}) bool {
 			b := a.element
 			return a.element.Equal(&b)
 		},
@@ -429,7 +429,7 @@ func Test{{toTitle .ElementName}}Equal(t *testing.T) {
 	))
 
 	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPairElement) bool {
+		func(a testPair{{.ElementName}}) bool {
 			b := a.element
 			return a.element.EqualCt(&b)
 		},

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -218,7 +218,7 @@ func Benchmark{{toTitle .ElementName}}Equal(b *testing.B) {
 	x.SetRandom()
 	y.SetRandom()
 
-	b.Run("logical", func(b *testing.B) {
+	b.Run("logical-random", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -226,7 +226,25 @@ func Benchmark{{toTitle .ElementName}}Equal(b *testing.B) {
 		}
 	})
 
-	b.Run("bitwise", func(b *testing.B) {
+	b.Run("bitwise-random", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.EqualCt(&y)
+		}
+	})
+
+	y = x
+
+	b.Run("logical-equal", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			x.Equal(&y)
+		}
+	})
+
+	b.Run("bitwise-equal", func(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -213,46 +213,6 @@ func Benchmark{{toTitle .ElementName}}Cmp(b *testing.B) {
 	}
 }
 
-func Benchmark{{toTitle .ElementName}}Equal(b *testing.B) {
-	var x, y {{.ElementName}}
-	x.SetRandom()
-	y.SetRandom()
-
-	b.Run("logical-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-random", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-
-	y = x
-
-	b.Run("logical-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.Equal(&y)
-		}
-	})
-
-	b.Run("bitwise-equal", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			x.EqualCt(&y)
-		}
-	})
-}
-
 func Test{{toTitle .ElementName}}Cmp(t *testing.T) {
 	var x, y {{.ElementName}}
 	
@@ -430,26 +390,10 @@ func Test{{toTitle .ElementName}}Equal(t *testing.T) {
 		genB,
 	))
 
-	properties.Property("Constant and non-constant implementations match; likely false for random pairs", prop.ForAll(
-		func(a testPair{{.ElementName}}, b testPair{{.ElementName}}) bool {
-			return a.element.EqualCt(&b.element) == a.element.Equal(&b.element)
-		},
-		genA,
-		genB,
-	))
-
 	properties.Property("x.Equal(&y) if x == y", prop.ForAll(
 		func(a testPair{{.ElementName}}) bool {
 			b := a.element
 			return a.element.Equal(&b)
-		},
-		genA,
-	))
-
-	properties.Property("x.EqualCt(&y) if x == y", prop.ForAll(
-		func(a testPair{{.ElementName}}) bool {
-			b := a.element
-			return a.element.EqualCt(&b)
 		},
 		genA,
 	))


### PR DESCRIPTION
Slightly faster than `Equals` on small moduli, up to %50 slower on big ones
May be useful in algorithms advertised as c-time like sswu hash