### PR TITLE
feat: field/generator suppors 1-limb modulus

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,14 +45,18 @@ jobs:
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after runing go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi
   
   test:
-    runs-on: [self-hosted,linux,x64,large]
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     needs:
       - staticcheck
     steps:
     - name: install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: ${{ matrix.go-version }}
     - name: checkout code
       uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -69,8 +73,7 @@ jobs:
       run: go install golang.org/x/tools/cmd/goimports@latest && go install github.com/klauspost/asmfmt/cmd/asmfmt@latest
     - name: Test
       run: |
-        go test -v -short ./...
-        GOARCH=386 go test -v -short ./ecc/bn254/...
+        go test -v -timeout=30m ./...
         
   
   slack-workflow-status:

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -378,9 +378,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 9586122913090633729, 0)
 		z[1], carry = bits.Add64(z[1], 1660523435060625408, carry)
 		z[2], carry = bits.Add64(z[2], 2230234197602682880, carry)
@@ -750,8 +750,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -773,8 +773,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -970,7 +970,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -978,17 +978,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1640,6 +1643,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1696,6 +1700,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -309,24 +309,32 @@ func init() {
 
 	{
 		a := qElement
-		a[5]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[5]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[5]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[5] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -261,7 +261,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2156,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -2157,7 +2157,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -350,9 +350,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 725501752471715841, 0)
 		z[1], carry = bits.Add64(z[1], 6461107452199829505, carry)
 		z[2], carry = bits.Add64(z[2], 6968279316240510977, carry)
@@ -600,8 +600,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -619,8 +619,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -798,7 +798,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -806,17 +806,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1414,6 +1417,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1462,6 +1466,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -378,9 +378,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 11045256207009841153, 0)
 		z[1], carry = bits.Add64(z[1], 14886639130118979584, carry)
 		z[2], carry = bits.Add64(z[2], 10956628289047010687, carry)
@@ -750,8 +750,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -773,8 +773,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -970,7 +970,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -978,17 +978,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1640,6 +1643,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1696,6 +1700,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls12-378/fp/element_test.go
+++ b/ecc/bls12-378/fp/element_test.go
@@ -309,24 +309,32 @@ func init() {
 
 	{
 		a := qElement
-		a[5]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[5]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[5]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[5] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-378/fp/element_test.go
+++ b/ecc/bls12-378/fp/element_test.go
@@ -261,7 +261,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2156,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-378/fp/element_test.go
+++ b/ecc/bls12-378/fp/element_test.go
@@ -2157,7 +2157,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -350,9 +350,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 3643768340310130689, 0)
 		z[1], carry = bits.Add64(z[1], 16926637627159085057, carry)
 		z[2], carry = bits.Add64(z[2], 9761692607219216639, carry)
@@ -600,8 +600,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -619,8 +619,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -798,7 +798,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -806,17 +806,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1414,6 +1417,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1462,6 +1466,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls12-378/fr/element_test.go
+++ b/ecc/bls12-378/fr/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-378/fr/element_test.go
+++ b/ecc/bls12-378/fr/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-378/fr/element_test.go
+++ b/ecc/bls12-378/fr/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -378,9 +378,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 13402431016077863595, 0)
 		z[1], carry = bits.Add64(z[1], 2210141511517208575, carry)
 		z[2], carry = bits.Add64(z[2], 7435674573564081700, carry)
@@ -750,8 +750,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -773,8 +773,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -970,7 +970,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -978,17 +978,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1586,6 +1589,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1642,6 +1646,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -309,24 +309,32 @@ func init() {
 
 	{
 		a := qElement
-		a[5]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[5]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[5]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[5] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -261,7 +261,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2156,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -2157,7 +2157,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -364,9 +364,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 8063698428123676673, 0)
 		z[1], carry = bits.Add64(z[1], 4764498181658371330, carry)
 		z[2], carry = bits.Add64(z[2], 16051339359738796768, carry)
@@ -671,8 +671,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -692,8 +692,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -880,7 +880,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -888,17 +888,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1522,6 +1525,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1574,6 +1578,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -2155,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -307,24 +307,32 @@ func init() {
 
 	{
 		a := qElement
-		a[4]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[4]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[4]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[4] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -259,7 +259,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2154,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -350,9 +350,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 1860204336533995521, 0)
 		z[1], carry = bits.Add64(z[1], 14466829657984787300, carry)
 		z[2], carry = bits.Add64(z[2], 2737202078770428568, carry)
@@ -600,8 +600,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -619,8 +619,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -798,7 +798,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -806,17 +806,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1414,6 +1417,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1462,6 +1466,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -350,9 +350,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 4332616871279656263, 0)
 		z[1], carry = bits.Add64(z[1], 10917124144477883021, carry)
 		z[2], carry = bits.Add64(z[2], 13281191951274694749, carry)
@@ -600,8 +600,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -619,8 +619,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -798,7 +798,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -806,17 +806,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1362,6 +1365,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1410,6 +1414,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -350,9 +350,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 4891460686036598785, 0)
 		z[1], carry = bits.Add64(z[1], 2896914383306846353, carry)
 		z[2], carry = bits.Add64(z[2], 13281191951274694749, carry)
@@ -600,8 +600,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -619,8 +619,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -798,7 +798,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -806,17 +806,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1414,6 +1417,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1462,6 +1466,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -257,7 +257,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2152,7 +2151,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -305,24 +305,32 @@ func init() {
 
 	{
 		a := qElement
-		a[3]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[3]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[3]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[3] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -2153,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -434,9 +434,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 15512955586897510413, 0)
 		z[1], carry = bits.Add64(z[1], 4410884215886313276, carry)
 		z[2], carry = bits.Add64(z[2], 15543556715411259941, carry)
@@ -1146,8 +1146,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -1177,8 +1177,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -1410,7 +1410,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -1418,17 +1418,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -2163,6 +2166,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -2235,6 +2239,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -2165,7 +2165,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -317,24 +317,32 @@ func init() {
 
 	{
 		a := qElement
-		a[9]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[9]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[9]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[9] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -269,7 +269,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2164,7 +2163,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -364,9 +364,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 8063698428123676673, 0)
 		z[1], carry = bits.Add64(z[1], 4764498181658371330, carry)
 		z[2], carry = bits.Add64(z[2], 16051339359738796768, carry)
@@ -671,8 +671,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -692,8 +692,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -880,7 +880,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -888,17 +888,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1522,6 +1525,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1574,6 +1578,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -2155,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -307,24 +307,32 @@ func init() {
 
 	{
 		a := qElement
-		a[4]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[4]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[4]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[4] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -259,7 +259,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2154,7 +2153,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-756/fp/element.go
+++ b/ecc/bw6-756/fp/element.go
@@ -462,9 +462,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 1, 0)
 		z[1], carry = bits.Add64(z[1], 3731203976813871104, carry)
 		z[2], carry = bits.Add64(z[2], 15039355238879481536, carry)
@@ -1392,8 +1392,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -1427,8 +1427,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -1678,7 +1678,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -1686,17 +1686,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -2558,6 +2561,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -2638,6 +2642,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-756/fp/element_test.go
+++ b/ecc/bw6-756/fp/element_test.go
@@ -2169,7 +2169,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-756/fp/element_test.go
+++ b/ecc/bw6-756/fp/element_test.go
@@ -273,7 +273,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2168,7 +2167,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-756/fp/element_test.go
+++ b/ecc/bw6-756/fp/element_test.go
@@ -321,24 +321,32 @@ func init() {
 
 	{
 		a := qElement
-		a[11]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[11]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[11]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[11] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -378,9 +378,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 11045256207009841153, 0)
 		z[1], carry = bits.Add64(z[1], 14886639130118979584, carry)
 		z[2], carry = bits.Add64(z[2], 10956628289047010687, carry)
@@ -750,8 +750,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -773,8 +773,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -970,7 +970,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -978,17 +978,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1640,6 +1643,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1696,6 +1700,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-756/fr/element_test.go
+++ b/ecc/bw6-756/fr/element_test.go
@@ -309,24 +309,32 @@ func init() {
 
 	{
 		a := qElement
-		a[5]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[5]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[5]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[5] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-756/fr/element_test.go
+++ b/ecc/bw6-756/fr/element_test.go
@@ -261,7 +261,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2156,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-756/fr/element_test.go
+++ b/ecc/bw6-756/fr/element_test.go
@@ -2157,7 +2157,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -462,9 +462,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 17626244516597989515, 0)
 		z[1], carry = bits.Add64(z[1], 16614129118623039618, carry)
 		z[2], carry = bits.Add64(z[2], 1588918198704579639, carry)
@@ -1392,8 +1392,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -1427,8 +1427,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -1678,7 +1678,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -1686,17 +1686,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -2498,6 +2501,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -2578,6 +2582,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -2169,7 +2169,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -273,7 +273,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2168,7 +2167,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -321,24 +321,32 @@ func init() {
 
 	{
 		a := qElement
-		a[11]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[11]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[11]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[11] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -378,9 +378,9 @@ func One() Element {
 // Halve sets z to z / 2 (mod p)
 func (z *Element) Halve() {
 	if z[0]&1 == 1 {
-		var carry uint64
 
 		// z = z + q
+		var carry uint64
 		z[0], carry = bits.Add64(z[0], 9586122913090633729, 0)
 		z[1], carry = bits.Add64(z[1], 1660523435060625408, carry)
 		z[2], carry = bits.Add64(z[2], 2230234197602682880, carry)
@@ -750,8 +750,8 @@ func _fromMontGeneric(z *Element) {
 }
 
 func _addGeneric(z, x, y *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
 	z[2], carry = bits.Add64(x[2], y[2], carry)
@@ -773,8 +773,8 @@ func _addGeneric(z, x, y *Element) {
 }
 
 func _doubleGeneric(z, x *Element) {
-	var carry uint64
 
+	var carry uint64
 	z[0], carry = bits.Add64(x[0], x[0], 0)
 	z[1], carry = bits.Add64(x[1], x[1], carry)
 	z[2], carry = bits.Add64(x[2], x[2], carry)
@@ -970,7 +970,7 @@ func (z *Element) String() string {
 // lower-case letters 'a' to 'z' for digit values 10 to 35.
 // No prefix (such as "0x") is added to the string. If z is a nil
 // pointer it returns "<nil>".
-// If base == 10 and -z fits in a uint64 prefix "-" is added to the string.
+// If base == 10 and -z fits in a uint16 prefix "-" is added to the string.
 func (z *Element) Text(base int) string {
 	if base < 2 || base > 36 {
 		panic("invalid base")
@@ -978,17 +978,20 @@ func (z *Element) Text(base int) string {
 	if z == nil {
 		return "<nil>"
 	}
+
+	const maxUint16 = 65535
+	if base == 10 {
+		var zzNeg Element
+		zzNeg.Neg(z)
+		zzNeg.FromMont()
+		if zzNeg.FitsOnOneWord() && zzNeg[0] <= maxUint16 && zzNeg[0] != 0 {
+			return "-" + strconv.FormatUint(zzNeg[0], base)
+		}
+	}
 	zz := *z
 	zz.FromMont()
 	if zz.FitsOnOneWord() {
 		return strconv.FormatUint(zz[0], base)
-	} else if base == 10 {
-		var zzNeg Element
-		zzNeg.Neg(z)
-		zzNeg.FromMont()
-		if zzNeg.FitsOnOneWord() {
-			return "-" + strconv.FormatUint(zzNeg[0], base)
-		}
 	}
 	vv := bigIntPool.Get().(*big.Int)
 	r := zz.ToBigInt(vv).Text(base)
@@ -1640,6 +1643,7 @@ func (z *Element) montReduceSigned(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)
@@ -1696,6 +1700,7 @@ func (z *Element) montReduceSignedSimpleButSlow(x *Element, xHi uint64) {
 			const neg1 = 0xFFFFFFFFFFFFFFFF
 
 			b = 0
+
 			z[0], b = bits.Add64(z[0], qElementWord0, b)
 			z[1], b = bits.Add64(z[1], qElementWord1, b)
 			z[2], b = bits.Add64(z[2], qElementWord2, b)

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -309,24 +309,32 @@ func init() {
 
 	{
 		a := qElement
-		a[5]--
-		staticTestValues = append(staticTestValues, a)
-	}
-	{
-		a := qElement
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
+	staticTestValues = append(staticTestValues, Element{0})
+	staticTestValues = append(staticTestValues, Element{0, 0})
+	staticTestValues = append(staticTestValues, Element{1})
+	staticTestValues = append(staticTestValues, Element{0, 1})
+	staticTestValues = append(staticTestValues, Element{2})
+	staticTestValues = append(staticTestValues, Element{0, 2})
 
-	for i := 0; i <= 3; i++ {
-		staticTestValues = append(staticTestValues, Element{uint64(i)})
-		staticTestValues = append(staticTestValues, Element{0, uint64(i)})
+	{
+		a := qElement
+		a[5]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := qElement
 		a[5]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := qElement
+		a[5] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -261,7 +261,6 @@ func TestElementCmp(t *testing.T) {
 		t.Fatal("x < y")
 	}
 }
-
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
@@ -2156,7 +2155,7 @@ func TestElementJSON(t *testing.T) {
 
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
-	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
+	const expected = "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
 	assert.Equal(expected, string(encoded))
 
 	// decode valid

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -2157,7 +2157,7 @@ func TestElementJSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/field/asm/amd64/element_mul.go
+++ b/field/asm/amd64/element_mul.go
@@ -52,7 +52,9 @@ func (f *FFAmd64) MulADX(registers *amd64.Registers, x, y func(int) string, t []
 			for j := 0; j < f.NbWords; j++ {
 				f.Comment(fmt.Sprintf("(A,t[%[1]d])  := x[%[1]d]*y[%[2]d] + A", j, i))
 
-				if j == 0 && j != f.NbWordsLastIndex {
+				if j == 0 && f.NbWords == 1 {
+					f.MULXQ(x(j), t[j], A)
+				} else if j == 0 {
 					f.MULXQ(x(j), t[j], t[j+1])
 				} else {
 					highBits := A

--- a/field/asm/amd64/element_mul.go
+++ b/field/asm/amd64/element_mul.go
@@ -52,7 +52,7 @@ func (f *FFAmd64) MulADX(registers *amd64.Registers, x, y func(int) string, t []
 			for j := 0; j < f.NbWords; j++ {
 				f.Comment(fmt.Sprintf("(A,t[%[1]d])  := x[%[1]d]*y[%[2]d] + A", j, i))
 
-				if j == 0 {
+				if j == 0 && j != f.NbWordsLastIndex {
 					f.MULXQ(x(j), t[j], t[j+1])
 				} else {
 					highBits := A

--- a/field/field.go
+++ b/field/field.go
@@ -32,44 +32,42 @@ var (
 
 // Field precomputed values used in template for code generation of field element APIs
 type Field struct {
-	PackageName                string
-	ElementName                string
-	ModulusBig                 *big.Int
-	Modulus                    string
-	ModulusHex                 string
-	NbWords                    int
-	NbBits                     int
-	NbWordsLastIndex           int
-	NbWordsIndexesNoZero       []int
-	NbWordsIndexesFull         []int
-	NbWordsIndexesNoLast       []int
-	NbWordsIndexesNoZeroNoLast []int
-	P20InversionCorrectiveFac  []uint64
-	P20InversionNbIterations   int
-	Q                          []uint64
-	QInverse                   []uint64
-	QMinusOneHalvedP           []uint64 // ((q-1) / 2 ) + 1
-	ASM                        bool
-	RSquare                    []uint64
-	One                        []uint64
-	LegendreExponent           string // big.Int to base16 string
-	NoCarry                    bool
-	NoCarrySquare              bool // used if NoCarry is set, but some op may overflow in square optimization
-	SqrtQ3Mod4                 bool
-	SqrtAtkin                  bool
-	SqrtTonelliShanks          bool
-	SqrtE                      uint64
-	SqrtS                      []uint64
-	SqrtAtkinExponent          string   // big.Int to base16 string
-	SqrtSMinusOneOver2         string   // big.Int to base16 string
-	SqrtQ3Mod4Exponent         string   // big.Int to base16 string
-	SqrtG                      []uint64 // NonResidue ^  SqrtR (montgomery form)
-	NonResidue                 big.Int  // (montgomery form)
-	LegendreExponentData       *addchain.AddChainData
-	SqrtAtkinExponentData      *addchain.AddChainData
-	SqrtSMinusOneOver2Data     *addchain.AddChainData
-	SqrtQ3Mod4ExponentData     *addchain.AddChainData
-	UseAddChain                bool
+	PackageName               string
+	ElementName               string
+	ModulusBig                *big.Int
+	Modulus                   string
+	ModulusHex                string
+	NbWords                   int
+	NbBits                    int
+	NbWordsLastIndex          int
+	NbWordsIndexesNoZero      []int
+	NbWordsIndexesFull        []int
+	P20InversionCorrectiveFac []uint64
+	P20InversionNbIterations  int
+	Q                         []uint64
+	QInverse                  []uint64
+	QMinusOneHalvedP          []uint64 // ((q-1) / 2 ) + 1
+	ASM                       bool
+	RSquare                   []uint64
+	One                       []uint64
+	LegendreExponent          string // big.Int to base16 string
+	NoCarry                   bool
+	NoCarrySquare             bool // used if NoCarry is set, but some op may overflow in square optimization
+	SqrtQ3Mod4                bool
+	SqrtAtkin                 bool
+	SqrtTonelliShanks         bool
+	SqrtE                     uint64
+	SqrtS                     []uint64
+	SqrtAtkinExponent         string   // big.Int to base16 string
+	SqrtSMinusOneOver2        string   // big.Int to base16 string
+	SqrtQ3Mod4Exponent        string   // big.Int to base16 string
+	SqrtG                     []uint64 // NonResidue ^  SqrtR (montgomery form)
+	NonResidue                big.Int  // (montgomery form)
+	LegendreExponentData      *addchain.AddChainData
+	SqrtAtkinExponentData     *addchain.AddChainData
+	SqrtSMinusOneOver2Data    *addchain.AddChainData
+	SqrtQ3Mod4ExponentData    *addchain.AddChainData
+	UseAddChain               bool
 }
 
 // NewField returns a data structure with needed information to generate apis for field element
@@ -99,9 +97,6 @@ func NewField(packageName, elementName, modulus string, useAddChain bool) (*Fiel
 	// pre compute field constants
 	F.NbBits = bModulus.BitLen()
 	F.NbWords = len(bModulus.Bits())
-	if F.NbWords < 2 {
-		return nil, errUnsupportedModulus
-	}
 
 	F.NbWordsLastIndex = F.NbWords - 1
 
@@ -150,18 +145,10 @@ func NewField(packageName, elementName, modulus string, useAddChain bool) (*Fiel
 	// indexes (template helpers)
 	F.NbWordsIndexesFull = make([]int, F.NbWords)
 	F.NbWordsIndexesNoZero = make([]int, F.NbWords-1)
-	F.NbWordsIndexesNoLast = make([]int, F.NbWords-1)
-	F.NbWordsIndexesNoZeroNoLast = make([]int, F.NbWords-2)
 	for i := 0; i < F.NbWords; i++ {
 		F.NbWordsIndexesFull[i] = i
 		if i > 0 {
 			F.NbWordsIndexesNoZero[i-1] = i
-		}
-		if i != F.NbWords-1 {
-			F.NbWordsIndexesNoLast[i] = i
-			if i > 0 {
-				F.NbWordsIndexesNoZeroNoLast[i-1] = i
-			}
 		}
 	}
 

--- a/field/field.go
+++ b/field/field.go
@@ -26,8 +26,7 @@ import (
 )
 
 var (
-	errUnsupportedModulus = errors.New("unsupported modulus. goff only works for prime modulus w/ size > 64bits")
-	errParseModulus       = errors.New("can't parse modulus")
+	errParseModulus = errors.New("can't parse modulus")
 )
 
 // Field precomputed values used in template for code generation of field element APIs

--- a/field/generator/generator_test.go
+++ b/field/generator/generator_test.go
@@ -40,11 +40,11 @@ func TestIntegration(t *testing.T) {
 
 	var bits []int
 	if testing.Short() {
-		for i := 128; i <= 448; i += 64 {
+		for i := 64; i <= 448; i += 64 {
 			bits = append(bits, i-3, i-2, i-1, i, i+1)
 		}
 	} else {
-		for i := 120; i < 704; i++ {
+		for i := 60; i < 704; i++ {
 			bits = append(bits, i)
 		}
 	}
@@ -72,7 +72,6 @@ func TestIntegration(t *testing.T) {
 	moduli["forty_seven"] = "47"
 	moduli["small"] = "9459143039767"
 	moduli["small_without_no_carry"] = "18446744073709551557" // 64bits
-	moduli["sixty_three_bits"] = "9223372036854775783"
 
 	moduli["e_secp256k1"] = "115792089237316195423570985008687907853269984665640564039457584007908834671663"
 

--- a/field/generator/generator_test.go
+++ b/field/generator/generator_test.go
@@ -67,10 +67,12 @@ func TestIntegration(t *testing.T) {
 			}
 			moduli[fmt.Sprintf("e_nocarry_%04d", i)] = q.String()
 		}
-
 	}
 
+	moduli["forty_seven"] = "47"
 	moduli["small"] = "9459143039767"
+	moduli["small_without_no_carry"] = "18446744073709551557" // 64bits
+	moduli["sixty_three_bits"] = "9223372036854775783"
 
 	moduli["e_secp256k1"] = "115792089237316195423570985008687907853269984665640564039457584007908834671663"
 

--- a/field/generator/generator_test.go
+++ b/field/generator/generator_test.go
@@ -70,6 +70,8 @@ func TestIntegration(t *testing.T) {
 
 	}
 
+	moduli["small"] = "9459143039767"
+
 	moduli["e_secp256k1"] = "115792089237316195423570985008687907853269984665640564039457584007908834671663"
 
 	// JUST fails to be nocarry -- only the following two can occur for < 3000 bits

--- a/field/internal/templates/element/base.go
+++ b/field/internal/templates/element/base.go
@@ -482,7 +482,7 @@ func _subGeneric(z,  x, y *{{.ElementName}}) {
 		z[{{$i}}], b = bits.Sub64(x[{{$i}}], y[{{$i}}], b)
 	{{- end}}
 	if b != 0 {
-		{{- if eq .NbWordsLastIndex 0}}
+		{{- if eq .NbWords 1}}
 		z[0], _ = bits.Add64(z[0], {{index $.Q 0}}, 0)
 		{{- else}}
 		var c uint64
@@ -503,18 +503,18 @@ func _negGeneric(z,  x *{{.ElementName}}) {
 		z.SetZero()
 		return
 	}
-	{{- if eq .NbWordsLastIndex 0}}
-	z[0], _ = bits.Sub64({{index $.Q 0}}, x[0], 0)
+	{{- if eq .NbWords 1}}
+		z[0], _ = bits.Sub64({{index $.Q 0}}, x[0], 0)
 	{{- else}}
-	var borrow uint64
-	z[0], borrow = bits.Sub64({{index $.Q 0}}, x[0], 0)
-	{{- range $i := .NbWordsIndexesNoZero}}
-		{{- if eq $i $.NbWordsLastIndex}}
-			z[{{$i}}], _ = bits.Sub64({{index $.Q $i}}, x[{{$i}}], borrow)
-		{{- else}}
-			z[{{$i}}], borrow = bits.Sub64({{index $.Q $i}}, x[{{$i}}], borrow)
+		var borrow uint64
+		z[0], borrow = bits.Sub64({{index $.Q 0}}, x[0], 0)
+		{{- range $i := .NbWordsIndexesNoZero}}
+			{{- if eq $i $.NbWordsLastIndex}}
+				z[{{$i}}], _ = bits.Sub64({{index $.Q $i}}, x[{{$i}}], borrow)
+			{{- else}}
+				z[{{$i}}], borrow = bits.Sub64({{index $.Q $i}}, x[{{$i}}], borrow)
+			{{- end}}
 		{{- end}}
-	{{- end}}
 	{{- end}}
 }
 

--- a/field/internal/templates/element/inverse.go
+++ b/field/internal/templates/element/inverse.go
@@ -301,8 +301,7 @@ func (z *{{.ElementName}}) montReduceSigned(x *{{.ElementName}}, xHi uint64) {
 	// xHi + C < 2⁶³ + 2⁶³ = 2⁶⁴
 
 	{{/* $NbWordsIndexesNoZeroInnerLoop := .NbWordsIndexesNoZero*/}}// <standard SOS>
-	{{- range $i := .NbWordsIndexesNoZero}}
-	{{- if eq $i $.NbWordsLastIndex}} {{break}} {{- end }}
+	{{- range $i := iterate 1 $.NbWordsLastIndex}}
 	{
 		const i = {{$i}}
 		m = t[i] * qInvNegLsw
@@ -321,8 +320,7 @@ func (z *{{.ElementName}}) montReduceSigned(x *{{.ElementName}}, xHi uint64) {
 		m := t[i] * qInvNegLsw
 
 		C = madd0(m, q{{.ElementName}}Word0, t[i+0])
-		{{- range $j := $.NbWordsIndexesNoZero}}
-		{{- if eq $j $.NbWordsLastIndex}} {{break}} {{- end }}
+		{{- range $j := iterate 1 $.NbWordsLastIndex}}
 		C, z[{{sub $j 1}}] = madd2(m, q{{$.ElementName}}Word{{$j}}, t[i+{{$j}}], C)
 		{{- end}}
 		z[{{.NbWordsLastIndex}}], z[{{sub .NbWordsLastIndex 1}}] = madd2(m, q{{.ElementName}}Word{{.NbWordsLastIndex}}, t[i+{{.NbWordsLastIndex}}], C)
@@ -354,8 +352,7 @@ func (z *{{.ElementName}}) montReduceSignedSimpleButSlow(x *{{.ElementName}}, xH
                // (xHi r + x) r⁻¹ = xHi + xr⁻¹ = xHi + z
                var c uint64
 			   z[0], c = bits.Add64(z[0], xHi, 0)   
-			   {{- range $i := .NbWordsIndexesNoZero }}
-			   {{- if eq $i $.NbWordsLastIndex}} {{break}} {{- end }}
+			   {{- range $i := iterate 1 $.NbWordsLastIndex}}
                z[{{$i}}], c = bits.Add64(z[{{$i}}], 0, c)
 			   {{- end }}
                z[{{.NbWordsLastIndex}}], _ = bits.Add64(z[{{.NbWordsLastIndex}}], 0, c)

--- a/field/internal/templates/element/mul_cios.go
+++ b/field/internal/templates/element/mul_cios.go
@@ -39,8 +39,10 @@ const MulCIOS = `
 
 	if t[{{$.all.NbWords}}] != 0 {
 		// we need to reduce, we have a result on {{add 1 $.all.NbWords}} words
+		{{- if gt $.all.NbWords 1}}
 		var b uint64
-		z[0], b = bits.Sub64(t[0], {{index $.all.Q 0}}, 0)
+		{{- end}}
+		z[0], {{- if gt $.all.NbWords 1}}b{{- else}}_{{- end}} = bits.Sub64(t[0], {{index $.all.Q 0}}, 0)
 		{{- range $i := .all.NbWordsIndexesNoZero}}
 			{{-  if eq $i $.all.NbWordsLastIndex}}
 				z[{{$i}}], _ = bits.Sub64(t[{{$i}}], {{index $.all.Q $i}}, b)

--- a/field/internal/templates/element/reduce.go
+++ b/field/internal/templates/element/reduce.go
@@ -6,13 +6,17 @@ const Reduce = `
 // note: this is NOT constant time
 if !({{- range $i := reverse .NbWordsIndexesNoZero}} z[{{$i}}] < {{index $.Q $i}} || ( z[{{$i}}] == {{index $.Q $i}} && (
 {{- end}}z[0] < {{index $.Q 0}} {{- range $i :=  .NbWordsIndexesNoZero}} )) {{- end}} ){
-	var b uint64
-	z[0], b = bits.Sub64(z[0], {{index $.Q 0}}, 0)
-	{{- range $i := .NbWordsIndexesNoZero}}
-		{{-  if eq $i $.NbWordsLastIndex}}
-			z[{{$i}}], _ = bits.Sub64(z[{{$i}}], {{index $.Q $i}}, b)
-		{{-  else  }}
-			z[{{$i}}], b = bits.Sub64(z[{{$i}}], {{index $.Q $i}}, b)
+	{{- if eq $.NbWordsLastIndex 0}}
+		z[0], _ = bits.Sub64(z[0], {{index $.Q 0}}, 0)
+	{{- else }}
+		var b uint64
+		z[0], b = bits.Sub64(z[0], {{index $.Q 0}}, 0)
+		{{- range $i := .NbWordsIndexesNoZero}}
+			{{-  if eq $i $.NbWordsLastIndex}}
+				z[{{$i}}], _ = bits.Sub64(z[{{$i}}], {{index $.Q $i}}, b)
+			{{-  else  }}
+				z[{{$i}}], b = bits.Sub64(z[{{$i}}], {{index $.Q $i}}, b)
+			{{- end}}
 		{{- end}}
 	{{- end}}
 }

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -3,7 +3,7 @@ package element
 const Test = `
 
 {{$elementCapacityNbBits := mul .NbWords 64}}
-{{$UsingP20Inverse := lt .NbBits $elementCapacityNbBits}}
+{{$UsingP20Inverse := and (lt .NbBits $elementCapacityNbBits) (gt .NbWords 1) }}
 
 import (
 	"crypto/rand"
@@ -315,7 +315,9 @@ func init() {
 
 	for i:=0; i <=3 ; i++ {
 		staticTestValues = append(staticTestValues, {{.ElementName}}{uint64(i)})
-		staticTestValues = append(staticTestValues, {{.ElementName}}{0, uint64(i)})
+		{{- if gt .NbWords 1}}
+			staticTestValues = append(staticTestValues, {{.ElementName}}{0, uint64(i)})
+		{{- end}}
 	}
 
 	{
@@ -1325,7 +1327,7 @@ func Test{{toTitle .ElementName}}JSON(t *testing.T) {
 	encoded, err := json.Marshal(&s)
 	assert.NoError(err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(expected, string(encoded))
 
 	// decode valid
 	var decoded S

--- a/field/internal/templates/element/tests.go
+++ b/field/internal/templates/element/tests.go
@@ -303,28 +303,39 @@ func init() {
 	e.Double(&one)
 	staticTestValues = append(staticTestValues, e) 	// 2 
 
-	{
-		a := q{{.ElementName}}
-		a[{{.NbWordsLastIndex}}]--
-		staticTestValues = append(staticTestValues, a)
-	}
+
 	{
 		a := q{{.ElementName}}
 		a[0]--
 		staticTestValues = append(staticTestValues, a)
 	}
 
-	for i:=0; i <=3 ; i++ {
-		staticTestValues = append(staticTestValues, {{.ElementName}}{uint64(i)})
-		{{- if gt .NbWords 1}}
-			staticTestValues = append(staticTestValues, {{.ElementName}}{0, uint64(i)})
+	{{- $qi := index $.Q $.NbWordsLastIndex}}
+	{{- range $i := iterate 0 3}}
+		staticTestValues = append(staticTestValues, {{$.ElementName}}{ {{$i}} })
+		{{- if gt $.NbWords 1}}
+			{{- if le $i $qi}}
+			staticTestValues = append(staticTestValues, {{$.ElementName}}{0, {{$i}} })
+			{{- end}}
 		{{- end}}
+	{{- end}}
+
+	{
+		a := q{{.ElementName}}
+		a[{{.NbWordsLastIndex}}]--
+		staticTestValues = append(staticTestValues, a)
 	}
 
 	{
 		a := q{{.ElementName}}
 		a[{{.NbWordsLastIndex}}]--
 		a[0]++
+		staticTestValues = append(staticTestValues, a)
+	}
+
+	{
+		a := q{{.ElementName}}
+		a[{{.NbWordsLastIndex}}] = 0
 		staticTestValues = append(staticTestValues, a)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/consensys/gnark-crypto
 go 1.17
 
 require (
-	github.com/consensys/bavard v0.1.10
+	github.com/consensys/bavard v0.1.11-0.20220418151131-08e04eec2153
 	github.com/leanovate/gopter v0.2.9
 	github.com/mmcloughlin/addchain v0.4.0
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/consensys/bavard v0.1.10 h1:1I/IvY7bkX/O7QLNCEuV2+YBKdTetzw3gnBbvFaWiEE=
 github.com/consensys/bavard v0.1.10/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
+github.com/consensys/bavard v0.1.11-0.20220418151131-08e04eec2153 h1:6d1VynA5G53Rfk0DXEPWeBakhNzXAnN1R7HUOYKCDBM=
+github.com/consensys/bavard v0.1.11-0.20220418151131-08e04eec2153/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/fft/template/fft.go.tmpl
+++ b/internal/generator/fft/template/fft.go.tmpl
@@ -246,10 +246,10 @@ func kerDIT8(a []fr.Element, twiddles [][]fr.Element, stage int) {
 	{{ $n := 2}}
 	{{ $m := div $n 2}}
 	{{ $split := 4}}
-	{{- range $step := reverse (iterate 3)}} 
+	{{- range $step := reverse (iterate 0 3)}} 
 		{{- $offset := 0}}
-		{{- range $s := reverse (iterate $split)}}
-			{{- range $i := iterate $m}}
+		{{- range $s := reverse (iterate 0 $split)}}
+			{{- range $i := iterate 0 $m}}
 				{{- $j := add $i $offset}}
 				{{- $k := add $j $m}}
 				{{- if ne $i 0}}
@@ -278,10 +278,10 @@ func kerDIF8(a []fr.Element, twiddles [][]fr.Element, stage int) {
 	{{ $n := 8}}
 	{{ $m := div $n 2}}
 	{{ $split := 1}}
-	{{- range $step := iterate 3}} 
+	{{- range $step := iterate 0 3}} 
 		{{- $offset := 0}}
-		{{- range $s := iterate $split}}
-			{{- range $i := iterate $m}}
+		{{- range $s := iterate 0 $split}}
+			{{- range $i := iterate 0 $m}}
 				{{- $j := add $i $offset}}
 				{{- $k := add $j $m}}
 				fr.Butterfly(&a[{{$j}}], &a[{{$k}}])
@@ -290,8 +290,8 @@ func kerDIF8(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		{{- end}}
 
 		{{- $offset := 0}}
-		{{- range $s := iterate $split}}
-			{{- range $i := iterate $m}}
+		{{- range $s := iterate 0 $split}}
+			{{- range $i := iterate 0 $m}}
 				{{- $j := add $i $offset}}
 				{{- $k := add $j $m}}
 				{{- if ne $i 0}}


### PR DESCRIPTION
Tested on amd64 and arm64. 

Remaining task:

- [ ] Pornin's inverse

Note that the generated code for 1-limb modulus is not specifically "optimized" (but could be); it uses the exact same algorithm as larger modulus, as designed (fuzz-testing purposes). 

