### PR TITLE
refactor: field mod base 10 unless prefixed by 0x. 'Field.ModulusDec'

### DIFF
--- a/field/field.go
+++ b/field/field.go
@@ -18,11 +18,10 @@ package field
 import (
 	"errors"
 	"fmt"
+	"github.com/consensys/gnark-crypto/field/internal/addchain"
 	"math"
 	"math/big"
 	"math/bits"
-
-	"github.com/consensys/gnark-crypto/field/internal/addchain"
 )
 
 var (
@@ -34,7 +33,7 @@ type Field struct {
 	PackageName               string
 	ElementName               string
 	ModulusBig                *big.Int
-	Modulus                   string
+	ModulusDec                string
 	ModulusHex                string
 	NbWords                   int
 	NbBits                    int
@@ -76,7 +75,14 @@ type Field struct {
 func NewField(packageName, elementName, modulus string, useAddChain bool) (*Field, error) {
 	// parse modulus
 	var bModulus big.Int
-	if _, ok := bModulus.SetString(modulus, 0); !ok {
+	var base int
+
+	if modulus[0] == '0' && (modulus[1] == 'x' || modulus[1] == 'X') {
+		base = 16
+		modulus = modulus[2:]
+	}
+
+	if _, ok := bModulus.SetString(modulus, base); !ok {
 		return nil, errParseModulus
 	}
 
@@ -84,7 +90,7 @@ func NewField(packageName, elementName, modulus string, useAddChain bool) (*Fiel
 	F := &Field{
 		PackageName: packageName,
 		ElementName: elementName,
-		Modulus:     bModulus.Text(10),
+		ModulusDec:  bModulus.Text(10),
 		ModulusHex:  bModulus.Text(16),
 		ModulusBig:  new(big.Int).Set(&bModulus),
 		UseAddChain: useAddChain,

--- a/field/internal/templates/element/base.go
+++ b/field/internal/templates/element/base.go
@@ -25,7 +25,7 @@ import (
 // {{.ElementName}} are assumed to be in Montgomery form in all methods
 // field modulus q =
 //
-// {{.Modulus}}
+// {{.ModulusDec}}
 type {{.ElementName}} [{{.NbWords}}]uint64
 
 // Limbs number of 64 bits words needed to represent {{.ElementName}}
@@ -43,7 +43,7 @@ var _modulus big.Int
 // Modulus returns q as a big.Int
 // q =
 //
-// {{.Modulus}}
+// {{.ModulusDec}}
 func Modulus() *big.Int {
 	return new(big.Int).Set(&_modulus)
 }
@@ -75,7 +75,7 @@ var bigIntPool = sync.Pool{
 }
 
 func init() {
-	// base10: {{.Modulus}}
+	// base10: {{.ModulusDec}}
 	_modulus.SetString("{{.ModulusHex}}", 16)
 }
 

--- a/field/internal/templates/element/doc.go
+++ b/field/internal/templates/element/doc.go
@@ -26,6 +26,6 @@ const Doc = `
 //
 // Modulus
 // 	0x{{.ModulusHex}} // base 16
-// 	{{.Modulus}} // base 10
+// 	{{.ModulusDec}} // base 10
 package {{.PackageName}}
 `


### PR DESCRIPTION
I personally get confused sometimes about the naming of the field "modulus". Not always sure if it's decimal or allowed to be hex. Thought it would be beneficial to be explicit about the base.

Also being a bit more strict about input modulus formatting to `NewField`. Technically the string `"123"` could be taken to be in either base 10 or 16. I changed that to assume base 10 unless prefixed by `"0x"` or `"0X"`.