### PR TITLE
Changes on SIS and tensor commitment resulting from the integration

### DIFF
--- a/ecc/bn254/fr/tensor-commitment/commitment.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment.go
@@ -393,10 +393,10 @@ func cmpBytes(a, b []byte) bool {
 // h: hash function that is used for hashing the columns of the polynomial
 // TODO make this function private and add a Verify function that derives
 // the randomness using Fiat Shamir
-// Note (alex), I removed the FS from this function. (I already do it from
-// outside). This is actually the simpler for me to do this. If you absolutely
-// want to expose a wrapper around it, can you keep exposing a this function
-// (possibly under a different name).
+//
+// Note (alex), A more convenient API would be to expose two functions,
+// one that does FS for you and what that let you do it for yourself. And likewise
+// for the prover.
 func Verify(proof Proof, digest Digest, l []fr.Element) error {
 
 	// for each entry in the list -> it corresponds to the sampling

--- a/ecc/bn254/fr/tensor-commitment/commitment.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment.go
@@ -171,7 +171,9 @@ func NewTensorCommitment(params *TcParams) *TensorCommitment {
 // ..
 // p[nbRows-1] 	| p[2*nbRows-1]	| p[3*nbRows-1] ..
 // If p doesn't fill a full submatrix it is padded with zeroes.
-func (tc *TensorCommitment) Append(currentColumnToFill int, p []fr.Element) ([][]byte, error) {
+func (tc *TensorCommitment) Append(p []fr.Element) ([][]byte, error) {
+
+	currentColumnToFill := int(tc.NbColumnsHashed)
 
 	// check if there is some room for p
 	nbColumnsTakenByP := (len(p) - len(p)%tc.params.NbRows) / tc.params.NbRows

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -72,7 +72,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(0, p)
+		_, err := tc.Append(p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,7 +93,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(1, p)
+		_, err := tc.Append(p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows+offset; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(2, p)
+		_, err := tc.Append(p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +140,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows+offset; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(4, p)
+		_, err := tc.Append(p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func TestLinearCombination(t *testing.T) {
 	}
 
 	// append p and commit (otherwise the proof cannot be built)
-	tc.Append(0, p)
+	tc.Append(p)
 	_, err = tc.Commit()
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestCommitmentDummyHash(t *testing.T) {
 	}
 
 	// compute the digest...
-	_, err = tc.Append(0, p)
+	_, err = tc.Append(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestOpeningDummyHash(t *testing.T) {
 	}
 
 	// create the digest before computing the proof
-	_, err = tc.Append(0, p)
+	_, err = tc.Append(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestAppendSis(t *testing.T) {
 		p[i].SetRandom()
 	}
 
-	s, err := tc.Append(0, p)
+	s, err := tc.Append(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestCommitmentSis(t *testing.T) {
 	}
 
 	// compute the digest...
-	_, err = tc.Append(0, p)
+	_, err = tc.Append(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func BenchmarkTensorCommitment(b *testing.B) {
 		b.Run("size poly"+strconv.Itoa(nbRows*nbColumns), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tc.Append(0, p)
+				tc.Append(p)
 				tc.Commit()
 			}
 		})

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -201,7 +201,7 @@ func TestLinearCombination(t *testing.T) {
 		l := make([]fr.Element, nbRows)
 		l[i].SetInt64(1)
 
-		proof, err := tc.BuildProof(l, entryList)
+		proof, err := tc.BuildProofAtOnceForTest(l, entryList)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestCommitmentDummyHash(t *testing.T) {
 	}
 
 	// build the proof...
-	proof, err := tc.BuildProof(l, entryList)
+	proof, err := tc.BuildProofAtOnceForTest(l, entryList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestOpeningDummyHash(t *testing.T) {
 	for i := 0; i < rho*nbColumns; i++ {
 		entryList[i] = i
 	}
-	proof, err := tc.BuildProof(lo, entryList)
+	proof, err := tc.BuildProofAtOnceForTest(lo, entryList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func TestCommitmentSis(t *testing.T) {
 		}
 
 		// build the proof...
-		proof, err := tc.BuildProof(l, entryList)
+		proof, err := tc.BuildProofAtOnceForTest(l, entryList)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -489,7 +489,7 @@ func TestCommitmentSis(t *testing.T) {
 		entryList[1] = 4
 
 		// build the proof...
-		proof, err := tc.BuildProof(l, entryList)
+		proof, err := tc.BuildProofAtOnceForTest(l, entryList)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -272,7 +272,7 @@ func TestCommitmentDummyHash(t *testing.T) {
 	}
 
 	// verfiy that the proof is correct
-	err = Verify(proof, digest, l, h)
+	err = Verify(proof, digest, l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestCommitmentSis(t *testing.T) {
 		}
 
 		// verfiy that the proof is correct
-		err = Verify(proof, digest, l, h)
+		err = Verify(proof, digest, l)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -495,7 +495,7 @@ func TestCommitmentSis(t *testing.T) {
 		}
 
 		// verfiy that the proof is correct
-		err = Verify(proof, digest, l, h)
+		err = Verify(proof, digest, l)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -72,7 +72,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(p)
+		_, err := tc.Append(0, p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,7 +93,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(p)
+		_, err := tc.Append(1, p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows+offset; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(p)
+		_, err := tc.Append(2, p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +140,7 @@ func TestAppend(t *testing.T) {
 		for i := 0; i < nbRows+offset; i++ {
 			p[i].SetRandom()
 		}
-		_, err := tc.Append(p)
+		_, err := tc.Append(4, p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func TestLinearCombination(t *testing.T) {
 	}
 
 	// append p and commit (otherwise the proof cannot be built)
-	tc.Append(p)
+	tc.Append(0, p)
 	_, err = tc.Commit()
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestCommitmentDummyHash(t *testing.T) {
 	}
 
 	// compute the digest...
-	_, err = tc.Append(p)
+	_, err = tc.Append(0, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestOpeningDummyHash(t *testing.T) {
 	}
 
 	// create the digest before computing the proof
-	_, err = tc.Append(p)
+	_, err = tc.Append(0, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestAppendSis(t *testing.T) {
 		p[i].SetRandom()
 	}
 
-	s, err := tc.Append(p)
+	s, err := tc.Append(0, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestCommitmentSis(t *testing.T) {
 	}
 
 	// compute the digest...
-	_, err = tc.Append(p)
+	_, err = tc.Append(0, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func BenchmarkTensorCommitment(b *testing.B) {
 		b.Run("size poly"+strconv.Itoa(nbRows*nbColumns), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tc.Append(p)
+				tc.Append(0, p)
 				tc.Commit()
 			}
 		})

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -272,7 +272,7 @@ func TestCommitmentDummyHash(t *testing.T) {
 	}
 
 	// verfiy that the proof is correct
-	err = Verify(proof, digest, l)
+	err = Verify(proof, digest, l, h)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestCommitmentSis(t *testing.T) {
 		}
 
 		// verfiy that the proof is correct
-		err = Verify(proof, digest, l)
+		err = Verify(proof, digest, l, h)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -495,7 +495,7 @@ func TestCommitmentSis(t *testing.T) {
 		}
 
 		// verfiy that the proof is correct
-		err = Verify(proof, digest, l)
+		err = Verify(proof, digest, l, h)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ecc/bn254/fr/tensor-commitment/commitment_test.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment_test.go
@@ -60,10 +60,11 @@ func TestAppend(t *testing.T) {
 	rho := 4
 	nbRows := 10
 	nbColumns := 16
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	{
 		// random Polynomial of size nbRows
@@ -78,7 +79,7 @@ func TestAppend(t *testing.T) {
 
 		// check if p corresponds to the first column of the state
 		for i := 0; i < nbRows; i++ {
-			if !tc.state[i][0].Equal(&p[i]) {
+			if !tc.State[i][0].Equal(&p[i]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
@@ -99,7 +100,7 @@ func TestAppend(t *testing.T) {
 
 		// check if p corresponds to the second column of the state
 		for i := 0; i < nbRows; i++ {
-			if !tc.state[i][1].Equal(&p[i]) {
+			if !tc.State[i][1].Equal(&p[i]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
@@ -120,12 +121,12 @@ func TestAppend(t *testing.T) {
 
 		// check if p corresponds to the first column of the state
 		for i := 0; i < nbRows; i++ {
-			if !tc.state[i][2].Equal(&p[i]) {
+			if !tc.State[i][2].Equal(&p[i]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
 		for i := 0; i < offset; i++ {
-			if !tc.state[i][3].Equal(&p[i+nbRows]) {
+			if !tc.State[i][3].Equal(&p[i+nbRows]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
@@ -146,12 +147,12 @@ func TestAppend(t *testing.T) {
 
 		// check if p corresponds to the first column of the state
 		for i := 0; i < nbRows; i++ {
-			if !tc.state[i][4].Equal(&p[i]) {
+			if !tc.State[i][4].Equal(&p[i]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
 		for i := 0; i < offset; i++ {
-			if !tc.state[i][5].Equal(&p[i+nbRows]) {
+			if !tc.State[i][5].Equal(&p[i+nbRows]) {
 				t.Fatal("a column is not filled correctly")
 			}
 		}
@@ -165,10 +166,11 @@ func TestLinearCombination(t *testing.T) {
 	rho := 4
 	nbRows := 8
 	nbColumns := 8
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	// build a random polynomial
 	p := make([]fr.Element, nbRows*nbColumns)
@@ -229,10 +231,11 @@ func TestCommitmentDummyHash(t *testing.T) {
 	nbRows = 8
 
 	var h DummyHash
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	// random polynomial
 	p := make([]fr.Element, nbRows*nbColumns)
@@ -285,10 +288,11 @@ func TestOpeningDummyHash(t *testing.T) {
 	nbRows = 8
 
 	var h DummyHash
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	// random polynomial
 	p := make([]fr.Element, nbColumns*nbRows)
@@ -368,10 +372,11 @@ func TestAppendSis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	// random polynomial (that does not fill the full matrix)
 	offset := 4
@@ -429,10 +434,11 @@ func TestCommitmentSis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tc, err := NewTensorCommitment(rho, nbColumns, nbRows, h)
+	params, err := NewTCParams(rho, nbColumns, nbRows, h)
 	if err != nil {
 		t.Fatal(err)
 	}
+	tc := NewTensorCommitment(params)
 
 	// random polynomial
 	p := make([]fr.Element, nbRows*nbColumns)
@@ -515,7 +521,8 @@ func BenchmarkTensorCommitment(b *testing.B) {
 		sizeKey := (nbColumns * sizeFr) / (logTwoBound * (1 << logTwoDegree))
 
 		h, _ := sis.NewRSis(5, logTwoDegree, logTwoBound, sizeKey)
-		tc, _ := NewTensorCommitment(rho, nbColumns, nbRows, h)
+		params, _ := NewTCParams(rho, nbColumns, nbRows, h)
+		tc := NewTensorCommitment(params)
 
 		// random polynomial
 		p := make([]fr.Element, nbRows*nbColumns)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/pkg/profile v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/consensys/bavard v0.1.12 h1:rApQlUvBg5FeW/fnigtVnAs0sBrgDN2pEuHNdWElSUE=
-github.com/consensys/bavard v0.1.12/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -14,8 +12,6 @@ github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
-github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
-github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
# Changes in the organization

## Creates a struct `TcParams`

Creates a struct `TcParams` that contains all the static parameters of the tensor commitment. The justification is that the parameters of this struct do not have the same lifecycle as the parameters of the `TcCommitment` struct which are used only for creating "1 instance of the commitment". It is a prerequisite for parallelization.

## Append takes a `pos` parameters

This allows the user-level parallelization by appending several columns at the same time. An alternative is to let the user pass several columns at the same time and do the parallelization internally. In this case, there is no need for the `pos` parameter.

## Splits the provers steps. 

Those steps happens at different interaction rounds thus they cannot be exposed in a single function if that function does not do the Fiat-Shamir hashes as well. Two APIs are possible

* Letting the user do FS on his own, exposing one function for each round where each function takes the coins of the current rounds as inputs. (I prefer this one, I added a note in the comments to leave a trace).
* A single function that does everything. Note that if you go for this one, it will require us (AC team) to work to make gnark's FiatShamir compatible with external FS. If you go for this one, I would love to still have the first exposed.

# Bug found but not fixed

## The sis.Hasher padding strategy is inconsitent with its gnark counter-part.

This bug can be bypassed at the user level by doing the padding itself. In gnark-crypto, the hasher appends zeroes but in gnark/std it prepends. In all cases, it would be interesting to have some way to notify the user that "zero-padding" happened because maybe it was unexpected.

## ~~The verifier does not check the column hashing~~

~~This is known, but still important IMO. Because the gnark-crypto verifier is used by the user code for testing as well.~~