### PR TITLE
perf: one less alloc in element.SetBytes

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -1019,11 +1019,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -1019,11 +1019,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -1019,11 +1019,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -945,11 +945,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -945,11 +945,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -877,11 +877,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -1375,11 +1375,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -945,11 +945,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-756/fp/element.go
+++ b/ecc/bw6-756/fp/element.go
@@ -1589,11 +1589,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -1019,11 +1019,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -1589,11 +1589,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -1019,11 +1019,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -728,11 +728,13 @@ func (z *Element) SetBytes(e []byte) *Element {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}

--- a/internal/field/internal/templates/element/conv.go
+++ b/internal/field/internal/templates/element/conv.go
@@ -138,11 +138,13 @@ func (z *{{.ElementName}}) SetBytes(e []byte) *{{.ElementName}} {
 			z.SetZero()
 		} else if c != 1 && vv.Sign() != -1 {
 			// 0 < v < q
+			z.SetZero()
 			z.setBigInt(vv)
 		} else {
 			// modular reduction
 			vv.Mod(vv, &_modulus)
 			// set big int byte value
+			z.SetZero()
 			z.setBigInt(vv)
 		}
 	}


### PR DESCRIPTION
Ports these 2 minor perf optim:

https://github.com/crate-crypto/go-ipa/pull/22 
https://github.com/crate-crypto/go-ipa/pull/20 