### PR TITLE
perf: faster GLV scalar decomposition

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -17,7 +17,6 @@
 package bls12377
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -463,12 +462,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -17,7 +17,6 @@
 package bls12377
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -470,12 +469,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -17,7 +17,6 @@
 package bls12378
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -463,12 +462,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -17,7 +17,6 @@
 package bls12378
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -470,12 +469,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -17,7 +17,6 @@
 package bls12381
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -463,12 +462,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -17,7 +17,6 @@
 package bls12381
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -471,12 +470,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -17,7 +17,6 @@
 package bls24315
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -465,12 +464,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -17,7 +17,6 @@
 package bls24315
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -472,12 +471,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -17,7 +17,6 @@
 package bls24317
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -465,12 +464,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -17,7 +17,6 @@
 package bls24317
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -472,12 +471,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -17,7 +17,6 @@
 package bn254
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -454,12 +453,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -17,7 +17,6 @@
 package bn254
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -471,12 +470,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -17,7 +17,6 @@
 package bw6633
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -468,12 +467,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -17,7 +17,6 @@
 package bw6633
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -463,12 +462,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -17,7 +17,6 @@
 package bw6756
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -472,12 +471,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -17,7 +17,6 @@
 package bw6761
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -472,12 +471,20 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -17,7 +17,6 @@
 package bw6761
 
 import (
-	"math"
 	"math/big"
 	"runtime"
 
@@ -467,12 +466,20 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+	// we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -6,7 +6,6 @@
 
 
 import (
-    "math"
 	"math/big"
 	"runtime"
 
@@ -644,12 +643,20 @@ func (p *{{ $TJacobian }}) mulGLV(a *{{ $TJacobian }}, s *big.Int) *{{ $TJacobia
 	table[13].Set(&table[11]).AddAssign(&table[1])
 	table[14].Set(&table[11]).AddAssign(&table[2])
 
-	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 bits long max
+	// bounds on the lattice base vectors guarantee that k1, k2 are len(r)/2 or len(r)/2+1 bits long max
+	// this is because we use a probabilistic scalar decomposition that replaces a division by a right-shift
 	k1.SetBigInt(&k[0]).FromMont()
 	k2.SetBigInt(&k[1]).FromMont()
 
-	// loop starts from len(k1)/2 due to the bounds
-	for i := int(math.Ceil(fr.Limbs/2. - 1)); i >= 0; i-- {
+    // we don't target constant-timeness so we check first if we increase the bounds or not
+	maxBit := k1.BitLen()
+	if k2.BitLen() > maxBit {
+		maxBit = k2.BitLen()
+	}
+	hiWordIndex := (maxBit - 1) / 64
+
+	// loop starts from len(k1)/2 or len(k1)/2+1 due to the bounds
+	for i := hiWordIndex; i >= 0; i-- {
 		mask := uint64(3) << 62
 		for j := 0; j < 32; j++ {
 			res.Double(&res).Double(&res)


### PR DESCRIPTION
This replaces the Babai rounding at runtime in `SplitScalar()` by a right-shift. We precompute `b=2^m*v/d` (`m > log2(d)`) and then at runtime compute `scalar*b/2^m`. This increases the bounds on sub-scalars by 1 which we check at runtime before increasing the loop size (we don't target constant-timeness). `m` is chosen to be a machine word twice big than `log2(d)` so that we rarely increase the loop size.