### PR TITLE
refactor: restore ScalarMultiplication (from ScalarMul name change in previous merge)

### DIFF
--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bls12377.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12377.G1Jac

--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bls12377.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12377.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bls12377.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bls12377.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bls12-377/fr/kzg/kzg_test.go
+++ b/ecc/bls12-377/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bls12377.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-377/fr/plookup/table.go
+++ b/ecc/bls12-377/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -869,10 +869,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,8 +382,8 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -514,7 +514,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMul(a, &xGen).Neg(&res).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).Neg(&res).AddAssign(a)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-377] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-377] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -868,10 +868,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -374,7 +374,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMul(p, &xGen).
+	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -513,8 +513,8 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen)
-	xxg.ScalarMul(&xg, &xGen)
+	xg.ScalarMultiplication(a, &xGen)
+	xxg.ScalarMultiplication(&xg, &xGen)
 
 	res.Set(&xxg).
 		SubAssign(&xg).

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -441,7 +441,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -457,7 +457,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-377] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-377] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -468,7 +468,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -505,7 +505,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -527,7 +527,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),
@@ -375,12 +375,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -533,7 +533,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-377/marshal_test.go
+++ b/ecc/bls12-377/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bls12-377/multiexp.go
+++ b/ecc/bls12-377/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bls12-377/multiexp_test.go
+++ b/ecc/bls12-377/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bls12-377/pairing_test.go
+++ b/ecc/bls12-377/pairing_test.go
@@ -120,8 +120,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -185,8 +185,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -228,8 +228,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -266,8 +266,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bls12-377/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-377/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bls12-378/fr/kzg/kzg.go
+++ b/ecc/bls12-378/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bls12378.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12378.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-378/fr/kzg/kzg.go
+++ b/ecc/bls12-378/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bls12378.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bls12378.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bls12-378/fr/kzg/kzg.go
+++ b/ecc/bls12-378/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bls12378.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12378.G1Jac

--- a/ecc/bls12-378/fr/kzg/kzg_test.go
+++ b/ecc/bls12-378/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bls12378.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-378/fr/plookup/table.go
+++ b/ecc/bls12-378/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -869,10 +869,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,8 +382,8 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -514,7 +514,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMul(a, &xGen).Neg(&res).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).Neg(&res).AddAssign(a)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bls12-378/g1_test.go
+++ b/ecc/bls12-378/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-378/g1_test.go
+++ b/ecc/bls12-378/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-378] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-378] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -868,10 +868,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -374,7 +374,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMul(p, &xGen).
+	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -513,8 +513,8 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen)
-	xxg.ScalarMul(&xg, &xGen)
+	xg.ScalarMultiplication(a, &xGen)
+	xxg.ScalarMultiplication(&xg, &xGen)
 
 	res.Set(&xxg).
 		SubAssign(&xg).

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -441,7 +441,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -457,7 +457,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-378] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-378] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -468,7 +468,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -505,7 +505,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -527,7 +527,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),
@@ -375,12 +375,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -533,7 +533,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-378/marshal_test.go
+++ b/ecc/bls12-378/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bls12-378/multiexp.go
+++ b/ecc/bls12-378/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bls12-378/multiexp_test.go
+++ b/ecc/bls12-378/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bls12-378/pairing_test.go
+++ b/ecc/bls12-378/pairing_test.go
@@ -120,8 +120,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -185,8 +185,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -228,8 +228,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -266,8 +266,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bls12-378/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-378/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bls12-378/twistededwards/point_test.go
+++ b/ecc/bls12-378/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls12-381/bandersnatch/endomorpism.go
+++ b/ecc/bls12-381/bandersnatch/endomorpism.go
@@ -30,7 +30,7 @@ func (p *PointProj) phi(p1 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication (GLV) of a point
+// ScalarMultiplication scalar multiplication (GLV) of a point
 // p1 in projective coordinates with a scalar in big.Int
 func (p *PointProj) scalarMulGLV(p1 *PointProj, scalar *big.Int) *PointProj {
 
@@ -121,7 +121,7 @@ func (p *PointExtended) phi(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication (GLV) of a point
+// ScalarMultiplication scalar multiplication (GLV) of a point
 // p1 in projective coordinates with a scalar in big.Int
 func (p *PointExtended) scalarMulGLV(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	initOnce.Do(initCurveParams)

--- a/ecc/bls12-381/bandersnatch/point.go
+++ b/ecc/bls12-381/bandersnatch/point.go
@@ -255,13 +255,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -408,9 +408,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	return p.scalarMulGLV(p1, scalar)
 }
 
@@ -597,8 +597,8 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	return p.scalarMulGLV(p1, scalar)
 }

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bls12381.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bls12381.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bls12381.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12381.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bls12381.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12381.G1Jac

--- a/ecc/bls12-381/fr/kzg/kzg_test.go
+++ b/ecc/bls12-381/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bls12381.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-381/fr/plookup/table.go
+++ b/ecc/bls12-381/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -869,10 +869,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,8 +382,8 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -514,7 +514,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMul(a, &xGen).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).AddAssign(a)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-381] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-381] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -869,10 +869,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -375,7 +375,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMul(p, &xGen).
+	res.ScalarMultiplication(p, &xGen).
 		AddAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -514,8 +514,8 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).Neg(&xg)
-	xxg.ScalarMul(&xg, &xGen).Neg(&xxg)
+	xg.ScalarMultiplication(a, &xGen).Neg(&xg)
+	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
 
 	res.Set(&xxg).
 		SubAssign(&xg).

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -441,7 +441,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -457,7 +457,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS12-381] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS12-381] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -468,7 +468,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -505,7 +505,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -527,7 +527,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),
@@ -375,12 +375,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -533,7 +533,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls12-381/marshal_test.go
+++ b/ecc/bls12-381/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bls12-381/multiexp.go
+++ b/ecc/bls12-381/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bls12-381/multiexp_test.go
+++ b/ecc/bls12-381/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bls12-381/pairing_test.go
+++ b/ecc/bls12-381/pairing_test.go
@@ -120,8 +120,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -185,8 +185,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -228,8 +228,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -266,8 +266,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bls12-381/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-381/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bls24315.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls24315.G1Jac

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bls24315.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls24315.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bls24315.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bls24315.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bls24-315/fr/kzg/kzg_test.go
+++ b/ecc/bls24-315/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bls24315.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls24-315/fr/plookup/table.go
+++ b/ecc/bls24-315/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -871,10 +871,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,10 +382,10 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -516,7 +516,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMul(a, &xGen).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).AddAssign(a)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS24-315] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS24-315] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -375,7 +375,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMul(p, &xGen).
+	res.ScalarMultiplication(p, &xGen).
 		AddAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -517,10 +517,10 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// multiply by (3x⁴-3)*cofacor
 
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).Neg(&xg).SubAssign(a)
-	xxg.ScalarMul(&xg, &xGen).Neg(&xxg)
-	xxxg.ScalarMul(&xxg, &xGen).Neg(&xxxg)
-	xxxxg.ScalarMul(&xxxg, &xGen).Neg(&xxxxg)
+	xg.ScalarMultiplication(a, &xGen).Neg(&xg).SubAssign(a)
+	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
+	xxxg.ScalarMultiplication(&xxg, &xGen).Neg(&xxxg)
+	xxxxg.ScalarMultiplication(&xxxg, &xGen).Neg(&xxxxg)
 
 	res.Set(&xxxxg).
 		SubAssign(a)

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -884,10 +884,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -441,7 +441,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -457,7 +457,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS24-315] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS24-315] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -468,7 +468,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -505,7 +505,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -527,7 +527,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE4(),
@@ -375,12 +375,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -533,7 +533,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls24-315/marshal_test.go
+++ b/ecc/bls24-315/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bls24-315/multiexp.go
+++ b/ecc/bls24-315/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bls24-315/multiexp_test.go
+++ b/ecc/bls24-315/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bls24-315/pairing_test.go
+++ b/ecc/bls24-315/pairing_test.go
@@ -122,8 +122,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -187,8 +187,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -230,8 +230,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -268,8 +268,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bls24-315/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-315/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bls24-317/fr/kzg/kzg.go
+++ b/ecc/bls24-317/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bls24317.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls24317.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls24-317/fr/kzg/kzg.go
+++ b/ecc/bls24-317/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bls24317.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls24317.G1Jac

--- a/ecc/bls24-317/fr/kzg/kzg.go
+++ b/ecc/bls24-317/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bls24317.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bls24317.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bls24-317/fr/kzg/kzg_test.go
+++ b/ecc/bls24-317/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bls24317.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls24-317/fr/plookup/table.go
+++ b/ecc/bls24-317/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -871,10 +871,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,10 +382,10 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -516,7 +516,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMul(a, &xGen).Neg(&res).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).Neg(&res).AddAssign(a)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS24-317] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS24-317] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -375,7 +375,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMul(p, &xGen).
+	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -517,10 +517,10 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// multiply by (3x⁴-3)*cofacor
 
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).SubAssign(a)
-	xxg.ScalarMul(&xg, &xGen)
-	xxxg.ScalarMul(&xxg, &xGen)
-	xxxxg.ScalarMul(&xxxg, &xGen)
+	xg.ScalarMultiplication(a, &xGen).SubAssign(a)
+	xxg.ScalarMultiplication(&xg, &xGen)
+	xxxg.ScalarMultiplication(&xxg, &xGen)
+	xxxxg.ScalarMultiplication(&xxxg, &xGen)
 
 	res.Set(&xxxxg).
 		SubAssign(a)

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -884,10 +884,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -441,7 +441,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -457,7 +457,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BLS24-317] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BLS24-317] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -468,7 +468,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -505,7 +505,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -527,7 +527,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE4(),
@@ -375,12 +375,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -533,7 +533,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bls24-317/marshal_test.go
+++ b/ecc/bls24-317/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bls24-317/multiexp.go
+++ b/ecc/bls24-317/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bls24-317/multiexp_test.go
+++ b/ecc/bls24-317/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bls24-317/pairing_test.go
+++ b/ecc/bls24-317/pairing_test.go
@@ -121,8 +121,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -186,8 +186,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -229,8 +229,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -267,8 +267,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bls24-317/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-317/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bn254.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bn254.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bn254.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bn254.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bn254.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bn254.G1Jac

--- a/ecc/bn254/fr/kzg/kzg_test.go
+++ b/ecc/bn254/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bn254.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bn254/fr/plookup/table.go
+++ b/ecc/bn254/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -841,10 +841,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -59,9 +59,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -50,8 +50,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -331,9 +331,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -383,7 +383,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -399,7 +399,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BN254] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BN254] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -410,7 +410,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -447,7 +447,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -469,7 +469,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -475,7 +475,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -55,8 +55,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -328,9 +328,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -374,7 +374,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var a, res G2Jac
 	a.psi(p)
-	res.ScalarMul(p, &fixedCoeff).
+	res.ScalarMultiplication(p, &fixedCoeff).
 		SubAssign(&a)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -515,7 +515,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	// cf http://cacr.uwaterloo.ca/techreports/2011/cacr2011-26.pdf, 6.1
 	var points [4]G2Jac
 
-	points[0].ScalarMul(a, &xGen)
+	points[0].ScalarMultiplication(a, &xGen)
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -867,10 +867,10 @@ func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -123,7 +123,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),
@@ -374,12 +374,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -532,7 +532,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -440,7 +440,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -456,7 +456,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BN254] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BN254] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -467,7 +467,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -504,7 +504,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -526,7 +526,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bn254/multiexp.go
+++ b/ecc/bn254/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bn254/multiexp_test.go
+++ b/ecc/bn254/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bn254/pairing_test.go
+++ b/ecc/bn254/pairing_test.go
@@ -120,8 +120,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -185,8 +185,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -228,8 +228,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -266,8 +266,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bn254/twistededwards/eddsa/eddsa.go
+++ b/ecc/bn254/twistededwards/eddsa/eddsa.go
@@ -89,7 +89,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -137,7 +137,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -223,8 +223,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -232,9 +232,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bw6633.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6633.G1Jac

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bw6633.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6633.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bw6633.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bw6633.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bw6-633/fr/kzg/kzg_test.go
+++ b/ecc/bw6-633/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bw6633.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-633/fr/plookup/table.go
+++ b/ecc/bw6-633/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -55,8 +55,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -336,9 +336,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -382,11 +382,11 @@ func (p *G1Jac) IsOnCurve() bool {
 func (p *G1Jac) IsInSubGroup() bool {
 
 	var uP, u4P, u5P, q, r G1Jac
-	uP.ScalarMul(p, &xGen)
-	u4P.ScalarMul(&uP, &xGen).
-		ScalarMul(&u4P, &xGen).
-		ScalarMul(&u4P, &xGen)
-	u5P.ScalarMul(&u4P, &xGen)
+	uP.ScalarMultiplication(p, &xGen)
+	u4P.ScalarMultiplication(&uP, &xGen).
+		ScalarMultiplication(&u4P, &xGen).
+		ScalarMultiplication(&u4P, &xGen)
+	u5P.ScalarMultiplication(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
 	r.phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
@@ -527,20 +527,20 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	ht.SetInt64(7)
 	v.Mul(&xGen, &xGen).Add(&v, &one).Mul(&v, &uPlusOne)
 
-	uP.ScalarMul(a, &xGen).Neg(&uP)
+	uP.ScalarMultiplication(a, &xGen).Neg(&uP)
 	vP.Set(a).SubAssign(&uP).
-		ScalarMul(&vP, &v)
-	wP.ScalarMul(&vP, &uMinusOne).Neg(&wP).
+		ScalarMultiplication(&vP, &v)
+	wP.ScalarMultiplication(&vP, &uMinusOne).Neg(&wP).
 		AddAssign(&uP)
-	L0.ScalarMul(&wP, &d1)
-	tmp.ScalarMul(&vP, &ht)
+	L0.ScalarMultiplication(&wP, &d1)
+	tmp.ScalarMultiplication(&vP, &ht)
 	L0.AddAssign(&tmp)
 	tmp.Double(a)
 	L0.AddAssign(&tmp)
-	L1.Set(&uP).AddAssign(a).ScalarMul(&L1, &d1)
-	tmp.ScalarMul(&vP, &d2)
+	L1.Set(&uP).AddAssign(a).ScalarMultiplication(&L1, &d1)
+	tmp.ScalarMultiplication(&vP, &d2)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMul(a, &ht)
+	tmp.ScalarMultiplication(a, &ht)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -972,10 +972,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -64,9 +64,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-633] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-633] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -840,10 +840,10 @@ func (p *g2JacExtended) doubleMixed(q *G2Affine) *g2JacExtended {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -50,8 +50,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -323,9 +323,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -369,11 +369,11 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 
 	var uP, u4P, u5P, q, r G2Jac
-	uP.ScalarMul(p, &xGen)
-	u4P.ScalarMul(&uP, &xGen).
-		ScalarMul(&u4P, &xGen).
-		ScalarMul(&u4P, &xGen)
-	u5P.ScalarMul(&u4P, &xGen)
+	uP.ScalarMultiplication(p, &xGen)
+	u4P.ScalarMultiplication(&uP, &xGen).
+		ScalarMultiplication(&u4P, &xGen).
+		ScalarMultiplication(&u4P, &xGen)
+	u5P.ScalarMultiplication(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
 	r.phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
@@ -510,11 +510,11 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	d1.SetInt64(13)
 	d3.SetInt64(5) // negative
 
-	uP.ScalarMul(a, &xGen) // negative
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen) // negative
-	u4P.ScalarMul(&u3P, &xGen)
-	u5P.ScalarMul(&u4P, &xGen) // negative
+	uP.ScalarMultiplication(a, &xGen) // negative
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen) // negative
+	u4P.ScalarMultiplication(&u3P, &xGen)
+	u5P.ScalarMultiplication(&u4P, &xGen) // negative
 	vP.Set(&u2P).AddAssign(&uP).
 		AddAssign(&u3P).
 		Double(&vP).
@@ -522,15 +522,15 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 		AddAssign(a)
 	wP.Set(&uP).SubAssign(&u4P).SubAssign(&u5P)
 	xP.Set(a).AddAssign(&vP)
-	L0.Set(&uP).SubAssign(a).ScalarMul(&L0, &d1)
-	tmp.ScalarMul(&xP, &d3)
+	L0.Set(&uP).SubAssign(a).ScalarMultiplication(&L0, &d1)
+	tmp.ScalarMultiplication(&xP, &d3)
 	L0.AddAssign(&tmp)
-	tmp.ScalarMul(a, &ht) // negative
+	tmp.ScalarMultiplication(a, &ht) // negative
 	L0.SubAssign(&tmp)
-	L1.ScalarMul(&wP, &d1)
-	tmp.ScalarMul(&vP, &ht)
+	L1.ScalarMultiplication(&wP, &d1)
+	tmp.ScalarMultiplication(&vP, &ht)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMul(a, &d3)
+	tmp.ScalarMultiplication(a, &d3)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -110,7 +110,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -422,7 +422,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-633] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-633] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-633/marshal_test.go
+++ b/ecc/bw6-633/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bw6-633/multiexp.go
+++ b/ecc/bw6-633/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bw6-633/multiexp_test.go
+++ b/ecc/bw6-633/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bw6-633/pairing_test.go
+++ b/ecc/bw6-633/pairing_test.go
@@ -122,8 +122,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -187,8 +187,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -230,8 +230,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -268,8 +268,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bw6-633/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-633/twistededwards/eddsa/eddsa.go
@@ -98,7 +98,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -146,7 +146,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -232,8 +232,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -241,9 +241,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bw6-756/fr/kzg/kzg.go
+++ b/ecc/bw6-756/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bw6756.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6756.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-756/fr/kzg/kzg.go
+++ b/ecc/bw6-756/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bw6756.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bw6756.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bw6-756/fr/kzg/kzg.go
+++ b/ecc/bw6-756/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bw6756.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6756.G1Jac

--- a/ecc/bw6-756/fr/kzg/kzg_test.go
+++ b/ecc/bw6-756/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bw6756.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-756/fr/plookup/table.go
+++ b/ecc/bw6-756/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -972,10 +972,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -64,9 +64,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -55,8 +55,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -336,9 +336,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -387,13 +387,13 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res, phip G1Jac
 	phip.phi(p)
-	res.ScalarMul(&phip, &xGen).
+	res.ScalarMultiplication(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMul(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -523,9 +523,9 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	var L0, L1, uP, u2P, u3P, tmp G1Jac
 
-	uP.ScalarMul(a, &xGen)
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen)
+	uP.ScalarMultiplication(a, &xGen)
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen)
 
 	L0.Set(a).AddAssign(&u3P).
 		SubAssign(&u2P)

--- a/ecc/bw6-756/g1_test.go
+++ b/ecc/bw6-756/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-756/g1_test.go
+++ b/ecc/bw6-756/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-756] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-756] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -50,8 +50,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -323,9 +323,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -374,13 +374,13 @@ func (p *G2Jac) IsInSubGroup() bool {
 
 	var res, phip G2Jac
 	phip.phi(p)
-	res.ScalarMul(&phip, &xGen).
+	res.ScalarMultiplication(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMul(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -511,9 +511,9 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	var L0, L1, uP, u2P, u3P, tmp G2Jac
 
-	uP.ScalarMul(a, &xGen)
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen)
+	uP.ScalarMultiplication(a, &xGen)
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen)
 	// ht=-2, hy=0
 	// d1=1, d2=-1, d3=-1
 

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -834,10 +834,10 @@ func (p *g2JacExtended) doubleMixed(q *G2Affine) *g2JacExtended {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-756/g2_test.go
+++ b/ecc/bw6-756/g2_test.go
@@ -110,7 +110,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-756/g2_test.go
+++ b/ecc/bw6-756/g2_test.go
@@ -422,7 +422,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-756] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-756] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-756/marshal_test.go
+++ b/ecc/bw6-756/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bw6-756/multiexp.go
+++ b/ecc/bw6-756/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bw6-756/multiexp_test.go
+++ b/ecc/bw6-756/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bw6-756/pairing_test.go
+++ b/ecc/bw6-756/pairing_test.go
@@ -121,8 +121,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -186,8 +186,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -229,8 +229,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -267,8 +267,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bw6-756/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-756/twistededwards/eddsa/eddsa.go
@@ -98,7 +98,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -146,7 +146,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -232,8 +232,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -241,9 +241,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bw6-756/twistededwards/point_test.go
+++ b/ecc/bw6-756/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -172,7 +172,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff bw6761.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6761.G1Jac

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -87,7 +87,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := bw6761.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := bw6761.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -77,7 +77,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := bw6761.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -189,7 +189,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -418,7 +418,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6761.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-761/fr/kzg/kzg_test.go
+++ b/ecc/bw6-761/fr/kzg/kzg_test.go
@@ -130,7 +130,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit bw6761.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-761/fr/plookup/table.go
+++ b/ecc/bw6-761/fr/plookup/table.go
@@ -209,9 +209,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -64,9 +64,9 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	return p
 }
 
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *G1Jac) ScalarMulUnconverted(a *G1Affine, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplicationAffine(a *G1Affine, s *big.Int) *G1Jac {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -983,10 +983,10 @@ func BatchJacobianToAffineG1(points []G1Jac, result []G1Affine) {
 
 }
 
-// BatchScalarMulG1 multiplies the same base by all scalars
+// BatchScalarMultiplicationG1 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG1(base *G1Affine, scalars []fr.Element) []G1Affine {
+func BatchScalarMultiplicationG1(base *G1Affine, scalars []fr.Element) []G1Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -55,8 +55,8 @@ func (p *G1Affine) Set(a *G1Affine) *G1Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G1Affine) ScalarMul(a *G1Affine, s *big.Int) *G1Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -336,9 +336,9 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G1Jac) ScalarMul(a *G1Jac, s *big.Int) *G1Jac {
+func (p *G1Jac) ScalarMultiplication(a *G1Jac, s *big.Int) *G1Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -387,13 +387,13 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res, phip G1Jac
 	phip.phi(p)
-	res.ScalarMul(&phip, &xGen).
+	res.ScalarMultiplication(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMul(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -524,9 +524,9 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	// https://eprint.iacr.org/2020/351.pdf
 	var points [4]G1Jac
 	points[0].Set(a)
-	points[1].ScalarMul(a, &xGen)
-	points[2].ScalarMul(&points[1], &xGen)
-	points[3].ScalarMul(&points[2], &xGen)
+	points[1].ScalarMultiplication(a, &xGen)
+	points[2].ScalarMultiplication(&points[1], &xGen)
+	points[3].ScalarMultiplication(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -539,18 +539,18 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	scalars[6].SetInt64(130)
 
 	var p1, p2, tmp G1Jac
-	p1.ScalarMul(&points[3], &scalars[0])
-	tmp.ScalarMul(&points[2], &scalars[1]).Neg(&tmp)
+	p1.ScalarMultiplication(&points[3], &scalars[0])
+	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[3])
+	tmp.ScalarMultiplication(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMul(&points[2], &scalars[4])
-	tmp.ScalarMul(&points[1], &scalars[5])
+	p2.ScalarMultiplication(&points[2], &scalars[4])
+	tmp.ScalarMultiplication(&points[1], &scalars[5])
 	p2.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[6])
+	tmp.ScalarMultiplication(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
 	p2.phi(&p2)
 

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -110,7 +110,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG1AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G1Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g1Gen, &rminusone)
+			op3.ScalarMultiplication(&g1Gen, &rminusone)
 			gneg.Neg(&g1Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g1Gen, &scalar)
-			op2.ScalarMul(&g1Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g1Gen, &scalar)
+			op2.ScalarMultiplication(&g1Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g1Infinity) && !op1.Equal(&g1Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG1JacScalarMul(b *testing.B) {
+func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -422,7 +422,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMul(t *testing.T) {
+func TestG1AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-761] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-761] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG1AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG1(&g1GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG1AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG1(&g1GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG1(&g1GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -50,8 +50,8 @@ func (p *G2Affine) Set(a *G2Affine) *G2Affine {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *G2Affine) ScalarMul(a *G2Affine, s *big.Int) *G2Affine {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -323,9 +323,9 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 	return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
-func (p *G2Jac) ScalarMul(a *G2Jac, s *big.Int) *G2Jac {
+func (p *G2Jac) ScalarMultiplication(a *G2Jac, s *big.Int) *G2Jac {
 	return p.mulGLV(a, s)
 }
 
@@ -374,13 +374,13 @@ func (p *G2Jac) IsInSubGroup() bool {
 
 	var res, phip G2Jac
 	phip.phi(p)
-	res.ScalarMul(&phip, &xGen).
+	res.ScalarMultiplication(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMul(&res, &xGen).
-		ScalarMul(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
+		ScalarMultiplication(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMul(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -511,9 +511,9 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	var points [4]G2Jac
 	points[0].Set(a)
-	points[1].ScalarMul(a, &xGen)
-	points[2].ScalarMul(&points[1], &xGen)
-	points[3].ScalarMul(&points[2], &xGen)
+	points[1].ScalarMultiplication(a, &xGen)
+	points[2].ScalarMultiplication(&points[1], &xGen)
+	points[3].ScalarMultiplication(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -526,18 +526,18 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	scalars[6].SetInt64(109)
 
 	var p1, p2, tmp G2Jac
-	p1.ScalarMul(&points[3], &scalars[0])
-	tmp.ScalarMul(&points[2], &scalars[1]).Neg(&tmp)
+	p1.ScalarMultiplication(&points[3], &scalars[0])
+	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[3])
+	tmp.ScalarMultiplication(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMul(&points[2], &scalars[4])
-	tmp.ScalarMul(&points[1], &scalars[5]).Neg(&tmp)
+	p2.ScalarMultiplication(&points[2], &scalars[4])
+	tmp.ScalarMultiplication(&points[1], &scalars[5]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[6]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
 	p2.phi(&p2).phi(&p2)
 

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -848,10 +848,10 @@ func (p *g2JacExtended) doubleMixed(q *G2Affine) *g2JacExtended {
 	return p
 }
 
-// BatchScalarMulG2 multiplies the same base by all scalars
+// BatchScalarMultiplicationG2 multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMulG2(base *G2Affine, scalars []fr.Element) []G2Affine {
+func BatchScalarMultiplicationG2(base *G2Affine, scalars []fr.Element) []G2Affine {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -110,7 +110,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMul(&op1, _r)
+			op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),
@@ -353,12 +353,12 @@ func TestG2AffineOps(t *testing.T) {
 			var scalar, blindedScalar, rminusone big.Int
 			var op1, op2, op3, gneg G2Jac
 			rminusone.SetUint64(1).Sub(r, &rminusone)
-			op3.ScalarMul(&g2Gen, &rminusone)
+			op3.ScalarMultiplication(&g2Gen, &rminusone)
 			gneg.Neg(&g2Gen)
 			s.ToBigIntRegular(&scalar)
 			blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-			op1.ScalarMul(&g2Gen, &scalar)
-			op2.ScalarMul(&g2Gen, &blindedScalar)
+			op1.ScalarMultiplication(&g2Gen, &scalar)
+			op2.ScalarMultiplication(&g2Gen, &blindedScalar)
 
 			return op1.Equal(&op2) && g.Equal(&g2Infinity) && !op1.Equal(&g2Infinity) && gneg.Equal(&op3)
 
@@ -514,7 +514,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 	}
 }
 
-func BenchmarkG2JacScalarMul(b *testing.B) {
+func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -422,7 +422,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMul(t *testing.T) {
+func TestG2AffineBatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -438,7 +438,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[BW6-761] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[BW6-761] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -449,7 +449,7 @@ func TestG2AffineBatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMulG2(&g2GenAff, sampleScalars[:])
+			result := BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -486,7 +486,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
-func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
+func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -508,7 +508,7 @@ func BenchmarkG2AffineBatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMulG2(&g2GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplicationG2(&g2GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/ecc/bw6-761/marshal_test.go
+++ b/ecc/bw6-761/marshal_test.go
@@ -55,9 +55,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -263,7 +263,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -283,7 +283,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			var start, end G1Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g1GenAff, &ab)
+			start.ScalarMultiplication(&g1GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])
@@ -356,7 +356,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.RawBytes()
 			n, err := end.SetBytes(buf[:])
@@ -376,7 +376,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			var start, end G2Affine
 			var ab big.Int
 			a.ToBigIntRegular(&ab)
-			start.ScalarMul(&g2GenAff, &ab)
+			start.ScalarMultiplication(&g2GenAff, &ab)
 
 			buf := start.Bytes()
 			n, err := end.SetBytes(buf[:])

--- a/ecc/bw6-761/multiexp.go
+++ b/ecc/bw6-761/multiexp.go
@@ -41,7 +41,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/ecc/bw6-761/multiexp_test.go
+++ b/ecc/bw6-761/multiexp_test.go
@@ -100,7 +100,7 @@ func TestMultiExpG1(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g1Gen, &finalScalar)
+			expected.ScalarMultiplication(&g1Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -150,7 +150,7 @@ func TestMultiExpG1(t *testing.T) {
 			var op1ScalarMul G1Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g1GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g1GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -249,7 +249,7 @@ func BenchmarkManyMultiExpG1Reference(b *testing.B) {
 func fillBenchBasesG1(samplePoints []G1Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()
@@ -330,7 +330,7 @@ func TestMultiExpG2(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar, mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&g2Gen, &finalScalar)
+			expected.ScalarMultiplication(&g2Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -380,7 +380,7 @@ func TestMultiExpG2(t *testing.T) {
 			var op1ScalarMul G2Affine
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&g2GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&g2GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -479,7 +479,7 @@ func BenchmarkManyMultiExpG2Reference(b *testing.B) {
 func fillBenchBasesG2(samplePoints []G2Affine) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/ecc/bw6-761/pairing_test.go
+++ b/ecc/bw6-761/pairing_test.go
@@ -122,8 +122,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -187,8 +187,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -230,8 +230,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -268,8 +268,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/ecc/bw6-761/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-761/twistededwards/eddsa/eddsa.go
@@ -98,7 +98,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -146,7 +146,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -232,8 +232,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -241,9 +241,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -256,13 +256,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -409,9 +409,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -622,9 +622,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -124,8 +124,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -336,7 +336,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -352,7 +352,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -371,8 +371,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -390,14 +390,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -413,9 +413,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -430,11 +430,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -463,7 +463,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -498,7 +498,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -515,11 +515,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -547,7 +547,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -582,7 +582,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -599,11 +599,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -619,8 +619,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -638,8 +638,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -658,8 +658,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -677,8 +677,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -697,9 +697,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -760,7 +760,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -776,6 +776,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/ecc/utils.go
+++ b/ecc/utils.go
@@ -147,7 +147,7 @@ func SplitScalar(s *big.Int, l *Lattice) [2]big.Int {
 	k2.Mul(s, &l.b2).Neg(&k2)
 	// right-shift instead of division by lattice determinant
 	// this increases the bounds on k1 and k2 by 1
-	// but we check this ScalarMul alg. (not constant-time)
+	// but we check this ScalarMultiplication alg. (not constant-time)
 	n := 2 * uint(((l.Det.BitLen()+32)>>6)<<6)
 	k1.Rsh(&k1, n)
 	k2.Rsh(&k2, n)

--- a/internal/generator/ecc/template/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/multiexp.go.tmpl
@@ -32,7 +32,7 @@ type selector struct {
 // if the digit is larger than 2^{c-1}, then, we borrow 2^c from the next window and substract
 // 2^{c} to the current digit, making it negative.
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
-// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMul)
+// (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 // scalarsMont indicates wheter the provided scalars are in montgomery form
 // returns smallValues, which represent the number of scalars which meets the following condition
 // 0 < scalar < 2^c (in other words, scalars where only the c-least significant bits are non zero)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -1422,10 +1422,10 @@ func BatchJacobianToAffine{{ toUpper .PointName }}(points []{{ $TJacobian }}, re
 {{- end}}
 
 
-// BatchScalarMul{{ toUpper .PointName }} multiplies the same base by all scalars
+// BatchScalarMultiplication{{ toUpper .PointName }} multiplies the same base by all scalars
 // and return resulting points in affine coordinates
 // uses a simple windowed-NAF like exponentiation algorithm
-func BatchScalarMul{{ toUpper .PointName }}(base *{{ $TAffine }}, scalars []fr.Element) []{{ $TAffine }} {
+func BatchScalarMultiplication{{ toUpper .PointName }}(base *{{ $TAffine }}, scalars []fr.Element) []{{ $TAffine }} {
 
 	// approximate cost in group ops is
 	// cost = 2^{c-1} + n(scalar.nbBits+nbChunks)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -62,9 +62,9 @@ func (p *{{ $TAffine }}) ScalarMultiplication(a *{{ $TAffine }}, s *big.Int) *{{
 }
 
 {{- if eq .PointName "g1"}}
-// ScalarMulUnconverted computes and returns p = a ⋅ s
+// ScalarMultiplicationAffine computes and returns p = a ⋅ s
 // Takes an affine point and returns a Jacobian point (useful for KZG)
-func (p *{{ $TJacobian }}) ScalarMulUnconverted(a *{{ $TAffine }}, s *big.Int) *{{ $TJacobian }} {
+func (p *{{ $TJacobian }}) ScalarMultiplicationAffine(a *{{ $TAffine }}, s *big.Int) *{{ $TJacobian }} {
 	p.FromAffine(a)
 	p.mulGLV(p, s)
 	return p

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -52,8 +52,8 @@ func (p *{{ $TAffine }}) Set(a *{{ $TAffine }}) *{{ $TAffine }} {
        return p
 }
 
-// ScalarMul computes and returns p = a ⋅ s
-func (p *{{ $TAffine }}) ScalarMul(a *{{ $TAffine }}, s *big.Int) *{{ $TAffine }} {
+// ScalarMultiplication computes and returns p = a ⋅ s
+func (p *{{ $TAffine }}) ScalarMultiplication(a *{{ $TAffine }}, s *big.Int) *{{ $TAffine }} {
 	var _p {{ $TJacobian }}
 	_p.FromAffine(a)
 	_p.mulGLV(&_p, s)
@@ -345,9 +345,9 @@ func (p *{{ $TJacobian }}) DoubleAssign() *{{ $TJacobian }} {
 }
 
 
-// ScalarMul computes and returns p = a ⋅ s
+// ScalarMultiplication computes and returns p = a ⋅ s
 // {{- if .GLV}} see https://www.iacr.org/archive/crypto2001/21390189.pdf {{- else }} using 2-bits windowed exponentiation {{- end }}
-func (p *{{ $TJacobian }}) ScalarMul(a *{{ $TJacobian }}, s *big.Int) *{{ $TJacobian }} {
+func (p *{{ $TJacobian }}) ScalarMultiplication(a *{{ $TJacobian }}, s *big.Int) *{{ $TJacobian }} {
 	{{- if .GLV}}
 		return p.mulGLV(a, s)
 	{{- else }}
@@ -413,7 +413,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 		func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var a, res G2Jac
             a.psi(p)
-            res.ScalarMul(p, &fixedCoeff).
+            res.ScalarMultiplication(p, &fixedCoeff).
                 SubAssign(&a)
 
 			return res.IsOnCurve() && res.Z.IsZero()
@@ -431,13 +431,13 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
 		var res, phip {{ $TJacobian }}
 		phip.phi(p)
-		res.ScalarMul(&phip, &xGen).
+		res.ScalarMultiplication(&phip, &xGen).
 			SubAssign(&phip).
-			ScalarMul(&res, &xGen).
-			ScalarMul(&res, &xGen).
+			ScalarMultiplication(&res, &xGen).
+			ScalarMultiplication(&res, &xGen).
 			AddAssign(&phip)
 
-		phip.ScalarMul(p, &xGen).AddAssign(p).AddAssign(&res)
+		phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
 		return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -448,11 +448,11 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
         var uP, u4P, u5P, q, r {{ $TJacobian }}
-        uP.ScalarMul(p, &xGen)
-        u4P.ScalarMul(&uP, &xGen).
-            ScalarMul(&u4P, &xGen).
-            ScalarMul(&u4P, &xGen)
-        u5P.ScalarMul(&u4P, &xGen)
+        uP.ScalarMultiplication(p, &xGen)
+        u4P.ScalarMultiplication(&uP, &xGen).
+            ScalarMultiplication(&u4P, &xGen).
+            ScalarMultiplication(&u4P, &xGen)
+        u5P.ScalarMultiplication(&u4P, &xGen)
         q.Set(p).SubAssign(&uP)
         r.phi(&q).SubAssign(&uP).
             AddAssign(&u4P).
@@ -472,10 +472,10 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
             var res {{ $TJacobian }}
             res.phi(p).
-                ScalarMul(&res, &xGen).
-                ScalarMul(&res, &xGen).
-                ScalarMul(&res, &xGen).
-                ScalarMul(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
                 AddAssign(p)
 
             return res.IsOnCurve() && res.Z.IsZero()
@@ -488,7 +488,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
         func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var res, tmp {{ $TJacobian }}
             tmp.psi(p)
-            res.ScalarMul(p, &xGen).
+            res.ScalarMultiplication(p, &xGen).
             {{ if eq .Name "bls24-315"}}
                 AddAssign(&tmp)
             {{ else }}
@@ -511,8 +511,8 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
             var res {{ $TJacobian }}
             res.phi(p).
-                ScalarMul(&res, &xGen).
-                ScalarMul(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
+                ScalarMultiplication(&res, &xGen).
                 AddAssign(p)
 
             return res.IsOnCurve() && res.Z.IsZero()
@@ -526,7 +526,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
                 tmp.psi(p)
-                res.ScalarMul(p, &xGen).
+                res.ScalarMultiplication(p, &xGen).
                     AddAssign(&tmp)
 
                 return res.IsOnCurve() && res.Z.IsZero()
@@ -537,7 +537,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
                 tmp.psi(p)
-                res.ScalarMul(p, &xGen).
+                res.ScalarMultiplication(p, &xGen).
                     SubAssign(&tmp)
 
                 return res.IsOnCurve() && res.Z.IsZero()
@@ -705,22 +705,22 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 {{- if or (eq .Name "bls12-381") (eq .Name "bls24-315")}}
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res {{$TJacobian}}
-	res.ScalarMul(a, &xGen).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).AddAssign(a)
 	p.Set(&res)
 	return p
 {{else if or (eq .Name "bls12-377") (eq .Name "bls12-378") (eq .Name "bls24-317")}}
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res {{$TJacobian}}
-	res.ScalarMul(a, &xGen).Neg(&res).AddAssign(a)
+	res.ScalarMultiplication(a, &xGen).Neg(&res).AddAssign(a)
 	p.Set(&res)
 	return p
 {{else if eq .Name "bw6-761"}}
 	// https://eprint.iacr.org/2020/351.pdf
 	var points [4]{{$TJacobian}}
 	points[0].Set(a)
-	points[1].ScalarMul(a, &xGen)
-	points[2].ScalarMul(&points[1], &xGen)
-	points[3].ScalarMul(&points[2], &xGen)
+	points[1].ScalarMultiplication(a, &xGen)
+	points[2].ScalarMultiplication(&points[1], &xGen)
+	points[3].ScalarMultiplication(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -733,18 +733,18 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	scalars[6].SetInt64(130)
 
 	var p1, p2, tmp {{$TJacobian}}
-	p1.ScalarMul(&points[3], &scalars[0])
-	tmp.ScalarMul(&points[2], &scalars[1]).Neg(&tmp)
+	p1.ScalarMultiplication(&points[3], &scalars[0])
+	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[3])
+	tmp.ScalarMultiplication(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMul(&points[2], &scalars[4])
-	tmp.ScalarMul(&points[1], &scalars[5])
+	p2.ScalarMultiplication(&points[2], &scalars[4])
+	tmp.ScalarMultiplication(&points[1], &scalars[5])
 	p2.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[6])
+	tmp.ScalarMultiplication(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
 	p2.phi(&p2)
 
@@ -762,20 +762,20 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	ht.SetInt64(7)
 	v.Mul(&xGen, &xGen).Add(&v, &one).Mul(&v, &uPlusOne)
 
-	uP.ScalarMul(a, &xGen).Neg(&uP)
+	uP.ScalarMultiplication(a, &xGen).Neg(&uP)
 	vP.Set(a).SubAssign(&uP).
-        ScalarMul(&vP, &v)
-	wP.ScalarMul(&vP, &uMinusOne).Neg(&wP).
+        ScalarMultiplication(&vP, &v)
+	wP.ScalarMultiplication(&vP, &uMinusOne).Neg(&wP).
         AddAssign(&uP)
-	L0.ScalarMul(&wP, &d1)
-	tmp.ScalarMul(&vP, &ht)
+	L0.ScalarMultiplication(&wP, &d1)
+	tmp.ScalarMultiplication(&vP, &ht)
 	L0.AddAssign(&tmp)
 	tmp.Double(a)
 	L0.AddAssign(&tmp)
-	L1.Set(&uP).AddAssign(a).ScalarMul(&L1, &d1)
-	tmp.ScalarMul(&vP, &d2)
+	L1.Set(&uP).AddAssign(a).ScalarMultiplication(&L1, &d1)
+	tmp.ScalarMultiplication(&vP, &d2)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMul(a, &ht)
+	tmp.ScalarMultiplication(a, &ht)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)
@@ -784,9 +784,9 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 {{else if eq .Name "bw6-756"}}
 	var L0, L1, uP, u2P, u3P, tmp G1Jac
 
-	uP.ScalarMul(a, &xGen)
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen)
+	uP.ScalarMultiplication(a, &xGen)
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen)
 
 	L0.Set(a).AddAssign(&u3P).
 		SubAssign(&u2P)
@@ -818,7 +818,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	// cf http://cacr.uwaterloo.ca/techreports/2011/cacr2011-26.pdf, 6.1
 	var points [4]{{$TJacobian}}
 
-	points[0].ScalarMul(a, &xGen)
+	points[0].ScalarMultiplication(a, &xGen)
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).
@@ -839,8 +839,8 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 {{else if eq .Name "bls12-381"}}
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).Neg(&xg)
-	xxg.ScalarMul(&xg, &xGen).Neg(&xxg)
+	xg.ScalarMultiplication(a, &xGen).Neg(&xg)
+	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
 
 	res.Set(&xxg).
 		SubAssign(&xg).
@@ -864,8 +864,8 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 {{else if or (eq .Name "bls12-377") (eq .Name "bls12-378")}}
     // https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen)
-	xxg.ScalarMul(&xg, &xGen)
+	xg.ScalarMultiplication(a, &xGen)
+	xxg.ScalarMultiplication(&xg, &xGen)
 
 	res.Set(&xxg).
 		SubAssign(&xg).
@@ -891,16 +891,16 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	// multiply by (3x⁴-3)*cofacor
     {{ if eq .Name "bls24-315"}}
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).Neg(&xg).SubAssign(a)
-	xxg.ScalarMul(&xg, &xGen).Neg(&xxg)
-	xxxg.ScalarMul(&xxg, &xGen).Neg(&xxxg)
-	xxxxg.ScalarMul(&xxxg, &xGen).Neg(&xxxxg)
+	xg.ScalarMultiplication(a, &xGen).Neg(&xg).SubAssign(a)
+	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
+	xxxg.ScalarMultiplication(&xxg, &xGen).Neg(&xxxg)
+	xxxxg.ScalarMultiplication(&xxxg, &xGen).Neg(&xxxxg)
     {{ else }}
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMul(a, &xGen).SubAssign(a)
-	xxg.ScalarMul(&xg, &xGen)
-	xxxg.ScalarMul(&xxg, &xGen)
-	xxxxg.ScalarMul(&xxxg, &xGen)
+	xg.ScalarMultiplication(a, &xGen).SubAssign(a)
+	xxg.ScalarMultiplication(&xg, &xGen)
+	xxxg.ScalarMultiplication(&xxg, &xGen)
+	xxxxg.ScalarMultiplication(&xxxg, &xGen)
     {{ end }}
 
 	res.Set(&xxxxg).
@@ -935,9 +935,9 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 
 	var points [4]{{$TJacobian}}
 	points[0].Set(a)
-	points[1].ScalarMul(a, &xGen)
-	points[2].ScalarMul(&points[1], &xGen)
-	points[3].ScalarMul(&points[2], &xGen)
+	points[1].ScalarMultiplication(a, &xGen)
+	points[2].ScalarMultiplication(&points[1], &xGen)
+	points[3].ScalarMultiplication(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -950,18 +950,18 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	scalars[6].SetInt64(109)
 
 	var p1, p2, tmp {{$TJacobian}}
-	p1.ScalarMul(&points[3], &scalars[0])
-	tmp.ScalarMul(&points[2], &scalars[1]).Neg(&tmp)
+	p1.ScalarMultiplication(&points[3], &scalars[0])
+	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[3])
+	tmp.ScalarMultiplication(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMul(&points[2], &scalars[4])
-	tmp.ScalarMul(&points[1], &scalars[5]).Neg(&tmp)
+	p2.ScalarMultiplication(&points[2], &scalars[4])
+	tmp.ScalarMultiplication(&points[1], &scalars[5]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	tmp.ScalarMul(&points[0], &scalars[6]).Neg(&tmp)
+	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
 	p2.phi(&p2).phi(&p2)
 
@@ -975,11 +975,11 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	d1.SetInt64(13)
 	d3.SetInt64(5) // negative
 
-	uP.ScalarMul(a, &xGen) // negative
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen) // negative
-	u4P.ScalarMul(&u3P, &xGen)
-	u5P.ScalarMul(&u4P, &xGen) // negative
+	uP.ScalarMultiplication(a, &xGen) // negative
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen) // negative
+	u4P.ScalarMultiplication(&u3P, &xGen)
+	u5P.ScalarMultiplication(&u4P, &xGen) // negative
 	vP.Set(&u2P).AddAssign(&uP).
 	    AddAssign(&u3P).
 	    Double(&vP).
@@ -987,15 +987,15 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	    AddAssign(a)
 	wP.Set(&uP).SubAssign(&u4P).SubAssign(&u5P)
     xP.Set(a).AddAssign(&vP)
-	L0.Set(&uP).SubAssign(a).ScalarMul(&L0, &d1)
-	tmp.ScalarMul(&xP, &d3)
+	L0.Set(&uP).SubAssign(a).ScalarMultiplication(&L0, &d1)
+	tmp.ScalarMultiplication(&xP, &d3)
 	L0.AddAssign(&tmp)
-    tmp.ScalarMul(a, &ht) // negative
+    tmp.ScalarMultiplication(a, &ht) // negative
 	L0.SubAssign(&tmp)
-	L1.ScalarMul(&wP, &d1)
-	tmp.ScalarMul(&vP, &ht)
+	L1.ScalarMultiplication(&wP, &d1)
+	tmp.ScalarMultiplication(&vP, &ht)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMul(a, &d3)
+	tmp.ScalarMultiplication(a, &d3)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)
@@ -1005,9 +1005,9 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 
 	var L0, L1, uP, u2P, u3P, tmp G2Jac
 
-	uP.ScalarMul(a, &xGen)
-	u2P.ScalarMul(&uP, &xGen)
-	u3P.ScalarMul(&u2P, &xGen)
+	uP.ScalarMultiplication(a, &xGen)
+	u2P.ScalarMultiplication(&uP, &xGen)
+	u3P.ScalarMultiplication(&u2P, &xGen)
 	// ht=-2, hy=0
 	// d1=1, d2=-1, d3=-1
 

--- a/internal/generator/ecc/template/tests/marshal.go.tmpl
+++ b/internal/generator/ecc/template/tests/marshal.go.tmpl
@@ -45,9 +45,9 @@ func TestEncoder(t *testing.T) {
 	inA = rand.Uint64()
 	inB.SetRandom()
 	inC.SetRandom()
-	inD.ScalarMul(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	// inE --> infinity
-	inF.ScalarMul(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
+	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64()))
 	inG = make([]G1Affine, 2)
 	inH = make([]G2Affine, 0)
 	inG[1] = inD
@@ -273,7 +273,7 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 				var start, end {{ $.TAffine }}
 				var ab big.Int
 				a.ToBigIntRegular(&ab)
-				start.ScalarMul(&{{ toLower .PointName }}GenAff, &ab)
+				start.ScalarMultiplication(&{{ toLower .PointName }}GenAff, &ab)
 
 				buf := start.RawBytes()
 				n, err := end.SetBytes(buf[:])
@@ -293,7 +293,7 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 				var start, end {{ $.TAffine }}
 				var ab big.Int
 				a.ToBigIntRegular(&ab)
-				start.ScalarMul(&{{ toLower .PointName }}GenAff, &ab)
+				start.ScalarMultiplication(&{{ toLower .PointName }}GenAff, &ab)
 
 				buf := start.Bytes()
 				n, err := end.SetBytes(buf[:])

--- a/internal/generator/ecc/template/tests/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/tests/multiexp.go.tmpl
@@ -100,7 +100,7 @@ func TestMultiExp{{toUpper $.PointName}}(t *testing.T) {
 			// compute expected result with double and add
 			var finalScalar,mixerBigInt big.Int
 			finalScalar.Mul(&scalar, mixer.ToBigIntRegular(&mixerBigInt))
-			expected.ScalarMul(&{{ toLower $.PointName }}Gen, &finalScalar)
+			expected.ScalarMultiplication(&{{ toLower $.PointName }}Gen, &finalScalar)
 
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -152,7 +152,7 @@ func TestMultiExp{{toUpper $.PointName}}(t *testing.T) {
 			var op1ScalarMul {{ $.TAffine }}
 			finalBigScalar.SetString("9455").Mul(&finalBigScalar, &mixer)
 			finalBigScalar.ToBigIntRegular(&finalBigScalarBi)
-			op1ScalarMul.ScalarMul(&{{ toLower .PointName}}GenAff, &finalBigScalarBi)
+			op1ScalarMul.ScalarMultiplication(&{{ toLower .PointName}}GenAff, &finalBigScalarBi)
 
 			return op1ScalarMul.Equal(&op1MultiExp)
 		},
@@ -256,7 +256,7 @@ func BenchmarkManyMultiExp{{ toUpper $.PointName }}Reference(b *testing.B) {
 func fillBenchBases{{ toUpper $.PointName }}(samplePoints []{{ $.TAffine }}) {
 	var r big.Int
 	r.SetString("340444420969191673093399857471996460938405", 10)
-	samplePoints[0].ScalarMul(&samplePoints[0], &r)
+	samplePoints[0].ScalarMultiplication(&samplePoints[0], &r)
 
 	one := samplePoints[0].X
 	one.SetOne()

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -136,7 +136,7 @@ func Test{{ $TAffine }}IsOnCurve(t *testing.T) {
             var op1, op2 {{ $TJacobian }}
 			op1 = fuzz{{ $TJacobian }}(&{{.PointName}}Gen, a)
             _r := fr.Modulus()
-            op2.ScalarMul(&op1, _r)
+            op2.ScalarMultiplication(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		{{$fuzzer}},
@@ -393,12 +393,12 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 				var scalar, blindedScalar, rminusone big.Int
 				var op1, op2, op3, gneg {{ $TJacobian }}
 				rminusone.SetUint64(1).Sub(r, &rminusone)
-				op3.ScalarMul(&{{.PointName}}Gen, &rminusone)
+				op3.ScalarMultiplication(&{{.PointName}}Gen, &rminusone)
 				gneg.Neg(&{{.PointName}}Gen)
 				s.ToBigIntRegular(&scalar)
 				blindedScalar.Mul(&scalar, r).Add(&blindedScalar, &scalar)
-				op1.ScalarMul(&{{.PointName}}Gen, &scalar)
-				op2.ScalarMul(&{{.PointName}}Gen, &blindedScalar)
+				op1.ScalarMultiplication(&{{.PointName}}Gen, &scalar)
+				op2.ScalarMultiplication(&{{.PointName}}Gen, &blindedScalar)
 
 				return op1.Equal(&op2) && g.Equal(&{{.PointName}}Infinity) && !op1.Equal(&{{.PointName}}Infinity) && gneg.Equal(&op3)
 
@@ -571,7 +571,7 @@ func Benchmark{{ $TAffine }}BatchScalarMul(b *testing.B) {
 	}
 }
 
-func Benchmark{{ $TJacobian }}ScalarMul(b *testing.B) {
+func Benchmark{{ $TJacobian }}ScalarMultiplication(b *testing.B) {
 
 	var scalar big.Int
 	r := fr.Modulus()

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -479,7 +479,7 @@ func Test{{ $TAffine }}CofactorCleaning(t *testing.T) {
 }
 {{end}}
 
-func Test{{ $TAffine }}BatchScalarMul(t *testing.T) {
+func Test{{ $TAffine }}BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -495,7 +495,7 @@ func Test{{ $TAffine }}BatchScalarMul(t *testing.T) {
 	// size of the multiExps
 	const nbSamples = 10
 
-	properties.Property("[{{ toUpper .Name }}] BatchScalarMul should be consistent with individual scalar multiplications", prop.ForAll(
+	properties.Property("[{{ toUpper .Name }}] BatchScalarMultiplication should be consistent with individual scalar multiplications", prop.ForAll(
 		func(mixer fr.Element) bool {
 			// mixer ensures that all the words of a fpElement are set
 			var sampleScalars [nbSamples]fr.Element
@@ -506,7 +506,7 @@ func Test{{ $TAffine }}BatchScalarMul(t *testing.T) {
 					FromMont()
 			}
 
-			result := BatchScalarMul{{ toUpper .PointName }}(&{{.PointName}}GenAff, sampleScalars[:])
+			result := BatchScalarMultiplication{{ toUpper .PointName }}(&{{.PointName}}GenAff, sampleScalars[:])
 
 			if len(result) != len(sampleScalars) {
 				return false
@@ -543,7 +543,7 @@ func Benchmark{{ $TJacobian }}IsInSubGroup(b *testing.B) {
 
 }
 
-func Benchmark{{ $TAffine }}BatchScalarMul(b *testing.B) {
+func Benchmark{{ $TAffine }}BatchScalarMultiplication(b *testing.B) {
 	// ensure every words of the scalars are filled
 	var mixer fr.Element
 	mixer.SetString("7716837800905789770901243404444209691916730933998574719964609384059111546487")
@@ -565,7 +565,7 @@ func Benchmark{{ $TAffine }}BatchScalarMul(b *testing.B) {
 		b.Run(fmt.Sprintf("%d points", using), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				_ = BatchScalarMul{{ toUpper .PointName }}(&{{.PointName}}GenAff, sampleScalars[:using])
+				_ = BatchScalarMultiplication{{ toUpper .PointName }}(&{{.PointName}}GenAff, sampleScalars[:using])
 			}
 		})
 	}

--- a/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
@@ -105,7 +105,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 
 	var bScalar big.Int
 	bScalar.SetBytes(priv.scalar[:])
-	pub.A.ScalarMul(&c.Base, &bScalar)
+	pub.A.ScalarMultiplication(&c.Base, &bScalar)
 
 	priv.PublicKey = pub
 
@@ -154,7 +154,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
-	res.R.ScalarMul(&curveParams.Base, &blindingFactorBigInt)
+	res.R.ScalarMultiplication(&curveParams.Base, &blindingFactorBigInt)
 	if !res.R.IsOnCurve() {
 		return nil, errNotOnCurve
 	}
@@ -240,8 +240,8 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 	var bCofactor, bs big.Int
 	curveParams.Cofactor.ToBigIntRegular(&bCofactor)
 	bs.SetBytes(sig.S[:])
-	lhs.ScalarMul(&curveParams.Base, &bs).
-		ScalarMul(&lhs, &bCofactor)
+	lhs.ScalarMultiplication(&curveParams.Base, &bs).
+		ScalarMultiplication(&lhs, &bCofactor)
 
 	if !lhs.IsOnCurve() {
 		return false, errNotOnCurve
@@ -249,9 +249,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	// rhs = cofactor*(R + H(R,A,M)*A)
 	var rhs twistededwards.PointAffine
-	rhs.ScalarMul(&pub.A, &hramInt).
+	rhs.ScalarMultiplication(&pub.A, &hramInt).
 		Add(&rhs, &sig.R).
-		ScalarMul(&rhs, &bCofactor)
+		ScalarMultiplication(&rhs, &bCofactor)
 	if !rhs.IsOnCurve() {
 		return false, errNotOnCurve
 	}

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -240,13 +240,13 @@ func (p *PointAffine) FromExtended(p1 *PointExtended) *PointAffine {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in affine coordinates with a scalar in big.Int
-func (p *PointAffine) ScalarMul(p1 *PointAffine, scalar *big.Int) *PointAffine {
+func (p *PointAffine) ScalarMultiplication(p1 *PointAffine, scalar *big.Int) *PointAffine {
 
 	var p1Extended, resExtended PointExtended
 	p1Extended.FromAffine(p1)
-	resExtended.ScalarMul(&p1Extended, scalar)
+	resExtended.ScalarMultiplication(&p1Extended, scalar)
 	p.FromExtended(&resExtended)
 
 	return p
@@ -393,9 +393,9 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMul(p1 *PointProj, scalar *big.Int) *PointProj {
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
 	{{- if .HasEndomorphism}}
 		return p.scalarMulGLV(p1, scalar)
 	{{- else }}
@@ -618,9 +618,9 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMul scalar multiplication of a point
+// ScalarMultiplication scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMul(p1 *PointExtended, scalar *big.Int) *PointExtended {
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	{{- if .HasEndomorphism}}
 		return p.scalarMulGLV(p1, scalar)
 	{{- else }}

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -106,8 +106,8 @@ func TestReceiverIsOperand(t *testing.T) {
 			var s big.Int
 			s.SetUint64(10)
 
-			p2.ScalarMul(&p1, &s)
-			p1.ScalarMul(&p1, &s)
+			p2.ScalarMultiplication(&p1, &s)
+			p1.ScalarMultiplication(&p1, &s)
 
 			return p2.Equal(&p1)
 		},
@@ -318,7 +318,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, zero PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -334,7 +334,7 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			p2.Neg(&p1)
 
 			p1.Add(&p1, &p2)
@@ -353,8 +353,8 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2, inf PointAffine
-			p1.ScalarMul(&params.Base, &s)
-			p2.ScalarMul(&params.Base, &s)
+			p1.ScalarMultiplication(&params.Base, &s)
+			p2.ScalarMultiplication(&params.Base, &s)
 
 			p1.Add(&p1, &p2)
 			p2.Double(&p2)
@@ -372,14 +372,14 @@ func TestOps(t *testing.T) {
 			var p1, p2, p3, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetZero()
-			p1.ScalarMul(&params.Base, &s1)
-			p2.ScalarMul(&params.Base, &s2)
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s2)
 			p3.Set(&params.Base)
 
 			p2.Add(&p1, &p2)
 
 			s1.Add(&s1, &s2)
-			p3.ScalarMul(&params.Base, &s1)
+			p3.ScalarMultiplication(&params.Base, &s1)
 
 			return p2.IsOnCurve() && p3.Equal(&p2) && !p3.Equal(&inf)
 		},
@@ -395,9 +395,9 @@ func TestOps(t *testing.T) {
 			var p1, p2, inf PointAffine
 			inf.X.SetZero()
 			inf.Y.SetOne()
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 			s1.Neg(&s1)
-			p2.ScalarMul(&params.Base, &s1)
+			p2.ScalarMultiplication(&params.Base, &s1)
 
 			p2.Add(&p1, &p2)
 
@@ -412,11 +412,11 @@ func TestOps(t *testing.T) {
 			params := GetEdwardsCurve()
 
 			var p1, p2 PointAffine
-			p1.ScalarMul(&params.Base, &s1)
+			p1.ScalarMultiplication(&params.Base, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.IsOnCurve() && p2.Equal(&p1)
 		},
@@ -445,7 +445,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, zero PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -462,7 +462,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -480,7 +480,7 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2, p PointProj
 			baseProj.FromAffine(&params.Base)
-			p.ScalarMul(&baseProj, &s)
+			p.ScalarMultiplication(&baseProj, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -497,11 +497,11 @@ func TestOps(t *testing.T) {
 
 			var baseProj, p1, p2 PointProj
 			baseProj.FromAffine(&params.Base)
-			p1.ScalarMul(&baseProj, &s1)
+			p1.ScalarMultiplication(&baseProj, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -529,7 +529,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, zero PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			zero.setInfinity()
 
 			p2.Add(&p1, &zero)
@@ -546,7 +546,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 			p2.Neg(&p1)
 
 			p.Add(&p1, &p2)
@@ -564,7 +564,7 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2, p PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p.ScalarMul(&baseExtended, &s)
+			p.ScalarMultiplication(&baseExtended, &s)
 
 			p1.Add(&p, &p)
 			p2.Double(&p)
@@ -581,11 +581,11 @@ func TestOps(t *testing.T) {
 
 			var baseExtended, p1, p2 PointExtended
 			baseExtended.FromAffine(&params.Base)
-			p1.ScalarMul(&baseExtended, &s1)
+			p1.ScalarMultiplication(&baseExtended, &s1)
 
 			five := big.NewInt(5)
 			p2.Double(&p1).Double(&p2).Add(&p2, &p1)
-			p1.ScalarMul(&p1, five)
+			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
 		},
@@ -601,8 +601,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pExtended, &pAffine)
@@ -620,8 +620,8 @@ func TestOps(t *testing.T) {
 			var baseExtended, pExtended, p, p2 PointExtended
 			var pAffine PointAffine
 			baseExtended.FromAffine(&params.Base)
-			pExtended.ScalarMul(&baseExtended, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pExtended.ScalarMultiplication(&baseExtended, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pExtended, &pAffine)
 			p2.MixedDouble(&pExtended)
@@ -640,8 +640,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 			pAffine.Neg(&pAffine)
 
 			p.MixedAdd(&pProj, &pAffine)
@@ -659,8 +659,8 @@ func TestOps(t *testing.T) {
 			var baseProj, pProj, p, p2 PointProj
 			var pAffine PointAffine
 			baseProj.FromAffine(&params.Base)
-			pProj.ScalarMul(&baseProj, &s)
-			pAffine.ScalarMul(&params.Base, &s)
+			pProj.ScalarMultiplication(&baseProj, &s)
+			pAffine.ScalarMultiplication(&params.Base, &s)
 
 			p.MixedAdd(&pProj, &pAffine)
 			p2.Double(&pProj)
@@ -679,9 +679,9 @@ func TestOps(t *testing.T) {
 			var baseExt PointExtended
 			var p1, p2 PointAffine
 			baseProj.FromAffine(&params.Base)
-			baseProj.ScalarMul(&baseProj, &s)
+			baseProj.ScalarMultiplication(&baseProj, &s)
 			baseExt.FromAffine(&params.Base)
-			baseExt.ScalarMul(&baseExt, &s)
+			baseExt.ScalarMultiplication(&baseExt, &s)
 
 			p1.FromProj(&baseProj)
 			p2.FromExtended(&baseExt)
@@ -744,7 +744,7 @@ func BenchmarkScalarMulExtended(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
 
@@ -760,6 +760,6 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 
 	b.ResetTimer()
 	for j := 0; j < b.N; j++ {
-		doubleAndAdd.ScalarMul(&a, &s)
+		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -154,7 +154,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	var claimedValueG1Aff {{ .CurvePackage }}.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.ToBigIntRegular(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMulUnconverted(&srs.G1[0], &claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&srs.G1[0], &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac {{ .CurvePackage }}.G1Jac

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -59,7 +59,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	_, _, gen1Aff, gen2Aff := {{ .CurvePackage }}.Generators()
 	srs.G1[0] = gen1Aff
 	srs.G2[0] = gen2Aff
-	srs.G2[1].ScalarMul(&gen2Aff, bAlpha)
+	srs.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -171,7 +171,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, srs *SRS)
 	point.ToBigIntRegular(&pointBigInt)
 	genG2Jac.FromAffine(&srs.G2[0])
 	alphaG2Jac.FromAffine(&srs.G2[1])
-	alphaMinusaG2Jac.ScalarMul(&genG2Jac, &pointBigInt).
+	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
 		Neg(&alphaMinusaG2Jac).
 		AddAssign(&alphaG2Jac)
 
@@ -400,7 +400,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit {{ .CurvePackage }}.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.ToBigIntRegular(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMul(&srs.G1[0], &foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&srs.G1[0], &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -69,7 +69,7 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 	for i := 0; i < len(alphas); i++ {
 		alphas[i].FromMont()
 	}
-	g1s := {{ .CurvePackage }}.BatchScalarMulG1(&gen1Aff, alphas)
+	g1s := {{ .CurvePackage }}.BatchScalarMultiplicationG1(&gen1Aff, alphas)
 	copy(srs.G1[1:], g1s)
 
 	return &srs, nil

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -112,7 +112,7 @@ func TestCommit(t *testing.T) {
 	fx.ToBigIntRegular(&fxbi)
 	var manualCommit {{ .CurvePackage }}.G1Affine
 	manualCommit.Set(&testSRS.G1[0])
-	manualCommit.ScalarMul(&manualCommit, &fxbi)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/internal/generator/pairing/template/tests/pairing.go.tmpl
+++ b/internal/generator/pairing/template/tests/pairing.go.tmpl
@@ -118,8 +118,8 @@ func TestPairing(t *testing.T) {
 			b.ToBigIntRegular(&bbigint)
 			ab.Mul(&abigint, &bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ = Pair([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
 			resa, _ = Pair([]G1Affine{ag1}, []G2Affine{g2GenAff})
@@ -187,8 +187,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			P0 := []G1Affine{g1GenAff}
 			P1 := []G1Affine{ag1}
@@ -230,8 +230,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			g1Inf.FromJacobian(&g1Infinity)
 			g2Inf.FromJacobian(&g2Infinity)
@@ -268,8 +268,8 @@ func TestMillerLoop(t *testing.T) {
 			a.ToBigIntRegular(&abigint)
 			b.ToBigIntRegular(&bbigint)
 
-			ag1.ScalarMul(&g1GenAff, &abigint)
-			bg2.ScalarMul(&g2GenAff, &bbigint)
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
 
 			res, _ := Pair([]G1Affine{ag1}, []G2Affine{bg2})
 

--- a/internal/generator/plookup/template/table.go.tmpl
+++ b/internal/generator/plookup/template/table.go.tmpl
@@ -191,9 +191,9 @@ func VerifyLookupTables(srs *kzg.SRS, proof ProofLookupTables) error {
 	var blambda big.Int
 	lambda.ToBigIntRegular(&blambda)
 	for i := nbRows - 2; i >= 0; i-- {
-		comf.ScalarMul(&comf, &blambda).
+		comf.ScalarMultiplication(&comf, &blambda).
 			Add(&comf, &proof.fs[i])
-		comt.ScalarMul(&comt, &blambda).
+		comt.ScalarMultiplication(&comt, &blambda).
 			Add(&comt, &proof.ts[i])
 	}
 


### PR DESCRIPTION
#220  did rename `ScalarMultiplication` to `ScalarMul` but it impacts all lib users and forces them to to a minor (not necessary) refactoring. 

- refactor: ScalarMul -> ScalarMultiplication
- refactor: BatchScalarMul -> BatchScalarMultiplication
- refactor: ScalarMulUnconverted -> ScalarMultiplicationAffine
