### PR TITLE
Add support for parallelization in the tensor-commitment

### DIFF
--- a/ecc/bn254/fr/sis/experiment_prereduction_test.go
+++ b/ecc/bn254/fr/sis/experiment_prereduction_test.go
@@ -1,0 +1,152 @@
+package sis_test
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+/*
+	Just a piece of code independent from the rest to assess if an approach for sis
+	works. The idea is that we limb-expand field elements in 6 limbs of 64 bits (instead of 4 normally).
+	To give an example, the field element 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+	would be represented as
+
+		0x00000fffffffffff
+		0x00000fffffffffff
+		0x00000fffffffffff
+		0x00000fffffffffff
+		0x00000fffffffffff
+		0x00000fffffffffff
+
+	Thus each limbs has 20 bits of margin. Multiplying by a small number of bits, reduces the margin
+	down to 17 bits. This leaves enough room to perform 2^17 additions before we need to `reset`. Since
+	reduction will happen "only occasionally" and since we are only interested in performances, we will
+	neglect it in the benchmarks.
+*/
+
+const (
+	MAX_NORM     int = 8
+	LOG_MAX_NORM int = 3
+	// We have that 254 / 3 = 85, but in practice each field element is given in limbs
+	// of uint64. In the end, it is simpler to work with 22 limbs per uint64, than it
+	// is to work with large integers. If we wanted to have something more optimal we
+	// would need to implement it by hand.
+	NUM_LIMBS_FIELD            int = 88
+	NUM_LIMBS_U64              int = 22
+	NUM_LIMBS_PER_FIELD_IN_KEY int = 6
+	NUM_FIELD_ELEMENT_KEY      int = 2
+	NUM_LIMBS_PER_KEY_ENTRY    int = NUM_LIMBS_PER_FIELD_IN_KEY * NUM_FIELD_ELEMENT_KEY
+)
+
+type ExpandedKeyEntry = [NUM_LIMBS_PER_KEY_ENTRY]uint64
+
+func BenchmarkLimbIdea(b *testing.B) {
+
+	vecSize := 1 << 20
+
+	key := GenerateKey(vecSize)
+
+	vec := make([]fr.Element, vecSize)
+	for i := range vec {
+		// Worst case
+		vec[i].SetInt64(-1)
+	}
+
+	b.ResetTimer()
+	for _cnt := 0; _cnt < b.N; _cnt++ {
+		HashLimbExpanded(key, vec)
+	}
+
+}
+
+/*
+The key is in limb expanded form, thus each entry will contain 12 u64 instead of two field element. The user
+pass the "number" of field element he wishes to hash.
+*/
+func GenerateKey(nbField int) [][NUM_LIMBS_PER_KEY_ENTRY]uint64 {
+
+	/*
+		Since the logTwoBound is 2^3, we need 85 entries to represent a field element
+	*/
+	key := make([][NUM_LIMBS_PER_KEY_ENTRY]uint64, nbField*NUM_LIMBS_FIELD)
+
+	for i := range key {
+		for j := 0; j < NUM_LIMBS_PER_KEY_ENTRY; j++ {
+			// Not really random but that does not matter for the performances
+			key[i][j] = uint64(0x00000fffffffffff - NUM_LIMBS_PER_KEY_ENTRY*i - j)
+		}
+	}
+
+	return key
+}
+
+/*
+We assume that each input is already short. That way, we are not impacted by the cost
+of "splitting" each field element into limbs. Since the limb are very small, we fit them
+on uint8 integers. The limbs can be considered as
+*/
+func HashLimbExpanded(key []ExpandedKeyEntry, inputFields []fr.Element) ExpandedKeyEntry {
+
+	var res ExpandedKeyEntry
+
+	for i := 0; i < len(inputFields); i++ {
+
+		xRegular := inputFields[i]
+		xRegular.ToRegular()
+
+		var xLimb uint64
+
+		pos := 0
+
+		for j := 0; j < 4; j++ {
+
+			xU64 := xRegular[j]
+
+			// We unroll the loop by taking "2" entries at a time
+
+			for k := 0; k < NUM_LIMBS_U64/2; k++ {
+
+				xLimb = xU64 & 7 // This takes the 3 last bits of xU64
+				xU64 >>= 3       // We shift, so that, next time we get the 3 next bits etc..
+
+				// Load to key portion at once
+				res[0] += key[pos][0] * xLimb
+				res[1] += key[pos][1] * xLimb
+				res[2] += key[pos][2] * xLimb
+				res[3] += key[pos][3] * xLimb
+				res[4] += key[pos][4] * xLimb
+				res[5] += key[pos][5] * xLimb
+				res[6] += key[pos][6] * xLimb
+				res[7] += key[pos][7] * xLimb
+				res[8] += key[pos][8] * xLimb
+				res[9] += key[pos][9] * xLimb
+				res[10] += key[pos][10] * xLimb
+				res[11] += key[pos][11] * xLimb
+
+				pos++
+				xLimb = xU64 & 7 // This takes the 3 last bits of xU64
+				xU64 >>= 3       // We shift, so that, next time we get the 3 next bits etc..
+
+				// Load to key portion at once
+				res[0] += key[pos][0] * xLimb
+				res[1] += key[pos][1] * xLimb
+				res[2] += key[pos][2] * xLimb
+				res[3] += key[pos][3] * xLimb
+				res[4] += key[pos][4] * xLimb
+				res[5] += key[pos][5] * xLimb
+				res[6] += key[pos][6] * xLimb
+				res[7] += key[pos][7] * xLimb
+				res[8] += key[pos][8] * xLimb
+				res[9] += key[pos][9] * xLimb
+				res[10] += key[pos][10] * xLimb
+				res[11] += key[pos][11] * xLimb
+
+				pos++
+
+			}
+		}
+	}
+
+	return res
+}

--- a/ecc/bn254/fr/sis/sis_test.go
+++ b/ecc/bn254/fr/sis/sis_test.go
@@ -15,6 +15,7 @@
 package sis
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -84,7 +85,7 @@ func TestSISParamsZKEVM(t *testing.T) {
 
 func BenchmarkSIS(b *testing.B) {
 
-	keySize := 65536
+	keySize := 1 << 20
 	logTwoBound := 3
 	logTwoDegree := 1
 
@@ -97,6 +98,8 @@ func BenchmarkSIS(b *testing.B) {
 		p.SetRandom()
 		sis.Write(p.Marshal())
 	}
+
+	fmt.Printf("#Field elements %v\n", nbFrElements)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/ecc/bn254/fr/tensor-commitment/commitment.go
+++ b/ecc/bn254/fr/tensor-commitment/commitment.go
@@ -79,8 +79,9 @@ type TcParams struct {
 	// Rho⁻¹, rate of the RS code ( > 1)
 	Rho int
 
-	// Function that returns a clean hasher
-	// Hash function for hashing the columns
+	// Function that returns a fresh hasher. The returned hash function is used for hashing the
+	// columns. We use this and not directly a hasher for threadsafety hasher. Indeed, if different
+	// thread share the same hasher, they will end up mixing hash inputs that should remain separate.
 	MakeHash func() hash.Hash
 }
 


### PR DESCRIPTION
## A small experiment for SIS

Also include a small-experiment, which lives in an isolated test file. The experiment underlines an idea to speed-up the SIS hashes down to 300ns per field element. It is however incomplete in the sense that it does not implement everything. Only the parts that are relevant "performance-wise" have been implemented.

The experiment is deeply tied to the choices of parameters that we use for SIS. (Recall d = 2 and \beta = 8). We do several thing. Instead, of representing "slots" in the hashing key with 2 field elements (internally represented as 4 uint64 each), we represent them using 6 uint64 limbs as follows.

```
0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

represented as

0x00000fffffffffff
0x00000fffffffffff
0x00000fffffffffff
0x00000fffffffffff
0x00000fffffffffff
0x00000fffffffffff
```

Thus, each uint64 in the key are prefixed with 20 bits. Multiplying these key elements, by small number reduces this margin to 17 bits. Thus, we can perform all our field operations using uint64 arithmetic. This is much faster than field arithmetic even though there are "more" addition" to do. This approach benefits from not having to do reductions.

Another notable improvement stems from how we split large field elements into small chunks. The approach benefits from how gnark stores field elements internally (i.e. the fact that they are stored as [4]uint64) to minimize the number of CPU operations required to obtain a limb. This is however done at the cost of increasing the number of limbs from 88 to 85.

## Parallelization for the tensor commitment

* Update the `Append` method of the tensor commitment to possibly take several polynomials at once. This is done at the cost of adding a breaking change. The tensor commitment no longer takes a SIS hasher as a parameter but takes a constructor that returns "fresh" hashers. This was necessary for thread-safety.