### PR TITLE
`element.SetBytesCanonical`, `element.BigEndian` and `element.LittleEndian`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    # - errcheck
 
 run:
   issues-exit-code: 1

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -1260,7 +1260,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 48-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[40:48])
 	z[1] = binary.BigEndian.Uint64((*b)[32:40])
@@ -1275,8 +1274,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[40:48], e[0])
@@ -1285,8 +1284,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[3])
 	binary.BigEndian.PutUint64((*b)[8:16], e[4])
 	binary.BigEndian.PutUint64((*b)[0:8], e[5])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1295,11 +1294,32 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -193,7 +193,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -931,10 +937,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1072,7 +1086,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1083,7 +1097,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 253       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 253 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -761,51 +761,51 @@ func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A0.SetBytesCanonical(e[528 : 528+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A1.SetBytesCanonical(e[480 : 480+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A0.SetBytesCanonical(e[432 : 432+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A1.SetBytesCanonical(e[384 : 384+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A0.SetBytesCanonical(e[336 : 336+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A1.SetBytesCanonical(e[288 : 288+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A0.SetBytesCanonical(e[240 : 240+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A1.SetBytesCanonical(e[192 : 192+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A0.SetBytesCanonical(e[144 : 144+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A1.SetBytesCanonical(e[96 : 96+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A0.SetBytesCanonical(e[48 : 48+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A1.SetBytesCanonical(e[0 : 0+fp.Bytes]); err != nil {
 		return err
 	}
 

--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -756,34 +756,58 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 // SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == 48 * 12
-// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
+// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes])
+	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes])
+	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes])
+	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes])
+	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes])
+	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes])
+	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes])
+	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes])
+	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes])
+	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes])
+	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes])
+	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
+	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -765,10 +765,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -790,7 +790,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -884,7 +884,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1070,17 +1070,17 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 		// p.Y.A1 | p.Y.A0
-		if err := p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.Y.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.Y.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 
@@ -1103,10 +1103,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
 
@@ -1203,10 +1203,10 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -1260,7 +1260,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 48-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[40:48])
 	z[1] = binary.BigEndian.Uint64((*b)[32:40])
@@ -1275,8 +1274,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[40:48], e[0])
@@ -1285,8 +1284,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[3])
 	binary.BigEndian.PutUint64((*b)[8:16], e[4])
 	binary.BigEndian.PutUint64((*b)[0:8], e[5])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1295,11 +1294,32 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -193,7 +193,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -931,10 +937,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1072,7 +1086,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1083,7 +1097,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [6]uint64
 
 const (
-	Limbs = 6         // number of 64 bits words needed to represent a Element
-	Bits  = 378       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 6   // number of 64 bits words needed to represent a Element
+	Bits  = 378 // number of bits needed to represent a Element
+	Bytes = 48  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -193,13 +193,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1048,7 +1042,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[40:48], z[0])
 	binary.BigEndian.PutUint64(b[32:40], z[1])
 	binary.BigEndian.PutUint64(b[24:32], z[2])
@@ -1066,15 +1060,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[40:48], _z[0])
-	binary.BigEndian.PutUint64(res[32:40], _z[1])
-	binary.BigEndian.PutUint64(res[24:32], _z[2])
-	binary.BigEndian.PutUint64(res[16:24], _z[3])
-	binary.BigEndian.PutUint64(res[8:16], _z[4])
-	binary.BigEndian.PutUint64(res[0:8], _z[5])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1086,7 +1073,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1097,6 +1094,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 48-byte integer.
+// If e is not a 48-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1232,6 +1244,63 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 48-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[40:48])
+	z[1] = binary.BigEndian.Uint64((*b)[32:40])
+	z[2] = binary.BigEndian.Uint64((*b)[24:32])
+	z[3] = binary.BigEndian.Uint64((*b)[16:24])
+	z[4] = binary.BigEndian.Uint64((*b)[8:16])
+	z[5] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[40:48], e[0])
+	binary.BigEndian.PutUint64((*b)[32:40], e[1])
+	binary.BigEndian.PutUint64((*b)[24:32], e[2])
+	binary.BigEndian.PutUint64((*b)[16:24], e[3])
+	binary.BigEndian.PutUint64((*b)[8:16], e[4])
+	binary.BigEndian.PutUint64((*b)[0:8], e[5])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 254       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 254 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls12-378/internal/fptower/e12.go
+++ b/ecc/bls12-378/internal/fptower/e12.go
@@ -761,51 +761,51 @@ func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A0.SetBytesCanonical(e[528 : 528+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A1.SetBytesCanonical(e[480 : 480+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A0.SetBytesCanonical(e[432 : 432+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A1.SetBytesCanonical(e[384 : 384+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A0.SetBytesCanonical(e[336 : 336+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A1.SetBytesCanonical(e[288 : 288+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A0.SetBytesCanonical(e[240 : 240+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A1.SetBytesCanonical(e[192 : 192+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A0.SetBytesCanonical(e[144 : 144+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A1.SetBytesCanonical(e[96 : 96+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A0.SetBytesCanonical(e[48 : 48+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A1.SetBytesCanonical(e[0 : 0+fp.Bytes]); err != nil {
 		return err
 	}
 

--- a/ecc/bls12-378/internal/fptower/e12.go
+++ b/ecc/bls12-378/internal/fptower/e12.go
@@ -756,34 +756,58 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 // SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == 48 * 12
-// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
+// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes])
+	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes])
+	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes])
+	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes])
+	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes])
+	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes])
+	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes])
+	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes])
+	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes])
+	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes])
+	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes])
+	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
+	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -765,10 +765,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -790,7 +790,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -884,7 +884,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1070,17 +1070,17 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 		// p.Y.A1 | p.Y.A0
-		if err := p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.Y.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.Y.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 
@@ -1103,10 +1103,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
 
@@ -1203,10 +1203,10 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bls12-381/bandersnatch/point.go
+++ b/ecc/bls12-381/bandersnatch/point.go
@@ -48,7 +48,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -1260,7 +1260,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 48-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[40:48])
 	z[1] = binary.BigEndian.Uint64((*b)[32:40])
@@ -1275,8 +1274,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[40:48], e[0])
@@ -1285,8 +1284,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[3])
 	binary.BigEndian.PutUint64((*b)[8:16], e[4])
 	binary.BigEndian.PutUint64((*b)[0:8], e[5])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1295,11 +1294,32 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [6]uint64
 
 const (
-	Limbs = 6         // number of 64 bits words needed to represent a Element
-	Bits  = 381       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 6   // number of 64 bits words needed to represent a Element
+	Bits  = 381 // number of bits needed to represent a Element
+	Bytes = 48  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -193,13 +193,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1048,7 +1042,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[40:48], z[0])
 	binary.BigEndian.PutUint64(b[32:40], z[1])
 	binary.BigEndian.PutUint64(b[24:32], z[2])
@@ -1066,15 +1060,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[40:48], _z[0])
-	binary.BigEndian.PutUint64(res[32:40], _z[1])
-	binary.BigEndian.PutUint64(res[24:32], _z[2])
-	binary.BigEndian.PutUint64(res[16:24], _z[3])
-	binary.BigEndian.PutUint64(res[8:16], _z[4])
-	binary.BigEndian.PutUint64(res[0:8], _z[5])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1086,7 +1073,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1097,6 +1094,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 48-byte integer.
+// If e is not a 48-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1232,6 +1244,63 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 48-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[40:48])
+	z[1] = binary.BigEndian.Uint64((*b)[32:40])
+	z[2] = binary.BigEndian.Uint64((*b)[24:32])
+	z[3] = binary.BigEndian.Uint64((*b)[16:24])
+	z[4] = binary.BigEndian.Uint64((*b)[8:16])
+	z[5] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[40:48], e[0])
+	binary.BigEndian.PutUint64((*b)[32:40], e[1])
+	binary.BigEndian.PutUint64((*b)[24:32], e[2])
+	binary.BigEndian.PutUint64((*b)[16:24], e[3])
+	binary.BigEndian.PutUint64((*b)[8:16], e[4])
+	binary.BigEndian.PutUint64((*b)[0:8], e[5])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -193,7 +193,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -931,10 +937,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1072,7 +1086,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1083,7 +1097,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 255       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 255 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -761,51 +761,51 @@ func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A0.SetBytesCanonical(e[528 : 528+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A1.SetBytesCanonical(e[480 : 480+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A0.SetBytesCanonical(e[432 : 432+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A1.SetBytesCanonical(e[384 : 384+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A0.SetBytesCanonical(e[336 : 336+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A1.SetBytesCanonical(e[288 : 288+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A0.SetBytesCanonical(e[240 : 240+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A1.SetBytesCanonical(e[192 : 192+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A0.SetBytesCanonical(e[144 : 144+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A1.SetBytesCanonical(e[96 : 96+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A0.SetBytesCanonical(e[48 : 48+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A1.SetBytesCanonical(e[0 : 0+fp.Bytes]); err != nil {
 		return err
 	}
 

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -756,34 +756,58 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 // SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == 48 * 12
-// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
+// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes])
+	if err := z.C0.B0.A0.SetBytes(e[528 : 528+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes])
+	if err := z.C0.B0.A1.SetBytes(e[480 : 480+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes])
+	if err := z.C0.B1.A0.SetBytes(e[432 : 432+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes])
+	if err := z.C0.B1.A1.SetBytes(e[384 : 384+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes])
+	if err := z.C0.B2.A0.SetBytes(e[336 : 336+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes])
+	if err := z.C0.B2.A1.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes])
+	if err := z.C1.B0.A0.SetBytes(e[240 : 240+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes])
+	if err := z.C1.B0.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes])
+	if err := z.C1.B1.A0.SetBytes(e[144 : 144+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes])
+	if err := z.C1.B1.A1.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes])
+	if err := z.C1.B2.A0.SetBytes(e[48 : 48+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
+	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -765,10 +765,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -790,7 +790,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -884,7 +884,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1070,17 +1070,17 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 		// p.Y.A1 | p.Y.A0
-		if err := p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.Y.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.Y.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 
@@ -1103,10 +1103,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
 
@@ -1203,10 +1203,10 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [5]uint64
 
 const (
-	Limbs = 5         // number of 64 bits words needed to represent a Element
-	Bits  = 315       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 5   // number of 64 bits words needed to represent a Element
+	Bits  = 315 // number of bits needed to represent a Element
+	Bytes = 40  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -190,13 +190,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -965,7 +959,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[32:40], z[0])
 	binary.BigEndian.PutUint64(b[24:32], z[1])
 	binary.BigEndian.PutUint64(b[16:24], z[2])
@@ -982,14 +976,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[32:40], _z[0])
-	binary.BigEndian.PutUint64(res[24:32], _z[1])
-	binary.BigEndian.PutUint64(res[16:24], _z[2])
-	binary.BigEndian.PutUint64(res[8:16], _z[3])
-	binary.BigEndian.PutUint64(res[0:8], _z[4])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1001,7 +989,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1012,6 +1010,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 40-byte integer.
+// If e is not a 40-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1147,6 +1160,61 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 40-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[32:40])
+	z[1] = binary.BigEndian.Uint64((*b)[24:32])
+	z[2] = binary.BigEndian.Uint64((*b)[16:24])
+	z[3] = binary.BigEndian.Uint64((*b)[8:16])
+	z[4] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[32:40], e[0])
+	binary.BigEndian.PutUint64((*b)[24:32], e[1])
+	binary.BigEndian.PutUint64((*b)[16:24], e[2])
+	binary.BigEndian.PutUint64((*b)[8:16], e[3])
+	binary.BigEndian.PutUint64((*b)[0:8], e[4])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -190,7 +190,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -849,10 +855,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -987,7 +1001,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -998,7 +1012,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -1176,7 +1176,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 40-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[32:40])
 	z[1] = binary.BigEndian.Uint64((*b)[24:32])
@@ -1190,8 +1189,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[32:40], e[0])
@@ -1199,8 +1198,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[2])
 	binary.BigEndian.PutUint64((*b)[8:16], e[3])
 	binary.BigEndian.PutUint64((*b)[0:8], e[4])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1209,11 +1208,30 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 253       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 253 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -762,10 +762,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -787,7 +787,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -881,7 +881,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1109,29 +1109,29 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		if err := p.X.B1.A1.SetBytes(buf[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+		if err := p.X.B1.A1.SetBytesCanonical(buf[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+		if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 		// p.Y.B1.A1 | p.Y.B1.A0 | p.Y.B0.A1 | p.Y.B0.A0
-		if err := p.Y.B1.A1.SetBytes(buf[fp.Bytes*4 : fp.Bytes*5]); err != nil {
+		if err := p.Y.B1.A1.SetBytesCanonical(buf[fp.Bytes*4 : fp.Bytes*5]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B1.A0.SetBytes(buf[fp.Bytes*5 : fp.Bytes*6]); err != nil {
+		if err := p.Y.B1.A0.SetBytesCanonical(buf[fp.Bytes*5 : fp.Bytes*6]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B0.A1.SetBytes(buf[fp.Bytes*6 : fp.Bytes*7]); err != nil {
+		if err := p.Y.B0.A1.SetBytesCanonical(buf[fp.Bytes*6 : fp.Bytes*7]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B0.A0.SetBytes(buf[fp.Bytes*7 : fp.Bytes*8]); err != nil {
+		if err := p.Y.B0.A0.SetBytesCanonical(buf[fp.Bytes*7 : fp.Bytes*8]); err != nil {
 			return 0, err
 		}
 
@@ -1154,16 +1154,16 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-	if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+	if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+	if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+	if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+	if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 		return 0, err
 	}
 
@@ -1260,16 +1260,16 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-	if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+	if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 		return false, err
 	}
-	if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+	if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 		return false, err
 	}
-	if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+	if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 		return false, err
 	}
-	if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+	if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [5]uint64
 
 const (
-	Limbs = 5         // number of 64 bits words needed to represent a Element
-	Bits  = 317       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 5   // number of 64 bits words needed to represent a Element
+	Bits  = 317 // number of bits needed to represent a Element
+	Bytes = 40  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -190,13 +190,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -965,7 +959,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[32:40], z[0])
 	binary.BigEndian.PutUint64(b[24:32], z[1])
 	binary.BigEndian.PutUint64(b[16:24], z[2])
@@ -982,14 +976,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[32:40], _z[0])
-	binary.BigEndian.PutUint64(res[24:32], _z[1])
-	binary.BigEndian.PutUint64(res[16:24], _z[2])
-	binary.BigEndian.PutUint64(res[8:16], _z[3])
-	binary.BigEndian.PutUint64(res[0:8], _z[4])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1001,7 +989,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1012,6 +1010,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 40-byte integer.
+// If e is not a 40-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1147,6 +1160,61 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 40-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[32:40])
+	z[1] = binary.BigEndian.Uint64((*b)[24:32])
+	z[2] = binary.BigEndian.Uint64((*b)[16:24])
+	z[3] = binary.BigEndian.Uint64((*b)[8:16])
+	z[4] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[32:40], e[0])
+	binary.BigEndian.PutUint64((*b)[24:32], e[1])
+	binary.BigEndian.PutUint64((*b)[16:24], e[2])
+	binary.BigEndian.PutUint64((*b)[8:16], e[3])
+	binary.BigEndian.PutUint64((*b)[0:8], e[4])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -190,7 +190,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -849,10 +855,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -987,7 +1001,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -998,7 +1012,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -1176,7 +1176,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 40-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[32:40])
 	z[1] = binary.BigEndian.Uint64((*b)[24:32])
@@ -1190,8 +1189,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[32:40], e[0])
@@ -1199,8 +1198,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[2])
 	binary.BigEndian.PutUint64((*b)[8:16], e[3])
 	binary.BigEndian.PutUint64((*b)[0:8], e[4])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1209,11 +1208,30 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 255       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 255 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -762,10 +762,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -787,7 +787,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -881,7 +881,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1109,29 +1109,29 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		if err := p.X.B1.A1.SetBytes(buf[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+		if err := p.X.B1.A1.SetBytesCanonical(buf[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+		if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 		// p.Y.B1.A1 | p.Y.B1.A0 | p.Y.B0.A1 | p.Y.B0.A0
-		if err := p.Y.B1.A1.SetBytes(buf[fp.Bytes*4 : fp.Bytes*5]); err != nil {
+		if err := p.Y.B1.A1.SetBytesCanonical(buf[fp.Bytes*4 : fp.Bytes*5]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B1.A0.SetBytes(buf[fp.Bytes*5 : fp.Bytes*6]); err != nil {
+		if err := p.Y.B1.A0.SetBytesCanonical(buf[fp.Bytes*5 : fp.Bytes*6]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B0.A1.SetBytes(buf[fp.Bytes*6 : fp.Bytes*7]); err != nil {
+		if err := p.Y.B0.A1.SetBytesCanonical(buf[fp.Bytes*6 : fp.Bytes*7]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.B0.A0.SetBytes(buf[fp.Bytes*7 : fp.Bytes*8]); err != nil {
+		if err := p.Y.B0.A0.SetBytesCanonical(buf[fp.Bytes*7 : fp.Bytes*8]); err != nil {
 			return 0, err
 		}
 
@@ -1154,16 +1154,16 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-	if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+	if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+	if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+	if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 		return 0, err
 	}
-	if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+	if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 		return 0, err
 	}
 
@@ -1260,16 +1260,16 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-	if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
+	if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0 : fp.Bytes*1]); err != nil {
 		return false, err
 	}
-	if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
+	if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1 : fp.Bytes*2]); err != nil {
 		return false, err
 	}
-	if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+	if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 		return false, err
 	}
-	if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+	if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 254       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 254 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -1098,7 +1098,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 32-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[24:32])
 	z[1] = binary.BigEndian.Uint64((*b)[16:24])
@@ -1111,16 +1110,16 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[24:32], e[0])
 	binary.BigEndian.PutUint64((*b)[16:24], e[1])
 	binary.BigEndian.PutUint64((*b)[8:16], e[2])
 	binary.BigEndian.PutUint64((*b)[0:8], e[3])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1129,11 +1128,28 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -187,7 +187,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -773,10 +779,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -908,7 +922,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -919,7 +933,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [4]uint64
 
 const (
-	Limbs = 4         // number of 64 bits words needed to represent a Element
-	Bits  = 254       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 4   // number of 64 bits words needed to represent a Element
+	Bits  = 254 // number of bits needed to represent a Element
+	Bytes = 32  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -187,13 +187,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -888,7 +882,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[24:32], z[0])
 	binary.BigEndian.PutUint64(b[16:24], z[1])
 	binary.BigEndian.PutUint64(b[8:16], z[2])
@@ -904,13 +898,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[24:32], _z[0])
-	binary.BigEndian.PutUint64(res[16:24], _z[1])
-	binary.BigEndian.PutUint64(res[8:16], _z[2])
-	binary.BigEndian.PutUint64(res[0:8], _z[3])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -922,7 +911,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -933,6 +932,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 32-byte integer.
+// If e is not a 32-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1068,6 +1082,59 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 32-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[24:32])
+	z[1] = binary.BigEndian.Uint64((*b)[16:24])
+	z[2] = binary.BigEndian.Uint64((*b)[8:16])
+	z[3] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[24:32], e[0])
+	binary.BigEndian.PutUint64((*b)[16:24], e[1])
+	binary.BigEndian.PutUint64((*b)[8:16], e[2])
+	binary.BigEndian.PutUint64((*b)[0:8], e[3])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bn254/internal/fptower/e12.go
+++ b/ecc/bn254/internal/fptower/e12.go
@@ -737,51 +737,51 @@ func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	if err := z.C0.B0.A0.SetBytes(e[352 : 352+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A0.SetBytesCanonical(e[352 : 352+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B0.A1.SetBytes(e[320 : 320+fp.Bytes]); err != nil {
+	if err := z.C0.B0.A1.SetBytesCanonical(e[320 : 320+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A0.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A0.SetBytesCanonical(e[288 : 288+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B1.A1.SetBytes(e[256 : 256+fp.Bytes]); err != nil {
+	if err := z.C0.B1.A1.SetBytesCanonical(e[256 : 256+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A0.SetBytes(e[224 : 224+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A0.SetBytesCanonical(e[224 : 224+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C0.B2.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+	if err := z.C0.B2.A1.SetBytesCanonical(e[192 : 192+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A0.SetBytes(e[160 : 160+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A0.SetBytesCanonical(e[160 : 160+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B0.A1.SetBytes(e[128 : 128+fp.Bytes]); err != nil {
+	if err := z.C1.B0.A1.SetBytesCanonical(e[128 : 128+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A0.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A0.SetBytesCanonical(e[96 : 96+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B1.A1.SetBytes(e[64 : 64+fp.Bytes]); err != nil {
+	if err := z.C1.B1.A1.SetBytesCanonical(e[64 : 64+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A0.SetBytes(e[32 : 32+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A0.SetBytesCanonical(e[32 : 32+fp.Bytes]); err != nil {
 		return err
 	}
 
-	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+	if err := z.C1.B2.A1.SetBytesCanonical(e[0 : 0+fp.Bytes]); err != nil {
 		return err
 	}
 

--- a/ecc/bn254/internal/fptower/e12.go
+++ b/ecc/bn254/internal/fptower/e12.go
@@ -732,34 +732,58 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 // SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == 32 * 12
-// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
+// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
 	}
-	z.C0.B0.A0.SetBytes(e[352 : 352+fp.Bytes])
+	if err := z.C0.B0.A0.SetBytes(e[352 : 352+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B0.A1.SetBytes(e[320 : 320+fp.Bytes])
+	if err := z.C0.B0.A1.SetBytes(e[320 : 320+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A0.SetBytes(e[288 : 288+fp.Bytes])
+	if err := z.C0.B1.A0.SetBytes(e[288 : 288+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B1.A1.SetBytes(e[256 : 256+fp.Bytes])
+	if err := z.C0.B1.A1.SetBytes(e[256 : 256+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A0.SetBytes(e[224 : 224+fp.Bytes])
+	if err := z.C0.B2.A0.SetBytes(e[224 : 224+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C0.B2.A1.SetBytes(e[192 : 192+fp.Bytes])
+	if err := z.C0.B2.A1.SetBytes(e[192 : 192+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A0.SetBytes(e[160 : 160+fp.Bytes])
+	if err := z.C1.B0.A0.SetBytes(e[160 : 160+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B0.A1.SetBytes(e[128 : 128+fp.Bytes])
+	if err := z.C1.B0.A1.SetBytes(e[128 : 128+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A0.SetBytes(e[96 : 96+fp.Bytes])
+	if err := z.C1.B1.A0.SetBytes(e[96 : 96+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B1.A1.SetBytes(e[64 : 64+fp.Bytes])
+	if err := z.C1.B1.A1.SetBytes(e[64 : 64+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A0.SetBytes(e[32 : 32+fp.Bytes])
+	if err := z.C1.B2.A0.SetBytes(e[32 : 32+fp.Bytes]); err != nil {
+		return err
+	}
 
-	z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes])
+	if err := z.C1.B2.A1.SetBytes(e[0 : 0+fp.Bytes]); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -94,7 +94,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -102,7 +102,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -120,7 +120,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -141,7 +141,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -750,10 +750,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -775,7 +775,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -869,7 +869,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1040,17 +1040,17 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 		// p.Y.A1 | p.Y.A0
-		if err := p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+		if err := p.Y.A1.SetBytesCanonical(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+		if err := p.Y.A0.SetBytesCanonical(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 
@@ -1073,10 +1073,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return 0, err
 	}
 
@@ -1173,10 +1173,10 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
-	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+	if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 		return false, err
 	}
 

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -94,7 +94,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytes(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -102,7 +102,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytes(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -120,7 +120,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fr.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *[]fp.Element:
@@ -139,7 +141,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fp.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *G1Affine:
@@ -215,7 +219,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -270,7 +278,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -738,8 +750,12 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -759,7 +775,9 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -833,7 +851,7 @@ func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -842,7 +860,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -851,12 +869,14 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }
 
 // SizeOfG2AffineCompressed represents the size in bytes that a G2Affine need in binary form, compressed
@@ -1020,11 +1040,19 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	if mData == mUncompressed {
 		// read X and Y coordinates
 		// p.X.A1 | p.X.A0
-		p.X.A1.SetBytes(buf[:fp.Bytes])
-		p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 		// p.Y.A1 | p.Y.A0
-		p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3])
-		p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4])
+		if err := p.Y.A1.SetBytes(buf[fp.Bytes*2 : fp.Bytes*3]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.A0.SetBytes(buf[fp.Bytes*3 : fp.Bytes*4]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -1045,8 +1073,12 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	p.X.A1.SetBytes(bufX[:fp.Bytes])
-	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
+	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fptower.E2
 
@@ -1122,7 +1154,7 @@ func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -1131,7 +1163,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -1141,12 +1173,16 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 
 	// read X coordinate
 	// p.X.A1 | p.X.A0
-	p.X.A1.SetBytes(bufX[:fp.Bytes])
-	p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+	if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
+	if err := p.X.A0.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		return false, err
+	}
 
 	// store mData in p.Y.A0[0]
 	p.Y.A0[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -1656,7 +1656,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 80-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[72:80])
 	z[1] = binary.BigEndian.Uint64((*b)[64:72])
@@ -1675,8 +1674,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[72:80], e[0])
@@ -1689,8 +1688,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[7])
 	binary.BigEndian.PutUint64((*b)[8:16], e[8])
 	binary.BigEndian.PutUint64((*b)[0:8], e[9])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1699,11 +1698,40 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
+	z[6] = binary.LittleEndian.Uint64((*b)[48:56])
+	z[7] = binary.LittleEndian.Uint64((*b)[56:64])
+	z[8] = binary.LittleEndian.Uint64((*b)[64:72])
+	z[9] = binary.LittleEndian.Uint64((*b)[72:80])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+	binary.LittleEndian.PutUint64((*b)[48:56], e[6])
+	binary.LittleEndian.PutUint64((*b)[56:64], e[7])
+	binary.LittleEndian.PutUint64((*b)[64:72], e[8])
+	binary.LittleEndian.PutUint64((*b)[72:80], e[9])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -205,7 +205,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1319,10 +1325,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1472,7 +1486,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1483,7 +1497,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [10]uint64
 
 const (
-	Limbs = 10        // number of 64 bits words needed to represent a Element
-	Bits  = 633       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 10  // number of 64 bits words needed to represent a Element
+	Bits  = 633 // number of bits needed to represent a Element
+	Bytes = 80  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -205,13 +205,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1440,7 +1434,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[72:80], z[0])
 	binary.BigEndian.PutUint64(b[64:72], z[1])
 	binary.BigEndian.PutUint64(b[56:64], z[2])
@@ -1462,19 +1456,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[72:80], _z[0])
-	binary.BigEndian.PutUint64(res[64:72], _z[1])
-	binary.BigEndian.PutUint64(res[56:64], _z[2])
-	binary.BigEndian.PutUint64(res[48:56], _z[3])
-	binary.BigEndian.PutUint64(res[40:48], _z[4])
-	binary.BigEndian.PutUint64(res[32:40], _z[5])
-	binary.BigEndian.PutUint64(res[24:32], _z[6])
-	binary.BigEndian.PutUint64(res[16:24], _z[7])
-	binary.BigEndian.PutUint64(res[8:16], _z[8])
-	binary.BigEndian.PutUint64(res[0:8], _z[9])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1486,7 +1469,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1497,6 +1490,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 80-byte integer.
+// If e is not a 80-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1632,6 +1640,71 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 80-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[72:80])
+	z[1] = binary.BigEndian.Uint64((*b)[64:72])
+	z[2] = binary.BigEndian.Uint64((*b)[56:64])
+	z[3] = binary.BigEndian.Uint64((*b)[48:56])
+	z[4] = binary.BigEndian.Uint64((*b)[40:48])
+	z[5] = binary.BigEndian.Uint64((*b)[32:40])
+	z[6] = binary.BigEndian.Uint64((*b)[24:32])
+	z[7] = binary.BigEndian.Uint64((*b)[16:24])
+	z[8] = binary.BigEndian.Uint64((*b)[8:16])
+	z[9] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[72:80], e[0])
+	binary.BigEndian.PutUint64((*b)[64:72], e[1])
+	binary.BigEndian.PutUint64((*b)[56:64], e[2])
+	binary.BigEndian.PutUint64((*b)[48:56], e[3])
+	binary.BigEndian.PutUint64((*b)[40:48], e[4])
+	binary.BigEndian.PutUint64((*b)[32:40], e[5])
+	binary.BigEndian.PutUint64((*b)[24:32], e[6])
+	binary.BigEndian.PutUint64((*b)[16:24], e[7])
+	binary.BigEndian.PutUint64((*b)[8:16], e[8])
+	binary.BigEndian.PutUint64((*b)[0:8], e[9])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -190,7 +190,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -849,10 +855,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -987,7 +1001,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -998,7 +1012,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -1176,7 +1176,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 40-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[32:40])
 	z[1] = binary.BigEndian.Uint64((*b)[24:32])
@@ -1190,8 +1189,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[32:40], e[0])
@@ -1199,8 +1198,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[2])
 	binary.BigEndian.PutUint64((*b)[8:16], e[3])
 	binary.BigEndian.PutUint64((*b)[0:8], e[4])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1209,11 +1208,30 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [5]uint64
 
 const (
-	Limbs = 5         // number of 64 bits words needed to represent a Element
-	Bits  = 315       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 5   // number of 64 bits words needed to represent a Element
+	Bits  = 315 // number of bits needed to represent a Element
+	Bytes = 40  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -190,13 +190,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -965,7 +959,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[32:40], z[0])
 	binary.BigEndian.PutUint64(b[24:32], z[1])
 	binary.BigEndian.PutUint64(b[16:24], z[2])
@@ -982,14 +976,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[32:40], _z[0])
-	binary.BigEndian.PutUint64(res[24:32], _z[1])
-	binary.BigEndian.PutUint64(res[16:24], _z[2])
-	binary.BigEndian.PutUint64(res[8:16], _z[3])
-	binary.BigEndian.PutUint64(res[0:8], _z[4])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1001,7 +989,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1012,6 +1010,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 40-byte integer.
+// If e is not a 40-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1147,6 +1160,61 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 40-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[32:40])
+	z[1] = binary.BigEndian.Uint64((*b)[24:32])
+	z[2] = binary.BigEndian.Uint64((*b)[16:24])
+	z[3] = binary.BigEndian.Uint64((*b)[8:16])
+	z[4] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[32:40], e[0])
+	binary.BigEndian.PutUint64((*b)[24:32], e[1])
+	binary.BigEndian.PutUint64((*b)[16:24], e[2])
+	binary.BigEndian.PutUint64((*b)[8:16], e[3])
+	binary.BigEndian.PutUint64((*b)[0:8], e[4])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -777,10 +777,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -802,7 +802,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -896,7 +896,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1063,10 +1063,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -1088,7 +1088,7 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -1182,7 +1182,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytes(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytes(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fr.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *[]fp.Element:
@@ -145,7 +147,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fp.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *G1Affine:
@@ -221,7 +225,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -276,7 +284,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -765,8 +777,12 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -786,7 +802,9 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -860,7 +878,7 @@ func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -869,7 +887,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -878,12 +896,14 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }
 
 // SizeOfG2AffineCompressed represents the size in bytes that a G2Affine need in binary form, compressed
@@ -1043,8 +1063,12 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -1064,7 +1088,9 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -1138,7 +1164,7 @@ func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -1147,7 +1173,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -1156,10 +1182,12 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bw6-756/fp/element.go
+++ b/ecc/bw6-756/fp/element.go
@@ -1890,7 +1890,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 96-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[88:96])
 	z[1] = binary.BigEndian.Uint64((*b)[80:88])
@@ -1911,8 +1910,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[88:96], e[0])
@@ -1927,8 +1926,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[9])
 	binary.BigEndian.PutUint64((*b)[8:16], e[10])
 	binary.BigEndian.PutUint64((*b)[0:8], e[11])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1937,11 +1936,44 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
+	z[6] = binary.LittleEndian.Uint64((*b)[48:56])
+	z[7] = binary.LittleEndian.Uint64((*b)[56:64])
+	z[8] = binary.LittleEndian.Uint64((*b)[64:72])
+	z[9] = binary.LittleEndian.Uint64((*b)[72:80])
+	z[10] = binary.LittleEndian.Uint64((*b)[80:88])
+	z[11] = binary.LittleEndian.Uint64((*b)[88:96])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+	binary.LittleEndian.PutUint64((*b)[48:56], e[6])
+	binary.LittleEndian.PutUint64((*b)[56:64], e[7])
+	binary.LittleEndian.PutUint64((*b)[64:72], e[8])
+	binary.LittleEndian.PutUint64((*b)[72:80], e[9])
+	binary.LittleEndian.PutUint64((*b)[80:88], e[10])
+	binary.LittleEndian.PutUint64((*b)[88:96], e[11])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-756/fp/element.go
+++ b/ecc/bw6-756/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [12]uint64
 
 const (
-	Limbs = 12        // number of 64 bits words needed to represent a Element
-	Bits  = 756       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 12  // number of 64 bits words needed to represent a Element
+	Bits  = 756 // number of bits needed to represent a Element
+	Bytes = 96  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -211,13 +211,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1672,7 +1666,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[88:96], z[0])
 	binary.BigEndian.PutUint64(b[80:88], z[1])
 	binary.BigEndian.PutUint64(b[72:80], z[2])
@@ -1696,21 +1690,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[88:96], _z[0])
-	binary.BigEndian.PutUint64(res[80:88], _z[1])
-	binary.BigEndian.PutUint64(res[72:80], _z[2])
-	binary.BigEndian.PutUint64(res[64:72], _z[3])
-	binary.BigEndian.PutUint64(res[56:64], _z[4])
-	binary.BigEndian.PutUint64(res[48:56], _z[5])
-	binary.BigEndian.PutUint64(res[40:48], _z[6])
-	binary.BigEndian.PutUint64(res[32:40], _z[7])
-	binary.BigEndian.PutUint64(res[24:32], _z[8])
-	binary.BigEndian.PutUint64(res[16:24], _z[9])
-	binary.BigEndian.PutUint64(res[8:16], _z[10])
-	binary.BigEndian.PutUint64(res[0:8], _z[11])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1722,7 +1703,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1733,6 +1724,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 96-byte integer.
+// If e is not a 96-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1868,6 +1874,75 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 96-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[88:96])
+	z[1] = binary.BigEndian.Uint64((*b)[80:88])
+	z[2] = binary.BigEndian.Uint64((*b)[72:80])
+	z[3] = binary.BigEndian.Uint64((*b)[64:72])
+	z[4] = binary.BigEndian.Uint64((*b)[56:64])
+	z[5] = binary.BigEndian.Uint64((*b)[48:56])
+	z[6] = binary.BigEndian.Uint64((*b)[40:48])
+	z[7] = binary.BigEndian.Uint64((*b)[32:40])
+	z[8] = binary.BigEndian.Uint64((*b)[24:32])
+	z[9] = binary.BigEndian.Uint64((*b)[16:24])
+	z[10] = binary.BigEndian.Uint64((*b)[8:16])
+	z[11] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[88:96], e[0])
+	binary.BigEndian.PutUint64((*b)[80:88], e[1])
+	binary.BigEndian.PutUint64((*b)[72:80], e[2])
+	binary.BigEndian.PutUint64((*b)[64:72], e[3])
+	binary.BigEndian.PutUint64((*b)[56:64], e[4])
+	binary.BigEndian.PutUint64((*b)[48:56], e[5])
+	binary.BigEndian.PutUint64((*b)[40:48], e[6])
+	binary.BigEndian.PutUint64((*b)[32:40], e[7])
+	binary.BigEndian.PutUint64((*b)[24:32], e[8])
+	binary.BigEndian.PutUint64((*b)[16:24], e[9])
+	binary.BigEndian.PutUint64((*b)[8:16], e[10])
+	binary.BigEndian.PutUint64((*b)[0:8], e[11])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -1260,7 +1260,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 48-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[40:48])
 	z[1] = binary.BigEndian.Uint64((*b)[32:40])
@@ -1275,8 +1274,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[40:48], e[0])
@@ -1285,8 +1284,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[3])
 	binary.BigEndian.PutUint64((*b)[8:16], e[4])
 	binary.BigEndian.PutUint64((*b)[0:8], e[5])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1295,11 +1294,32 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -193,7 +193,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -931,10 +937,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1072,7 +1086,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1083,7 +1097,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [6]uint64
 
 const (
-	Limbs = 6         // number of 64 bits words needed to represent a Element
-	Bits  = 378       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 6   // number of 64 bits words needed to represent a Element
+	Bits  = 378 // number of bits needed to represent a Element
+	Bytes = 48  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -193,13 +193,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1048,7 +1042,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[40:48], z[0])
 	binary.BigEndian.PutUint64(b[32:40], z[1])
 	binary.BigEndian.PutUint64(b[24:32], z[2])
@@ -1066,15 +1060,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[40:48], _z[0])
-	binary.BigEndian.PutUint64(res[32:40], _z[1])
-	binary.BigEndian.PutUint64(res[24:32], _z[2])
-	binary.BigEndian.PutUint64(res[16:24], _z[3])
-	binary.BigEndian.PutUint64(res[8:16], _z[4])
-	binary.BigEndian.PutUint64(res[0:8], _z[5])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1086,7 +1073,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1097,6 +1094,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 48-byte integer.
+// If e is not a 48-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1232,6 +1244,63 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 48-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[40:48])
+	z[1] = binary.BigEndian.Uint64((*b)[32:40])
+	z[2] = binary.BigEndian.Uint64((*b)[24:32])
+	z[3] = binary.BigEndian.Uint64((*b)[16:24])
+	z[4] = binary.BigEndian.Uint64((*b)[8:16])
+	z[5] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[40:48], e[0])
+	binary.BigEndian.PutUint64((*b)[32:40], e[1])
+	binary.BigEndian.PutUint64((*b)[24:32], e[2])
+	binary.BigEndian.PutUint64((*b)[16:24], e[3])
+	binary.BigEndian.PutUint64((*b)[8:16], e[4])
+	binary.BigEndian.PutUint64((*b)[0:8], e[5])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -783,10 +783,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -808,7 +808,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -902,7 +902,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1075,10 +1075,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -1100,7 +1100,7 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -1194,7 +1194,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytes(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytes(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fr.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *[]fp.Element:
@@ -145,7 +147,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fp.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *G1Affine:
@@ -221,7 +225,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -276,7 +284,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -771,8 +783,12 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -792,7 +808,9 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -866,7 +884,7 @@ func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -875,7 +893,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -884,12 +902,14 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }
 
 // SizeOfG2AffineCompressed represents the size in bytes that a G2Affine need in binary form, compressed
@@ -1055,8 +1075,12 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -1076,7 +1100,9 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -1150,7 +1176,7 @@ func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -1159,7 +1185,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -1168,10 +1194,12 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -1890,7 +1890,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 96-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[88:96])
 	z[1] = binary.BigEndian.Uint64((*b)[80:88])
@@ -1911,8 +1910,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[88:96], e[0])
@@ -1927,8 +1926,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[9])
 	binary.BigEndian.PutUint64((*b)[8:16], e[10])
 	binary.BigEndian.PutUint64((*b)[0:8], e[11])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1937,11 +1936,44 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
+	z[6] = binary.LittleEndian.Uint64((*b)[48:56])
+	z[7] = binary.LittleEndian.Uint64((*b)[56:64])
+	z[8] = binary.LittleEndian.Uint64((*b)[64:72])
+	z[9] = binary.LittleEndian.Uint64((*b)[72:80])
+	z[10] = binary.LittleEndian.Uint64((*b)[80:88])
+	z[11] = binary.LittleEndian.Uint64((*b)[88:96])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+	binary.LittleEndian.PutUint64((*b)[48:56], e[6])
+	binary.LittleEndian.PutUint64((*b)[56:64], e[7])
+	binary.LittleEndian.PutUint64((*b)[64:72], e[8])
+	binary.LittleEndian.PutUint64((*b)[72:80], e[9])
+	binary.LittleEndian.PutUint64((*b)[80:88], e[10])
+	binary.LittleEndian.PutUint64((*b)[88:96], e[11])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -45,9 +45,9 @@ import (
 type Element [12]uint64
 
 const (
-	Limbs = 12        // number of 64 bits words needed to represent a Element
-	Bits  = 761       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 12  // number of 64 bits words needed to represent a Element
+	Bits  = 761 // number of bits needed to represent a Element
+	Bytes = 96  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -211,13 +211,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fp.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1672,7 +1666,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[88:96], z[0])
 	binary.BigEndian.PutUint64(b[80:88], z[1])
 	binary.BigEndian.PutUint64(b[72:80], z[2])
@@ -1696,21 +1690,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[88:96], _z[0])
-	binary.BigEndian.PutUint64(res[80:88], _z[1])
-	binary.BigEndian.PutUint64(res[72:80], _z[2])
-	binary.BigEndian.PutUint64(res[64:72], _z[3])
-	binary.BigEndian.PutUint64(res[56:64], _z[4])
-	binary.BigEndian.PutUint64(res[48:56], _z[5])
-	binary.BigEndian.PutUint64(res[40:48], _z[6])
-	binary.BigEndian.PutUint64(res[32:40], _z[7])
-	binary.BigEndian.PutUint64(res[24:32], _z[8])
-	binary.BigEndian.PutUint64(res[16:24], _z[9])
-	binary.BigEndian.PutUint64(res[8:16], _z[10])
-	binary.BigEndian.PutUint64(res[0:8], _z[11])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1722,7 +1703,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1733,6 +1724,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 96-byte integer.
+// If e is not a 96-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fp.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1868,6 +1874,75 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 96-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[88:96])
+	z[1] = binary.BigEndian.Uint64((*b)[80:88])
+	z[2] = binary.BigEndian.Uint64((*b)[72:80])
+	z[3] = binary.BigEndian.Uint64((*b)[64:72])
+	z[4] = binary.BigEndian.Uint64((*b)[56:64])
+	z[5] = binary.BigEndian.Uint64((*b)[48:56])
+	z[6] = binary.BigEndian.Uint64((*b)[40:48])
+	z[7] = binary.BigEndian.Uint64((*b)[32:40])
+	z[8] = binary.BigEndian.Uint64((*b)[24:32])
+	z[9] = binary.BigEndian.Uint64((*b)[16:24])
+	z[10] = binary.BigEndian.Uint64((*b)[8:16])
+	z[11] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fp.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[88:96], e[0])
+	binary.BigEndian.PutUint64((*b)[80:88], e[1])
+	binary.BigEndian.PutUint64((*b)[72:80], e[2])
+	binary.BigEndian.PutUint64((*b)[64:72], e[3])
+	binary.BigEndian.PutUint64((*b)[56:64], e[4])
+	binary.BigEndian.PutUint64((*b)[48:56], e[5])
+	binary.BigEndian.PutUint64((*b)[40:48], e[6])
+	binary.BigEndian.PutUint64((*b)[32:40], e[7])
+	binary.BigEndian.PutUint64((*b)[24:32], e[8])
+	binary.BigEndian.PutUint64((*b)[16:24], e[9])
+	binary.BigEndian.PutUint64((*b)[8:16], e[10])
+	binary.BigEndian.PutUint64((*b)[0:8], e[11])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -1260,7 +1260,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 48-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[40:48])
 	z[1] = binary.BigEndian.Uint64((*b)[32:40])
@@ -1275,8 +1274,8 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[40:48], e[0])
@@ -1285,8 +1284,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	binary.BigEndian.PutUint64((*b)[16:24], e[3])
 	binary.BigEndian.PutUint64((*b)[8:16], e[4])
 	binary.BigEndian.PutUint64((*b)[0:8], e[5])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -1295,11 +1294,32 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
+	z[1] = binary.LittleEndian.Uint64((*b)[8:16])
+	z[2] = binary.LittleEndian.Uint64((*b)[16:24])
+	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
+	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
+	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+	binary.LittleEndian.PutUint64((*b)[8:16], e[1])
+	binary.LittleEndian.PutUint64((*b)[16:24], e[2])
+	binary.LittleEndian.PutUint64((*b)[24:32], e[3])
+	binary.LittleEndian.PutUint64((*b)[32:40], e[4])
+	binary.LittleEndian.PutUint64((*b)[40:48], e[5])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -193,7 +193,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -931,10 +937,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -1072,7 +1086,7 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1083,7 +1097,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -45,9 +45,9 @@ import (
 type Element [6]uint64
 
 const (
-	Limbs = 6         // number of 64 bits words needed to represent a Element
-	Bits  = 377       // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 6   // number of 64 bits words needed to represent a Element
+	Bits  = 377 // number of bits needed to represent a Element
+	Bytes = 48  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -193,13 +193,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set fr.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -1048,7 +1042,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[40:48], z[0])
 	binary.BigEndian.PutUint64(b[32:40], z[1])
 	binary.BigEndian.PutUint64(b[24:32], z[2])
@@ -1066,15 +1060,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[40:48], _z[0])
-	binary.BigEndian.PutUint64(res[32:40], _z[1])
-	binary.BigEndian.PutUint64(res[24:32], _z[2])
-	binary.BigEndian.PutUint64(res[16:24], _z[3])
-	binary.BigEndian.PutUint64(res[8:16], _z[4])
-	binary.BigEndian.PutUint64(res[0:8], _z[5])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -1086,7 +1073,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
+		// fast path
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
+	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -1097,6 +1094,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 48-byte integer.
+// If e is not a 48-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid fr.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -1232,6 +1244,63 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 48-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[40:48])
+	z[1] = binary.BigEndian.Uint64((*b)[32:40])
+	z[2] = binary.BigEndian.Uint64((*b)[24:32])
+	z[3] = binary.BigEndian.Uint64((*b)[16:24])
+	z[4] = binary.BigEndian.Uint64((*b)[8:16])
+	z[5] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid fr.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[40:48], e[0])
+	binary.BigEndian.PutUint64((*b)[32:40], e[1])
+	binary.BigEndian.PutUint64((*b)[24:32], e[2])
+	binary.BigEndian.PutUint64((*b)[16:24], e[3])
+	binary.BigEndian.PutUint64((*b)[8:16], e[4])
+	binary.BigEndian.PutUint64((*b)[0:8], e[5])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -147,7 +147,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -783,10 +783,10 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -808,7 +808,7 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -902,7 +902,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]
@@ -1075,10 +1075,10 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+		if err := p.Y.SetBytesCanonical(buf[fp.Bytes : fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 
@@ -1100,7 +1100,7 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return 0, err
 	}
 
@@ -1194,7 +1194,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err er
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+	if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 		return false, err
 	}
 	// store mData in p.Y[0]

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -100,7 +100,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytes(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -108,7 +108,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytes(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -126,7 +126,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fr.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *[]fp.Element:
@@ -145,7 +147,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fp.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *G1Affine:
@@ -221,7 +225,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -276,7 +284,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -771,8 +783,12 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -792,7 +808,9 @@ func (p *G1Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -866,7 +884,7 @@ func (p *G1Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -875,7 +893,7 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -884,12 +902,14 @@ func (p *G1Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }
 
 // SizeOfG2AffineCompressed represents the size in bytes that a G2Affine need in binary form, compressed
@@ -1055,8 +1075,12 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	// uncompressed point
 	if mData == mUncompressed {
 		// read X and Y coordinates
-		p.X.SetBytes(buf[:fp.Bytes])
-		p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2])
+		if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.Y.SetBytes(buf[fp.Bytes : fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 
 		// subgroup check
 		if subGroupCheck && !p.IsInSubGroup() {
@@ -1076,7 +1100,9 @@ func (p *G2Affine) setBytes(buf []byte, subGroupCheck bool) (int, error) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return 0, err
+	}
 
 	var YSquared, Y fp.Element
 
@@ -1150,7 +1176,7 @@ func (p *G2Affine) unsafeComputeY(subGroupCheck bool) error {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
+func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error) {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -1159,7 +1185,7 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -1168,10 +1194,12 @@ func (p *G2Affine) unsafeSetCompressedBytes(buf []byte) (isInfinity bool) {
 	bufX[0] &= ^mMask
 
 	// read X coordinate
-	p.X.SetBytes(bufX[:fp.Bytes])
+	if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		return false, err
+	}
 	// store mData in p.Y[0]
 	p.Y[0] = uint64(mData)
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -49,7 +49,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -179,7 +179,13 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		return z.SetBytes(c1), nil
+		if err := z.SetBytes(c1); err != nil {
+			vv := bigIntPool.Get().(*big.Int)
+			defer bigIntPool.Put(vv)
+			vv.SetBytes(c1)
+			return z.SetBigInt(vv), nil
+		}
+		return z, nil
 	default:
 		return nil, errors.New("can't set goldilocks.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -578,10 +584,18 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 		return nil, err
 	}
 
+	// get temporary big int from the pool
+	vv := bigIntPool.Get().(*big.Int)
+
 	res := make([]Element, count)
 	for i := 0; i < count; i++ {
-		res[i].SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		vv.SetBytes(pseudoRandomBytes[i*L : (i+1)*L])
+		res[i].SetBigInt(vv)
 	}
+
+	// release object into pool
+	bigIntPool.Put(vv)
+
 	return res, nil
 }
 
@@ -698,11 +712,12 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) *Element {
+func (z *Element) SetBytes(e []byte) error {
 	if len(e) == 8 {
 		// fast path
 		z[0] = binary.BigEndian.Uint64(e)
-		return z.ToMont()
+		z.ToMont()
+		return nil
 	}
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
@@ -714,7 +729,7 @@ func (z *Element) SetBytes(e []byte) *Element {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 // SetBigInt sets z to v and returns z

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -891,7 +891,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian 8-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
-
 	var z Element
 	z[0] = binary.BigEndian.Uint64((*b)[0:8])
 
@@ -901,13 +900,13 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
 	e.FromMont()
 	binary.BigEndian.PutUint64((*b)[0:8], e[0])
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 // LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
@@ -916,11 +915,22 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	var z Element
+	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
 
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid goldilocks.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.LittleEndian.PutUint64((*b)[0:8], e[0])
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -45,9 +45,9 @@ import (
 type Element [1]uint64
 
 const (
-	Limbs = 1         // number of 64 bits words needed to represent a Element
-	Bits  = 64        // number of bits needed to represent a Element
-	Bytes = Limbs * 8 // number of bytes needed to represent a Element
+	Limbs = 1  // number of 64 bits words needed to represent a Element
+	Bits  = 64 // number of bits needed to represent a Element
+	Bytes = 8  // number of bytes needed to represent a Element
 )
 
 // Field modulus q
@@ -179,13 +179,7 @@ func (z *Element) SetInterface(i1 interface{}) (*Element, error) {
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set goldilocks.Element from type " + reflect.TypeOf(i1).String())
 	}
@@ -684,7 +678,7 @@ func (z *Element) Text(base int) string {
 
 // ToBigInt returns z as a big.Int in Montgomery form
 func (z *Element) ToBigInt(res *big.Int) *big.Int {
-	var b [Limbs * 8]byte
+	var b [Bytes]byte
 	binary.BigEndian.PutUint64(b[0:8], z[0])
 
 	return res.SetBytes(b[:])
@@ -697,10 +691,8 @@ func (z Element) ToBigIntRegular(res *big.Int) *big.Int {
 }
 
 // Bytes returns the value of z as a big-endian byte array
-func (z *Element) Bytes() (res [Limbs * 8]byte) {
-	_z := z.ToRegular()
-	binary.BigEndian.PutUint64(res[0:8], _z[0])
-
+func (z *Element) Bytes() (res [Bytes]byte) {
+	BigEndian.PutElement(&res, *z)
 	return
 }
 
@@ -712,13 +704,17 @@ func (z *Element) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *Element) SetBytes(e []byte) error {
-	if len(e) == 8 {
+func (z *Element) SetBytes(e []byte) *Element {
+	if len(e) == Bytes {
 		// fast path
-		z[0] = binary.BigEndian.Uint64(e)
-		z.ToMont()
-		return nil
+		v, err := BigEndian.Element((*[Bytes]byte)(e))
+		if err == nil {
+			*z = v
+			return z
+		}
 	}
+
+	// slow path.
 	// get a big int from our pool
 	vv := bigIntPool.Get().(*big.Int)
 	vv.SetBytes(e)
@@ -729,6 +725,21 @@ func (z *Element) SetBytes(e []byte) error {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
+	return z
+}
+
+// SetBytesCanonical interprets e as the bytes of a big-endian 8-byte integer.
+// If e is not a 8-byte slice or encodes a value higher than q,
+// SetBytesCanonical returns an error.
+func (z *Element) SetBytesCanonical(e []byte) error {
+	if len(e) != Bytes {
+		return errors.New("invalid goldilocks.Element encoding")
+	}
+	v, err := BigEndian.Element((*[Bytes]byte)(e))
+	if err != nil {
+		return err
+	}
+	*z = v
 	return nil
 }
 
@@ -864,6 +875,53 @@ func (z *Element) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+// A ByteOrder specifies how to convert byte slices into a Element
+type ByteOrder interface {
+	Element(*[Bytes]byte) (Element, error)
+	PutElement(*[Bytes]byte, Element)
+	String() string
+}
+
+// BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
+var BigEndian bigEndian
+
+type bigEndian struct{}
+
+// Element interpret b is a big-endian 8-byte slice.
+// If b encodes a value higher than q, Element returns error.
+func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
+
+	var z Element
+	z[0] = binary.BigEndian.Uint64((*b)[0:8])
+
+	if !z.smallerThanModulus() {
+		return Element{}, errors.New("invalid goldilocks.Element encoding")
+	}
+
+	z.ToMont()
+	return z, nil
+
+}
+func (bigEndian) PutElement(b *[Bytes]byte, e Element) {
+	e.FromMont()
+	binary.BigEndian.PutUint64((*b)[0:8], e[0])
+
+}
+func (bigEndian) String() string { return "BigEndian" }
+
+// LittleEndian is the little-endian implementation of ByteOrder and AppendByteOrder.
+var LittleEndian littleEndian
+
+type littleEndian struct{}
+
+func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
+	panic("not implemented")
+}
+func (littleEndian) PutElement(b *[Bytes]byte, e Element) {
+
+}
+func (littleEndian) String() string { return "LittleEndian" }
 
 // Legendre returns the Legendre symbol of z (either +1, -1, or 0.)
 func (z *Element) Legendre() int {

--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -41,6 +41,7 @@ type FieldConfig struct {
 	ModulusHex                string
 	NbWords                   int
 	NbBits                    int
+	NbBytes                   int
 	NbWordsLastIndex          int
 	NbWordsIndexesNoZero      []int
 	NbWordsIndexesFull        []int
@@ -96,6 +97,7 @@ func NewFieldConfig(packageName, elementName, modulus string, useAddChain bool) 
 	// pre compute field constants
 	F.NbBits = bModulus.BitLen()
 	F.NbWords = len(bModulus.Bits())
+	F.NbBytes = F.NbWords * 8 // (F.NbBits + 7) / 8
 
 	F.NbWordsLastIndex = F.NbWords - 1
 

--- a/internal/field/internal/templates/element/base.go
+++ b/internal/field/internal/templates/element/base.go
@@ -33,7 +33,7 @@ type {{.ElementName}} [{{.NbWords}}]uint64
 const (
 	Limbs = {{.NbWords}} 	// number of 64 bits words needed to represent a {{.ElementName}}
 	Bits = {{.NbBits}} 		// number of bits needed to represent a {{.ElementName}}
-	Bytes = Limbs * 8 		// number of bytes needed to represent a {{.ElementName}}
+	Bytes = {{.NbBytes}} 	// number of bytes needed to represent a {{.ElementName}}
 )
 
 
@@ -171,13 +171,7 @@ func (z *{{.ElementName}}) SetInterface(i1 interface{}) (*{{.ElementName}}, erro
 	case big.Int:
 		return z.SetBigInt(&c1), nil
 	case []byte:
-		if err := z.SetBytes(c1); err != nil {
-			vv := bigIntPool.Get().(*big.Int)
-			defer bigIntPool.Put(vv)
-			vv.SetBytes(c1)
-			return z.SetBigInt(vv), nil
-		}
-		return z, nil
+		return z.SetBytes(c1), nil
 	default:
 		return nil, errors.New("can't set {{.PackageName}}.{{.ElementName}} from type " + reflect.TypeOf(i1).String())
 	}

--- a/internal/field/internal/templates/element/conv.go
+++ b/internal/field/internal/templates/element/conv.go
@@ -300,7 +300,6 @@ type bigEndian struct{}
 // Element interpret b is a big-endian {{.NbBytes}}-byte slice.
 // If b encodes a value higher than q, Element returns error.
 func (bigEndian) Element(b *[Bytes]byte) ({{.ElementName}}, error) {
-
 	var z {{.ElementName}}
 	{{- range $i := reverse .NbWordsIndexesFull}}
 		{{- $j := mul $i 8}}
@@ -316,8 +315,8 @@ func (bigEndian) Element(b *[Bytes]byte) ({{.ElementName}}, error) {
 
 	z.ToMont()
 	return z, nil
-
 }
+
 func (bigEndian) PutElement(b *[Bytes]byte, e {{.ElementName}})  {
 	e.FromMont()
 
@@ -328,9 +327,8 @@ func (bigEndian) PutElement(b *[Bytes]byte, e {{.ElementName}})  {
 		{{- $jj := add $j 8}}
 		binary.BigEndian.PutUint64((*b)[{{$j}}:{{$jj}}], e[{{$k}}])
 	{{- end}}
-
-
 }
+
 func (bigEndian) String() string { return "BigEndian" }
 
 
@@ -341,11 +339,31 @@ var LittleEndian littleEndian
 type littleEndian struct{}
 
 func (littleEndian) Element(b *[Bytes]byte) ({{.ElementName}}, error) {
-	panic("not implemented")
-}
-func (littleEndian) PutElement(b *[Bytes]byte, e {{.ElementName}})  {
+	var z {{.ElementName}}
+	{{- range $i := .NbWordsIndexesFull}}
+		{{- $j := mul $i 8}}
+		{{- $jj := add $j 8}}
+		z[{{$i}}] = binary.LittleEndian.Uint64((*b)[{{$j}}:{{$jj}}])
+	{{- end}}
 
+	if !z.smallerThanModulus() {
+		return {{.ElementName}}{}, errors.New("invalid {{.PackageName}}.{{.ElementName}} encoding")
+	}
+
+	z.ToMont()
+	return z, nil
 }
+
+func (littleEndian) PutElement(b *[Bytes]byte, e {{.ElementName}})  {
+	e.FromMont()
+
+	{{- range $i := .NbWordsIndexesFull}}
+		{{- $j := mul $i 8}}
+		{{- $jj := add $j 8}}
+		binary.LittleEndian.PutUint64((*b)[{{$j}}:{{$jj}}], e[{{$i}}])
+	{{- end}}
+}
+
 func (littleEndian) String() string { return "LittleEndian" }
 
 

--- a/internal/field/internal/templates/element/conv.go
+++ b/internal/field/internal/templates/element/conv.go
@@ -117,12 +117,13 @@ func (z *{{.ElementName}}) Marshal() []byte {
 
 // SetBytes interprets e as the bytes of a big-endian unsigned integer,
 // sets z to that value, and returns z.
-func (z *{{.ElementName}}) SetBytes(e []byte) *{{.ElementName}} {
+func (z *{{.ElementName}}) SetBytes(e []byte) error {
 	{{- if eq .NbWords 1}}
 	if len(e) == 8 {
 		// fast path
 		z[0] = binary.BigEndian.Uint64(e)
-		return z.ToMont()
+		z.ToMont()
+		return nil
 	}
 	{{- end}}
 	// get a big int from our pool
@@ -135,7 +136,7 @@ func (z *{{.ElementName}}) SetBytes(e []byte) *{{.ElementName}} {
 	// put temporary object back in pool
 	bigIntPool.Put(vv)
 
-	return z
+	return nil
 }
 
 
@@ -272,6 +273,9 @@ func (z *{{.ElementName}}) UnmarshalJSON(data []byte) error {
 	bigIntPool.Put(vv)
 	return nil
 }
+
+
+
 
 
 `

--- a/internal/generator/config/curve.go
+++ b/internal/generator/config/curve.go
@@ -90,7 +90,7 @@ func newFieldInfo(modulus string) Field {
 	}
 
 	F.Bits = bModulus.BitLen()
-	F.Bytes = len(bModulus.Bits()) * 8
+	F.Bytes = (F.Bits + 7) / 8
 	F.Modulus = func() *big.Int { return new(big.Int).Set(&bModulus) }
 	return F
 }

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -106,7 +106,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytesCanonical(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -114,7 +114,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		err = t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -132,7 +132,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
 				return
 			}
 		}
@@ -153,7 +153,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return
 			}
 		}
@@ -743,51 +743,51 @@ func (p *{{ $.TAffine }}) setBytes(buf []byte, subGroupCheck bool) (int, error) 
 		// read X and Y coordinates
 		{{- if eq $.CoordType "fptower.E2"}}
 			// p.X.A1 | p.X.A0
-			if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+			if err := p.X.A1.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return 0, err
 			}
-			if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+			if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes:fp.Bytes*2]); err != nil {
 				return 0, err
 			}
 			// p.Y.A1 | p.Y.A0
-			if err := p.Y.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+			if err := p.Y.A1.SetBytesCanonical(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
 				return 0, err
 			}
-			if err := p.Y.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+			if err := p.Y.A0.SetBytesCanonical(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
 				return 0, err
 			}
 		{{- else if eq $.CoordType "fptower.E4"}}	
 			// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-			if err := p.X.B1.A1.SetBytes(buf[fp.Bytes*0:fp.Bytes*1]); err != nil {
+			if err := p.X.B1.A1.SetBytesCanonical(buf[fp.Bytes*0:fp.Bytes*1]); err != nil {
 				return 0, err
 			}
-			if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+			if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
 				return 0, err
 			}
-			if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+			if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
 				return 0, err
 			}
-			if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+			if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
 				return 0, err
 			}
 			// p.Y.B1.A1 | p.Y.B1.A0 | p.Y.B0.A1 | p.Y.B0.A0
-			if err := p.Y.B1.A1.SetBytes(buf[fp.Bytes*4:fp.Bytes*5]); err != nil {
+			if err := p.Y.B1.A1.SetBytesCanonical(buf[fp.Bytes*4:fp.Bytes*5]); err != nil {
 				return 0, err
 			}
-			if err := p.Y.B1.A0.SetBytes(buf[fp.Bytes*5:fp.Bytes*6]); err != nil {
+			if err := p.Y.B1.A0.SetBytesCanonical(buf[fp.Bytes*5:fp.Bytes*6]); err != nil {
 				return 0, err
 			}
-			if err := p.Y.B0.A1.SetBytes(buf[fp.Bytes*6:fp.Bytes*7]); err != nil {
+			if err := p.Y.B0.A1.SetBytesCanonical(buf[fp.Bytes*6:fp.Bytes*7]); err != nil {
 				return 0, err
 			}
-			if err := p.Y.B0.A0.SetBytes(buf[fp.Bytes*7:fp.Bytes*8]); err != nil {
+			if err := p.Y.B0.A0.SetBytesCanonical(buf[fp.Bytes*7:fp.Bytes*8]); err != nil {
 				return 0, err
 			}
 		{{- else}}
-			if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+			if err := p.X.SetBytesCanonical(buf[:fp.Bytes]); err != nil {
 				return 0, err
 			}
-			if err := p.Y.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+			if err := p.Y.SetBytesCanonical(buf[fp.Bytes:fp.Bytes*2]); err != nil {
 				return 0, err
 			}
 		{{- end}}
@@ -812,28 +812,28 @@ func (p *{{ $.TAffine }}) setBytes(buf []byte, subGroupCheck bool) (int, error) 
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 			return 0, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes:fp.Bytes*2]); err != nil {
 			return 0, err
 		}
 	{{- else if eq $.CoordType "fptower.E4"}}
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
+		if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+		if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+		if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
 			return 0, err
 		}
-		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+		if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
 			return 0, err
 		}
 	{{- else}}
-		if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 			return 0, err
 		}
 	{{- end}}
@@ -957,10 +957,10 @@ func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool,
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
 		// p.X.A1 | p.X.A0
-		if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+		if err := p.X.A1.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 			return false, err
 		}
-		if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+		if err := p.X.A0.SetBytesCanonical(buf[fp.Bytes:fp.Bytes*2]); err != nil {
 			return false, err
 		}
 		
@@ -968,23 +968,23 @@ func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool,
 		p.Y.A0[0] = uint64(mData)
 	{{- else if eq $.CoordType "fptower.E4"}}
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
+		if err := p.X.B1.A1.SetBytesCanonical(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
 			return false, err
 		}
-		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+		if err := p.X.B1.A0.SetBytesCanonical(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
 			return false, err
 		}
-		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+		if err := p.X.B0.A1.SetBytesCanonical(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
 			return false, err
 		}
-		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+		if err := p.X.B0.A0.SetBytesCanonical(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
 			return false, err
 		}
 		
 		// store mData in p.Y.B0.A0[0]
 		p.Y.B0.A0[0] = uint64(mData)
 	{{- else}}
-		if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+		if err := p.X.SetBytesCanonical(bufX[:fp.Bytes]); err != nil {
 			return false, err
 		}
 		// store mData in p.Y[0]

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -106,7 +106,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fr.Bytes])
+		err = t.SetBytes(buf[:fr.Bytes])
 		return
 	case *fp.Element:
 		read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
@@ -114,7 +114,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		t.SetBytes(buf[:fp.Bytes])
+		err = t.SetBytes(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
 		var sliceLen uint32
@@ -132,7 +132,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fr.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fr.Bytes]); err != nil {
+				return
+			}
 		}
 		return
 	case *[]fp.Element:
@@ -151,7 +153,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i].SetBytes(buf[:fp.Bytes])
+			if err = (*t)[i].SetBytes(buf[:fp.Bytes]); err != nil {
+				return
+			}
 		}
 		return 
 	case *G1Affine:
@@ -227,7 +231,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool 
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return 
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -282,7 +290,11 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 					return
 				}
 			} else {
-				compressed[i] = !((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]))
+				var r bool
+				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+					return
+				}
+				compressed[i] = !r
 			}
 		}
 		var nbErrs uint64
@@ -731,25 +743,53 @@ func (p *{{ $.TAffine }}) setBytes(buf []byte, subGroupCheck bool) (int, error) 
 		// read X and Y coordinates
 		{{- if eq $.CoordType "fptower.E2"}}
 			// p.X.A1 | p.X.A0
-			p.X.A1.SetBytes(buf[:fp.Bytes])
-			p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
+			if err := p.X.A1.SetBytes(buf[:fp.Bytes]); err != nil {
+				return 0, err
+			}
+			if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+				return 0, err
+			}
 			// p.Y.A1 | p.Y.A0
-			p.Y.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3])
-			p.Y.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4])
+			if err := p.Y.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+				return 0, err
+			}
+			if err := p.Y.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+				return 0, err
+			}
 		{{- else if eq $.CoordType "fptower.E4"}}	
 			// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-			p.X.B1.A1.SetBytes(buf[fp.Bytes*0:fp.Bytes*1])
-			p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2])
-			p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3])
-			p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4])
+			if err := p.X.B1.A1.SetBytes(buf[fp.Bytes*0:fp.Bytes*1]); err != nil {
+				return 0, err
+			}
+			if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+				return 0, err
+			}
+			if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+				return 0, err
+			}
+			if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+				return 0, err
+			}
 			// p.Y.B1.A1 | p.Y.B1.A0 | p.Y.B0.A1 | p.Y.B0.A0
-			p.Y.B1.A1.SetBytes(buf[fp.Bytes*4:fp.Bytes*5])
-			p.Y.B1.A0.SetBytes(buf[fp.Bytes*5:fp.Bytes*6])
-			p.Y.B0.A1.SetBytes(buf[fp.Bytes*6:fp.Bytes*7])
-			p.Y.B0.A0.SetBytes(buf[fp.Bytes*7:fp.Bytes*8])
+			if err := p.Y.B1.A1.SetBytes(buf[fp.Bytes*4:fp.Bytes*5]); err != nil {
+				return 0, err
+			}
+			if err := p.Y.B1.A0.SetBytes(buf[fp.Bytes*5:fp.Bytes*6]); err != nil {
+				return 0, err
+			}
+			if err := p.Y.B0.A1.SetBytes(buf[fp.Bytes*6:fp.Bytes*7]); err != nil {
+				return 0, err
+			}
+			if err := p.Y.B0.A0.SetBytes(buf[fp.Bytes*7:fp.Bytes*8]); err != nil {
+				return 0, err
+			}
 		{{- else}}
-			p.X.SetBytes(buf[:fp.Bytes])
-			p.Y.SetBytes(buf[fp.Bytes:fp.Bytes*2])
+			if err := p.X.SetBytes(buf[:fp.Bytes]); err != nil {
+				return 0, err
+			}
+			if err := p.Y.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+				return 0, err
+			}
 		{{- end}}
 
 		// subgroup check 
@@ -772,16 +812,30 @@ func (p *{{ $.TAffine }}) setBytes(buf []byte, subGroupCheck bool) (int, error) 
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
 		// p.X.A1 | p.X.A0
-		p.X.A1.SetBytes(bufX[:fp.Bytes])
-		p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
+		if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+			return 0, err
+		}
+		if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+			return 0, err
+		}
 	{{- else if eq $.CoordType "fptower.E4"}}
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1])
-		p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2])
-		p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3])
-		p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4])
+		if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
+			return 0, err
+		}
+		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+			return 0, err
+		}
+		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+			return 0, err
+		}
+		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+			return 0, err
+		}
 	{{- else}}
-		p.X.SetBytes(bufX[:fp.Bytes])
+		if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+			return 0, err
+		}
 	{{- end}}
 
 
@@ -883,7 +937,7 @@ func (p *{{ $.TAffine }}) unsafeComputeY(subGroupCheck bool) error  {
 // assumes buf[:8] mask is set to compressed
 // returns true if point is infinity and need no further processing
 // it sets X coordinate and uses Y for scratch space to store decompression metadata
-func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool)  {
+func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool, err error)  {
 
 	// read the most significant byte
 	mData := buf[0] & mMask
@@ -892,7 +946,7 @@ func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool)
 		p.X.SetZero()
 		p.Y.SetZero()
 		isInfinity = true
-		return
+		return isInfinity, nil
 	}
 
 	// we need to copy the input buffer (to keep this method thread safe)
@@ -903,28 +957,42 @@ func (p *{{ $.TAffine }}) unsafeSetCompressedBytes(buf []byte) (isInfinity bool)
 	// read X coordinate
 	{{- if eq $.CoordType "fptower.E2"}}
 		// p.X.A1 | p.X.A0
-		p.X.A1.SetBytes(bufX[:fp.Bytes])
-		p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2])
+		if err := p.X.A1.SetBytes(bufX[:fp.Bytes]); err != nil {
+			return false, err
+		}
+		if err := p.X.A0.SetBytes(buf[fp.Bytes:fp.Bytes*2]); err != nil {
+			return false, err
+		}
 		
 		// store mData in p.Y.A0[0]
 		p.Y.A0[0] = uint64(mData)
 	{{- else if eq $.CoordType "fptower.E4"}}
 		// p.X.B1.A1 | p.X.B1.A0 | p.X.B0.A1 | p.X.B0.A0
-		p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1])
-		p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2])
-		p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3])
-		p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4])
+		if err := p.X.B1.A1.SetBytes(bufX[fp.Bytes*0:fp.Bytes*1]); err != nil {
+			return false, err
+		}
+		if err := p.X.B1.A0.SetBytes(buf[fp.Bytes*1:fp.Bytes*2]); err != nil {
+			return false, err
+		}
+		if err := p.X.B0.A1.SetBytes(buf[fp.Bytes*2:fp.Bytes*3]); err != nil {
+			return false, err
+		}
+		if err := p.X.B0.A0.SetBytes(buf[fp.Bytes*3:fp.Bytes*4]); err != nil {
+			return false, err
+		}
 		
 		// store mData in p.Y.B0.A0[0]
 		p.Y.B0.A0[0] = uint64(mData)
 	{{- else}}
-		p.X.SetBytes(bufX[:fp.Bytes])
+		if err := p.X.SetBytes(bufX[:fp.Bytes]); err != nil {
+			return false, err
+		}
 		// store mData in p.Y[0]
 		p.Y[0] = uint64(mData)
 	{{- end}}
 
 	// recomputing Y will be done asynchronously
-	return
+	return isInfinity, nil
 }
 
 

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -33,7 +33,7 @@ const (
 	mUnmask             = 0x7f
 
 	// size in byte of a compressed point (point.Y --> fr.Element)
-	sizePointCompressed = fr.Limbs * 8
+	sizePointCompressed = fr.Bytes
 )
 
 // Bytes returns the compressed point as a byte array

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -777,7 +777,7 @@ func (z *E12) IsInSubGroup() bool {
 {{end}}
 
 {{define "readFp"}}
-	if err := {{$.To}}.SetBytes(e[{{$.OffSet}}:{{$.OffSet}} + fp.Bytes]); err != nil {
+	if err := {{$.To}}.SetBytesCanonical(e[{{$.OffSet}}:{{$.OffSet}} + fp.Bytes]); err != nil {
 		return err
 	}
 {{end}}

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -690,7 +690,7 @@ func (z *E12) Bytes() (r [SizeOfGT]byte) {
 // SetBytes interprets e as the bytes of a big-endian GT
 // sets z to that value (in Montgomery form), and returns z.
 // size(e) == {{ $sizeOfFp }} * 12
-// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
+// z.C1.B2.A1 | z.C1.B2.A0 | z.C1.B1.A1 | ...
 func (z *E12) SetBytes(e []byte) error {
 	if len(e) != SizeOfGT {
 		return errors.New("invalid buffer size")
@@ -777,7 +777,9 @@ func (z *E12) IsInSubGroup() bool {
 {{end}}
 
 {{define "readFp"}}
-	{{$.To}}.SetBytes(e[{{$.OffSet}}:{{$.OffSet}} + fp.Bytes])
+	if err := {{$.To}}.SetBytes(e[{{$.OffSet}}:{{$.OffSet}} + fp.Bytes]); err != nil {
+		return err
+	}
 {{end}}
 
 // CompressTorus GT/E12 element to half its size


### PR DESCRIPTION
This PR introduces `SetBytesCanonical` 
```go
// SetBytesCanonical interprets e as the bytes of a big-endian X-byte integer.
// If e is not a X-byte slice or encodes a value higher than q,
// SetBytesCanonical returns an error.
func (z *Element) SetBytesCanonical(e []byte) error {
```

 `element.BigEndian` and `element.LittleEndian` implements a `encoding/binary` inspired interface: 

```go
// A ByteOrder specifies how to convert byte slices into a Element
type ByteOrder interface {
	Element(*[Bytes]byte) (Element, error)
	PutElement(*[Bytes]byte, Element)
	String() string
}
```


