### PR TITLE
fix: closes #199 correct bound in eddsa key gen template

### DIFF
--- a/ecc/bls12-377/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-377/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bls12-378/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-378/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bls12-381/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-381/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bls24-315/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-315/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bls24-317/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-317/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bn254/twistededwards/eddsa/eddsa.go
+++ b/ecc/bn254/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -79,24 +77,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr - 1; i < j; i, j = i+1, j-1 {
-
-		h[i], h[j] = h[j], h[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h[j]
 	}
 
-	copy(priv.scalar[:], h[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bw6-633/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-633/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// The source of randomness and the secret scalar must come
 	// from 2 distincts sources. Since the scalar is the size of the
 	// field of definition (48 bytes), the scalar must come from a
@@ -88,24 +86,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h1[0] &= 0xF8
 	h1[sizeFr-1] &= 0x7F
 	h1[sizeFr-1] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h1[i], h1[j] = h1[j], h1[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h1[j]
 	}
 
-	copy(priv.scalar[:], h1[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bw6-756/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-756/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// The source of randomness and the secret scalar must come
 	// from 2 distincts sources. Since the scalar is the size of the
 	// field of definition (48 bytes), the scalar must come from a
@@ -88,24 +86,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h1[0] &= 0xF8
 	h1[sizeFr-1] &= 0x7F
 	h1[sizeFr-1] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h1[i], h1[j] = h1[j], h1[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h1[j]
 	}
 
-	copy(priv.scalar[:], h1[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/ecc/bw6-761/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-761/twistededwards/eddsa/eddsa.go
@@ -60,12 +60,10 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
-
 	// The source of randomness and the secret scalar must come
 	// from 2 distincts sources. Since the scalar is the size of the
 	// field of definition (48 bytes), the scalar must come from a
@@ -88,24 +86,19 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
 	h1[0] &= 0xF8
 	h1[sizeFr-1] &= 0x7F
 	h1[sizeFr-1] |= 0x40
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-
-		h1[i], h1[j] = h1[j], h1[i]
-
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = h1[j]
 	}
 
-	copy(priv.scalar[:], h1[:sizeFr])
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 

--- a/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
@@ -43,13 +43,12 @@ type Signature struct {
 
 // GenerateKey generates a public and private key pair.
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var pub PublicKey
 	var priv PrivateKey
 
-    {{ if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
+    {{- if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
 	// The source of randomness and the secret scalar must come
 	// from 2 distincts sources. Since the scalar is the size of the
 	// field of definition (48 bytes), the scalar must come from a
@@ -69,7 +68,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 	for i := 0; i < 32; i++ {
 		priv.randSrc[i] = h2[i]
 	}
-	{{ else }}
+	{{- else }}
 	// hash(h) = private_key || random_source, on 32 bytes each
 	seed := make([]byte, 32)
 	_, err := r.Read(seed)
@@ -80,39 +79,33 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 	for i := 0; i < 32; i++ {
 		priv.randSrc[i] = h[i+32]
 	}
-	{{ end }}
+	{{- end }}
 
 	// prune the key
 	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-	{{ if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
+	{{- if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
 	h1[0] &= 0xF8
 	h1[sizeFr-1] &= 0x7F
 	h1[sizeFr-1] |= 0x40
-	{{ else }}
+	{{- else }}
 	h[0] &= 0xF8
 	h[31] &= 0x7F
 	h[31] |= 0x40
-	{{ end }}
+	{{- end }}
 
 	// reverse first bytes because setBytes interpret stream as big endian
 	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr; i < j; i, j = i+1, j-1 {
-		{{ if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
-		h1[i], h1[j] = h1[j], h1[i]
-		{{ else }}
-		h[i], h[j] = h[j], h[i]
-		{{ end }}
+	{{- $h := "h"}}
+	{{- if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
+		{{- $h = "h1"}}
+	{{- end}}
+	for i, j := 0, sizeFr - 1; i < sizeFr; i, j = i+1, j-1 {
+		priv.scalar[i] = {{$h}}[j]
 	}
 
-	{{ if or (eq .Name "bw6-761") (eq .Name "bw6-633") (eq .Name "bw6-756")}}
-	copy(priv.scalar[:], h1[:sizeFr])
-	{{ else }}
-	copy(priv.scalar[:], h[:sizeFr])
-	{{ end }}
-
-	var bscalar big.Int
-	bscalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bscalar)
+	var bScalar big.Int
+	bScalar.SetBytes(priv.scalar[:])
+	pub.A.ScalarMul(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 


### PR DESCRIPTION
- Update endian revert process logic
- fix: closes #199. Correct bound in eddsa key gen template

See also #200 --> keeping commit [014a9cf](https://github.com/ConsenSys/gnark-crypto/pull/202/commits/014a9cfdefaa48442d6f03de29ae4f87bf25fb0b) but reported modif to template generation for all curves. 