### PR TITLE
refactor: clean iop APIs + add Marshal methods

### DIFF
--- a/ecc/bls12-377/fp/vector.go
+++ b/ecc/bls12-377/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-377/fr/iop/expressions.go
+++ b/ecc/bls12-377/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-377/fr/iop/expressions_test.go
+++ b/ecc/bls12-377/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bls12-377/fr/iop/expressions_test.go
+++ b/ecc/bls12-377/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bls12-377/fr/iop/expressions_test.go
+++ b/ecc/bls12-377/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-377/fr/iop/expressions_test.go
+++ b/ecc/bls12-377/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-377/fr/iop/expressions_test.go
+++ b/ecc/bls12-377/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bls12-377/fr/iop/quotient.go
+++ b/ecc/bls12-377/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bls12-377/fr/iop/quotient.go
+++ b/ecc/bls12-377/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-377/fr/iop/quotient.go
+++ b/ecc/bls12-377/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-377/fr/iop/quotient.go
+++ b/ecc/bls12-377/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bls12-377/fr/iop/quotient.go
+++ b/ecc/bls12-377/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bls12-377/fr/iop/utils.go
+++ b/ecc/bls12-377/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bls12-377/fr/vector.go
+++ b/ecc/bls12-377/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bls12-377/marshal_test.go
+++ b/ecc/bls12-377/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bls12-378/fp/vector.go
+++ b/ecc/bls12-378/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-378/fr/iop/expressions.go
+++ b/ecc/bls12-378/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-378/fr/iop/expressions_test.go
+++ b/ecc/bls12-378/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bls12-378/fr/iop/expressions_test.go
+++ b/ecc/bls12-378/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bls12-378/fr/iop/expressions_test.go
+++ b/ecc/bls12-378/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-378/fr/iop/expressions_test.go
+++ b/ecc/bls12-378/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-378/fr/iop/expressions_test.go
+++ b/ecc/bls12-378/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bls12-378/fr/iop/polynomial_test.go
+++ b/ecc/bls12-378/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bls12-378/fr/iop/quotient.go
+++ b/ecc/bls12-378/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bls12-378/fr/iop/quotient.go
+++ b/ecc/bls12-378/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-378/fr/iop/quotient.go
+++ b/ecc/bls12-378/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-378/fr/iop/quotient.go
+++ b/ecc/bls12-378/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bls12-378/fr/iop/quotient.go
+++ b/ecc/bls12-378/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bls12-378/fr/iop/quotient_test.go
+++ b/ecc/bls12-378/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bls12-378/fr/iop/quotient_test.go
+++ b/ecc/bls12-378/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-378/fr/iop/quotient_test.go
+++ b/ecc/bls12-378/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-378/fr/iop/quotient_test.go
+++ b/ecc/bls12-378/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bls12-378/fr/iop/quotient_test.go
+++ b/ecc/bls12-378/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bls12-378/fr/iop/ratios_test.go
+++ b/ecc/bls12-378/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bls12-378/fr/iop/ratios_test.go
+++ b/ecc/bls12-378/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bls12-378/fr/iop/ratios_test.go
+++ b/ecc/bls12-378/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-378/fr/iop/ratios_test.go
+++ b/ecc/bls12-378/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-378/fr/iop/ratios_test.go
+++ b/ecc/bls12-378/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bls12-378/fr/iop/utils.go
+++ b/ecc/bls12-378/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bls12-378/fr/vector.go
+++ b/ecc/bls12-378/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bls12-378/marshal_test.go
+++ b/ecc/bls12-378/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bls12-381/fp/vector.go
+++ b/ecc/bls12-381/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-381/fr/iop/expressions.go
+++ b/ecc/bls12-381/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls12-381/fr/iop/expressions_test.go
+++ b/ecc/bls12-381/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bls12-381/fr/iop/expressions_test.go
+++ b/ecc/bls12-381/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bls12-381/fr/iop/expressions_test.go
+++ b/ecc/bls12-381/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-381/fr/iop/expressions_test.go
+++ b/ecc/bls12-381/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-381/fr/iop/expressions_test.go
+++ b/ecc/bls12-381/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bls12-381/fr/iop/quotient.go
+++ b/ecc/bls12-381/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bls12-381/fr/iop/quotient.go
+++ b/ecc/bls12-381/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-381/fr/iop/quotient.go
+++ b/ecc/bls12-381/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls12-381/fr/iop/quotient.go
+++ b/ecc/bls12-381/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bls12-381/fr/iop/quotient.go
+++ b/ecc/bls12-381/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bls12-381/fr/iop/utils.go
+++ b/ecc/bls12-381/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bls12-381/fr/vector.go
+++ b/ecc/bls12-381/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bls12-381/marshal_test.go
+++ b/ecc/bls12-381/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bls24-315/fp/vector.go
+++ b/ecc/bls24-315/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-315/fr/iop/expressions.go
+++ b/ecc/bls24-315/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-315/fr/iop/expressions_test.go
+++ b/ecc/bls24-315/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bls24-315/fr/iop/expressions_test.go
+++ b/ecc/bls24-315/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bls24-315/fr/iop/expressions_test.go
+++ b/ecc/bls24-315/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-315/fr/iop/expressions_test.go
+++ b/ecc/bls24-315/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-315/fr/iop/expressions_test.go
+++ b/ecc/bls24-315/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bls24-315/fr/iop/quotient.go
+++ b/ecc/bls24-315/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bls24-315/fr/iop/quotient.go
+++ b/ecc/bls24-315/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls24-315/fr/iop/quotient.go
+++ b/ecc/bls24-315/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls24-315/fr/iop/quotient.go
+++ b/ecc/bls24-315/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bls24-315/fr/iop/quotient.go
+++ b/ecc/bls24-315/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bls24-315/fr/iop/utils.go
+++ b/ecc/bls24-315/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bls24-315/fr/vector.go
+++ b/ecc/bls24-315/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bls24-315/marshal_test.go
+++ b/ecc/bls24-315/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bls24-317/fp/vector.go
+++ b/ecc/bls24-317/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-317/fr/iop/expressions.go
+++ b/ecc/bls24-317/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bls24-317/fr/iop/expressions_test.go
+++ b/ecc/bls24-317/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bls24-317/fr/iop/expressions_test.go
+++ b/ecc/bls24-317/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bls24-317/fr/iop/expressions_test.go
+++ b/ecc/bls24-317/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-317/fr/iop/expressions_test.go
+++ b/ecc/bls24-317/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-317/fr/iop/expressions_test.go
+++ b/ecc/bls24-317/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bls24-317/fr/iop/quotient.go
+++ b/ecc/bls24-317/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bls24-317/fr/iop/quotient.go
+++ b/ecc/bls24-317/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls24-317/fr/iop/quotient.go
+++ b/ecc/bls24-317/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bls24-317/fr/iop/quotient.go
+++ b/ecc/bls24-317/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bls24-317/fr/iop/quotient.go
+++ b/ecc/bls24-317/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bls24-317/fr/iop/utils.go
+++ b/ecc/bls24-317/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bls24-317/fr/vector.go
+++ b/ecc/bls24-317/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bls24-317/marshal_test.go
+++ b/ecc/bls24-317/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bn254/fp/vector.go
+++ b/ecc/bn254/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bn254/fr/iop/expressions.go
+++ b/ecc/bn254/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bn254/fr/iop/expressions_test.go
+++ b/ecc/bn254/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bn254/fr/iop/expressions_test.go
+++ b/ecc/bn254/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bn254/fr/iop/expressions_test.go
+++ b/ecc/bn254/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bn254/fr/iop/expressions_test.go
+++ b/ecc/bn254/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bn254/fr/iop/expressions_test.go
+++ b/ecc/bn254/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bn254/fr/iop/quotient.go
+++ b/ecc/bn254/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bn254/fr/iop/quotient.go
+++ b/ecc/bn254/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bn254/fr/iop/quotient.go
+++ b/ecc/bn254/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bn254/fr/iop/quotient.go
+++ b/ecc/bn254/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bn254/fr/iop/quotient.go
+++ b/ecc/bn254/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bn254/fr/iop/utils.go
+++ b/ecc/bn254/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bn254/fr/vector.go
+++ b/ecc/bn254/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bw6-633/fp/vector.go
+++ b/ecc/bw6-633/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-633/fr/iop/expressions.go
+++ b/ecc/bw6-633/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-633/fr/iop/expressions_test.go
+++ b/ecc/bw6-633/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bw6-633/fr/iop/expressions_test.go
+++ b/ecc/bw6-633/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bw6-633/fr/iop/expressions_test.go
+++ b/ecc/bw6-633/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-633/fr/iop/expressions_test.go
+++ b/ecc/bw6-633/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-633/fr/iop/expressions_test.go
+++ b/ecc/bw6-633/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bw6-633/fr/iop/quotient.go
+++ b/ecc/bw6-633/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bw6-633/fr/iop/quotient.go
+++ b/ecc/bw6-633/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-633/fr/iop/quotient.go
+++ b/ecc/bw6-633/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-633/fr/iop/quotient.go
+++ b/ecc/bw6-633/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bw6-633/fr/iop/quotient.go
+++ b/ecc/bw6-633/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bw6-633/fr/iop/utils.go
+++ b/ecc/bw6-633/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bw6-633/fr/vector.go
+++ b/ecc/bw6-633/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bw6-633/marshal_test.go
+++ b/ecc/bw6-633/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bw6-756/fp/vector.go
+++ b/ecc/bw6-756/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-756/fr/iop/expressions.go
+++ b/ecc/bw6-756/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-756/fr/iop/expressions_test.go
+++ b/ecc/bw6-756/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bw6-756/fr/iop/expressions_test.go
+++ b/ecc/bw6-756/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bw6-756/fr/iop/expressions_test.go
+++ b/ecc/bw6-756/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-756/fr/iop/expressions_test.go
+++ b/ecc/bw6-756/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-756/fr/iop/expressions_test.go
+++ b/ecc/bw6-756/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bw6-756/fr/iop/polynomial_test.go
+++ b/ecc/bw6-756/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bw6-756/fr/iop/quotient.go
+++ b/ecc/bw6-756/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bw6-756/fr/iop/quotient.go
+++ b/ecc/bw6-756/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-756/fr/iop/quotient.go
+++ b/ecc/bw6-756/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-756/fr/iop/quotient.go
+++ b/ecc/bw6-756/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bw6-756/fr/iop/quotient.go
+++ b/ecc/bw6-756/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bw6-756/fr/iop/quotient_test.go
+++ b/ecc/bw6-756/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bw6-756/fr/iop/quotient_test.go
+++ b/ecc/bw6-756/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-756/fr/iop/quotient_test.go
+++ b/ecc/bw6-756/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-756/fr/iop/quotient_test.go
+++ b/ecc/bw6-756/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bw6-756/fr/iop/quotient_test.go
+++ b/ecc/bw6-756/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bw6-756/fr/iop/ratios_test.go
+++ b/ecc/bw6-756/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bw6-756/fr/iop/ratios_test.go
+++ b/ecc/bw6-756/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bw6-756/fr/iop/ratios_test.go
+++ b/ecc/bw6-756/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-756/fr/iop/ratios_test.go
+++ b/ecc/bw6-756/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-756/fr/iop/ratios_test.go
+++ b/ecc/bw6-756/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bw6-756/fr/iop/utils.go
+++ b/ecc/bw6-756/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bw6-756/fr/vector.go
+++ b/ecc/bw6-756/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bw6-756/marshal_test.go
+++ b/ecc/bw6-756/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/bw6-761/fp/vector.go
+++ b/ecc/bw6-761/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -32,8 +32,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input")
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 		}
 	})
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -49,7 +49,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -68,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -32,11 +32,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -44,7 +42,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -70,7 +68,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-761/fr/iop/expressions.go
+++ b/ecc/bw6-761/fr/iop/expressions.go
@@ -40,16 +40,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -70,7 +70,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 		}
 	})
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/ecc/bw6-761/fr/iop/expressions_test.go
+++ b/ecc/bw6-761/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -68,13 +68,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/ecc/bw6-761/fr/iop/expressions_test.go
+++ b/ecc/bw6-761/fr/iop/expressions_test.go
@@ -31,9 +31,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/ecc/bw6-761/fr/iop/expressions_test.go
+++ b/ecc/bw6-761/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-761/fr/iop/expressions_test.go
+++ b/ecc/bw6-761/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-761/fr/iop/expressions_test.go
+++ b/ecc/bw6-761/fr/iop/expressions_test.go
@@ -44,9 +44,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -78,11 +78,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -204,15 +204,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -170,7 +170,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -214,8 +214,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -256,7 +256,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -267,7 +267,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -278,9 +278,9 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -307,9 +307,9 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular, canonicalBitReverse:
 		return p
@@ -340,9 +340,9 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -74,28 +74,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
@@ -103,29 +104,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -133,64 +134,64 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -198,27 +199,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients: make(fr.Vector, len(p.Coefficients), c),
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -232,14 +240,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -253,7 +261,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -264,7 +272,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -277,20 +285,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -308,16 +316,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -326,10 +334,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -339,18 +347,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -124,8 +124,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -147,7 +145,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -156,13 +154,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -229,9 +227,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	return r
 }
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -334,8 +332,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -80,11 +80,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients.
 // It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -130,8 +130,8 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
@@ -183,11 +183,11 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -195,19 +195,19 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -218,10 +218,10 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
+		coefficients: &newCoeffs,
 		Form:         p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -236,13 +236,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -256,7 +256,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -267,7 +267,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -280,20 +280,20 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -311,16 +311,16 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -331,7 +331,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -342,18 +342,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -397,7 +397,8 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -17,6 +17,8 @@
 package iop
 
 import (
+	"encoding/binary"
+	"io"
 	"math/big"
 	"math/bits"
 
@@ -360,4 +362,66 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+// WriteTo implements io.WriterTo
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+	return n, nil
 }

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])) {
+		if !p[i].Equal(&q[i]) {
 			return false
 		}
 	}

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -29,9 +29,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -75,9 +74,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -124,11 +122,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -165,10 +159,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -178,7 +172,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -187,7 +181,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -195,7 +189,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -204,7 +198,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -214,7 +208,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -224,7 +218,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -262,7 +256,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -370,7 +364,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -386,7 +380,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -396,7 +390,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -405,7 +399,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -415,7 +409,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -536,7 +530,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -546,7 +540,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -555,7 +549,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -565,7 +559,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -576,7 +570,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -584,7 +578,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -599,7 +593,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -162,7 +162,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -172,7 +172,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -181,7 +181,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -189,7 +189,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -198,7 +198,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -208,7 +208,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -218,7 +218,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -257,14 +257,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -281,7 +278,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -297,7 +294,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -314,7 +311,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -331,7 +328,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -365,7 +362,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -381,7 +378,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -391,7 +388,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -400,7 +397,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -410,7 +407,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -425,14 +422,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -448,7 +442,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -464,7 +458,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -481,7 +475,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -497,7 +491,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -514,7 +508,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -531,7 +525,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -541,7 +535,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -550,7 +544,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -560,7 +554,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -571,7 +565,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -579,7 +573,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -594,14 +588,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -618,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -634,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -650,7 +641,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -667,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -683,7 +674,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -58,9 +58,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -70,7 +70,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -258,7 +258,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -426,7 +426,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -595,7 +595,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -21,6 +21,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -111,6 +116,38 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -63,13 +63,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -275,12 +275,12 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
+		if !((*p)[i].Equal(&(*q)[i])) {
 			return false
 		}
 	}

--- a/ecc/bw6-761/fr/iop/quotient.go
+++ b/ecc/bw6-761/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/ecc/bw6-761/fr/iop/quotient.go
+++ b/ecc/bw6-761/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-761/fr/iop/quotient.go
+++ b/ecc/bw6-761/fr/iop/quotient.go
@@ -44,7 +44,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
@@ -53,7 +53,7 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/ecc/bw6-761/fr/iop/quotient.go
+++ b/ecc/bw6-761/fr/iop/quotient.go
@@ -29,7 +29,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -43,10 +43,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/ecc/bw6-761/fr/iop/quotient.go
+++ b/ecc/bw6-761/fr/iop/quotient.go
@@ -43,7 +43,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -37,7 +37,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -38,7 +38,7 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -36,8 +36,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -37,7 +37,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 func TestDivideByXMinusOne(t *testing.T) {
@@ -66,12 +67,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -126,7 +126,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -223,7 +223,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -67,7 +67,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -85,9 +85,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -102,32 +102,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -162,7 +163,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -179,9 +180,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int) {
@@ -201,32 +202,33 @@ func BuildRatioCopyConstraint(
 
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 
 				b.Mul(&b, &a)
 
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -241,24 +243,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -269,10 +271,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -232,7 +232,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -50,9 +50,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -145,13 +145,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -235,7 +235,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -265,7 +265,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -129,7 +129,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -225,35 +225,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -45,7 +45,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -40,11 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -55,9 +55,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -84,8 +84,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -200,11 +200,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -230,7 +230,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -199,7 +199,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -40,14 +40,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -55,13 +52,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -85,8 +78,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -201,14 +194,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -232,9 +223,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/ecc/bw6-761/fr/iop/utils.go
+++ b/ecc/bw6-761/fr/iop/utils.go
@@ -20,49 +20,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 

--- a/ecc/bw6-761/fr/vector.go
+++ b/ecc/bw6-761/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -86,9 +86,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n += read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -111,46 +118,12 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n += read64
 		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
@@ -400,7 +373,15 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -422,41 +403,22 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -514,7 +476,15 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -536,41 +506,22 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
 		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/ecc/bw6-761/marshal_test.go
+++ b/ecc/bw6-761/marshal_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -50,6 +51,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -64,12 +66,14 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -93,8 +97,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -130,6 +135,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/ecc/secp256k1/fp/vector.go
+++ b/ecc/secp256k1/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/secp256k1/fr/vector.go
+++ b/ecc/secp256k1/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/stark-curve/fp/vector.go
+++ b/ecc/stark-curve/fp/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/ecc/stark-curve/fr/vector.go
+++ b/ecc/stark-curve/fr/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -20,7 +20,7 @@ import (
 type Vector []{{.ElementName}}
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -39,17 +39,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded {{.ElementName}}.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
     // encode slice length
-    if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+    if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
         return 0, err 
     }
 
 	n := int64(4)
 
 	var buf [Bytes]byte 
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -36,7 +36,6 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
     return err 
 }
 
-
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded {{.ElementName}}.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
 func (vector *Vector) WriteTo(w io.Writer) (int64, error) {

--- a/field/goldilocks/vector.go
+++ b/field/goldilocks/vector.go
@@ -35,7 +35,7 @@ import (
 type Vector []Element
 
 // MarshalBinary implements encoding.BinaryMarshaler
-func (vector Vector) MarshalBinary() (data []byte, err error) {
+func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	var buf bytes.Buffer
 
 	if _, err = vector.WriteTo(&buf); err != nil {
@@ -53,17 +53,17 @@ func (vector *Vector) UnmarshalBinary(data []byte) error {
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded Element.
 // Length of the vector is encoded as a uint32 on the first 4 bytes.
-func (vector Vector) WriteTo(w io.Writer) (int64, error) {
+func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 	// encode slice length
-	if err := binary.Write(w, binary.BigEndian, uint32(len(vector))); err != nil {
+	if err := binary.Write(w, binary.BigEndian, uint32(len(*vector))); err != nil {
 		return 0, err
 	}
 
 	n := int64(4)
 
 	var buf [Bytes]byte
-	for i := 0; i < len(vector); i++ {
-		BigEndian.PutElement(&buf, vector[i])
+	for i := 0; i < len(*vector); i++ {
+		BigEndian.PutElement(&buf, (*vector)[i])
 		m, err := w.Write(buf[:])
 		n += int64(m)
 		if err != nil {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -92,9 +92,16 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 	// in particular, careful attention must be given to usage of Bytes() method on Elements and Points
-	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memallocs 
+	// that return an array (not a slice) of bytes. Using this is beneficial to minimize memory allocations
 	// in very large (de)serialization upstream in gnark.
-	// (but detrimental to code lisibility here)
+	// (but detrimental to code readability here)
+
+	var read64 int64
+	if vf, ok := v.(io.ReaderFrom); ok {
+		read64, err = vf.ReadFrom(dec.r)
+		dec.n+=read64
+		return
+	}
 
 	var buf [SizeOfG2AffineUncompressed]byte
 	var read int
@@ -117,47 +124,13 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		err = t.SetBytesCanonical(buf[:fp.Bytes])
 		return
 	case *[]fr.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fr.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fr.Bytes]); err != nil {
-				return
-			}
-		}
+		read64, err = (*fr.Vector)(t).ReadFrom(dec.r)
+		dec.n+=read64
 		return
 	case *[]fp.Element:
-		var sliceLen uint32
-		sliceLen, err = dec.readUint32()
-		if err != nil {
-			return
-		}
-		if len(*t) != int(sliceLen) {
-			*t = make([]fp.Element, sliceLen)
-		}
-
-		for i := 0; i < len(*t); i++ {
-			read, err = io.ReadFull(dec.r, buf[:fp.Bytes])
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			if err = (*t)[i].SetBytesCanonical(buf[:fp.Bytes]); err != nil {
-				return
-			}
-		}
-		return 
+		read64, err = (*fp.Vector)(t).ReadFrom(dec.r)
+		dec.n+=read64
+		return
 	case *G1Affine:
 		// we start by reading compressed point size, if metadata tells us it is uncompressed, we read more.
 		read, err = io.ReadFull(dec.r, buf[:SizeOfG1AffineCompressed])
@@ -419,7 +392,15 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 
 	// implementation note: code is a bit verbose (abusing code generation), but minimize allocations on the heap
 
+	var written64 int64 
+	if vw, ok := v.(io.WriterTo); ok {
+		written64, err = vw.WriteTo(enc.w)
+		enc.n += written64
+		return 
+	}
+
 	var written int
+
 	switch t := v.(type) {
 	case *fr.Element:
 		buf := t.Bytes()
@@ -440,42 +421,23 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		buf := t.{{- $.Raw}}Bytes()
 		written, err = enc.w.Write(buf[:])
 		enc.n += int64(written)
+		return
+	case fr.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
+		return 
+	case fp.Vector:
+		written64, err = t.WriteTo(enc.w)
+		enc.n += written64
 		return 
 	case []fr.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fr.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		written64, err = (*fr.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return 
 	case []fp.Element:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-		var buf [fp.Bytes]byte
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
-
+		written64, err = (*fp.Vector)(&t).WriteTo(enc.w)
+		enc.n += written64
+		return 
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/internal/generator/ecc/template/tests/marshal.go.tmpl
+++ b/internal/generator/ecc/template/tests/marshal.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"bytes"
 	"io"
+	"reflect"
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
@@ -40,6 +41,7 @@ func TestEncoder(t *testing.T) {
 	var inH []G2Affine
 	var inI []fp.Element
 	var inJ []fr.Element
+	var inK fr.Vector
 
 	// set values of inputs
 	inA = rand.Uint64()
@@ -54,13 +56,15 @@ func TestEncoder(t *testing.T) {
 	inI = make([]fp.Element, 3)
 	inI[2] = inD.X
 	inJ = make([]fr.Element, 0)
+	inK = make(fr.Vector, 42)
+	inK[41].SetUint64(42)
 
 
 	// encode them, compressed and raw
 	var buf, bufRaw bytes.Buffer
 	enc := NewEncoder(&buf)
 	encRaw := NewEncoder(&bufRaw, RawEncoding())
-	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ}
+	toEncode := []interface{}{inA, &inB, &inC, &inD, &inE, &inF, inG, inH, inI, inJ, inK}
 	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			t.Fatal(err)
@@ -85,8 +89,9 @@ func TestEncoder(t *testing.T) {
 		var outH []G2Affine
 		var outI []fp.Element
 		var outJ []fr.Element
+		var outK fr.Vector
 
-		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ}
+		toDecode := []interface{}{&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI, &outJ, &outK}
 		for _, v := range toDecode {
 			if err := dec.Decode(v); err != nil {
 				t.Fatal(err)
@@ -122,6 +127,9 @@ func TestEncoder(t *testing.T) {
 			if !inI[i].Equal(&outI[i]) {
 				t.Fatal("decode(encode(slice(elements))) failed")
 			}
+		}
+		if !reflect.DeepEqual(inK, outK) {
+			t.Fatal("decode(encode(vector)) failed")
 		}
 		if n != dec.BytesRead() {
 			t.Fatal("bytes read don't match bytes written")

--- a/internal/generator/iop/generate.go
+++ b/internal/generator/iop/generate.go
@@ -27,6 +27,7 @@ func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) er
 
 		{File: filepath.Join(baseDir, "utils.go"), Templates: []string{"utils.go.tmpl"}},
 	}
+
 	return bgen.Generate(conf, conf.Package, "./iop/template/", entries...)
 
 }

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -31,7 +31,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// result coefficients
-	r := make(fr.Vector, n)
+	r := make([]fr.Element, n)
 	idx := func(i int) int {
 		return i
 	}

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -16,7 +16,7 @@ type Expression func(x ...fr.Element) fr.Element
 // The Shift field of the result is 0.
 func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return nil, errors.New("need at lest one input")
+		return nil, errors.New("need at lest one input") 
 	}
 
 	// check that the sizes are consistent
@@ -38,7 +38,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		idx = func(i int) int {
 			return int(bits.Reverse64(uint64(i)) >> nn)
 		}
-	}
+	} 
 
 	parallel.Execute(n, func(start, end int) {
 		vx := make([]fr.Element, m)
@@ -50,7 +50,8 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-	res := NewPolynomial(r, form)
+
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -22,16 +22,16 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	}
 
 	// check that the sizes are consistent
-	n := len(x[0].Coefficients)
+	n := x[0].coefficients.Len()
 	m := len(x)
 	for i := 1; i < m; i++ {
-		if n != len(x[i].Coefficients) {
+		if n != x[i].coefficients.Len() {
 			return res, ErrInconsistentSize
 		}
 	}
 
 	// result coefficients
-	r := make([]fr.Element, n)
+	r := make(fr.Vector, n)
 	idx := func(i int) int {
 		return i
 	}
@@ -54,7 +54,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 
 
 
-	res.polynomial = newPolynomial(r, form)
+	res.polynomial = newPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -14,11 +14,9 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
-	var res Polynomial
-
+func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return res, errors.New("need at lest one input") 
+		return nil, errors.New("need at lest one input") 
 	}
 
 	// check that the sizes are consistent
@@ -26,7 +24,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	m := len(x)
 	for i := 1; i < m; i++ {
 		if n != x[i].coefficients.Len() {
-			return res, ErrInconsistentSize
+			return nil, ErrInconsistentSize
 		}
 	}
 
@@ -53,8 +51,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
 	})
 
 
-
-	res.polynomial = newPolynomial(&r, form)
+	res := NewPolynomial(&r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -16,7 +16,7 @@ type Expression func(x ...fr.Element) fr.Element
 // The Shift field of the result is 0.
 func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 	if len(x) == 0 {
-		return nil, errors.New("need at lest one input") 
+		return nil, errors.New("need at lest one input")
 	}
 
 	// check that the sizes are consistent
@@ -38,7 +38,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		idx = func(i int) int {
 			return int(bits.Reverse64(uint64(i)) >> nn)
 		}
-	} 
+	}
 
 	parallel.Execute(n, func(start, end int) {
 		vx := make([]fr.Element, m)
@@ -50,8 +50,7 @@ func Evaluate(f Expression, form Form, x ...*Polynomial) (*Polynomial, error) {
 		}
 	})
 
-
-	res := NewPolynomial(&r, form)
+	res := NewPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/internal/generator/iop/template/expressions.go.tmpl
+++ b/internal/generator/iop/template/expressions.go.tmpl
@@ -14,8 +14,8 @@ type Expression func(x ...fr.Element) fr.Element
 // The Size field of the result is the same as the one of x[0].
 // The blindedSize field of the result is the same as Size.
 // The Shift field of the result is 0.
-func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomial, error) {
-	var res WrappedPolynomial
+func Evaluate(f Expression, form Form, x ...*Polynomial) (Polynomial, error) {
+	var res Polynomial
 
 	if len(x) == 0 {
 		return res, errors.New("need at lest one input") 
@@ -54,7 +54,7 @@ func Evaluate(f Expression, form Form, x ...*WrappedPolynomial) (WrappedPolynomi
 
 
 
-	res.Polynomial = NewPolynomial(r, form)
+	res.polynomial = newPolynomial(r, form)
 	res.size = x[0].size
 	res.blindedSize = x[0].size
 	res.shift = 0

--- a/internal/generator/iop/template/expressions.test.go.tmpl
+++ b/internal/generator/iop/template/expressions.test.go.tmpl
@@ -13,9 +13,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make([]fr.Element, size)
-	v := make([]fr.Element, size)
-	w := make([]fr.Element, size)
+	u := make(fr.Vector, size)
+	v := make(fr.Vector, size)
+	w := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))
@@ -26,9 +26,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {
@@ -50,13 +50,13 @@ func TestEvaluate(t *testing.T) {
 
 	// compare with the expected result
 	for i := 0; i < size; i++ {
-		if !rr.Coefficients[i].Equal(&r[i]) {
+		if !rr.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrb.Coefficients[i].Equal(&r[i]) {
+		if !rrb.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
-		if !rrc.Coefficients[i].Equal(&r[i]) {
+		if !rrc.Coefficients()[i].Equal(&r[i]) {
 			t.Fatal("error evaluation")
 		}
 

--- a/internal/generator/iop/template/expressions.test.go.tmpl
+++ b/internal/generator/iop/template/expressions.test.go.tmpl
@@ -26,9 +26,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(&u, form)
-	wv := NewPolynomial(&v, form)
-	ww := NewPolynomial(&w, form)
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/internal/generator/iop/template/expressions.test.go.tmpl
+++ b/internal/generator/iop/template/expressions.test.go.tmpl
@@ -26,9 +26,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewWrappedPolynomial(NewPolynomial(u, form))
-	wv := NewWrappedPolynomial(NewPolynomial(v, form))
-	ww := NewWrappedPolynomial(NewPolynomial(w, form))
+	wu := NewPolynomial(u, form)
+	wv := NewPolynomial(v, form)
+	ww := NewPolynomial(w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/internal/generator/iop/template/expressions.test.go.tmpl
+++ b/internal/generator/iop/template/expressions.test.go.tmpl
@@ -26,9 +26,9 @@ func TestEvaluate(t *testing.T) {
 		r[i].SetUint64(uint64(3 * (i + 1)))
 	}
 	form := Form{Layout: Regular, Basis: Canonical}
-	wu := NewPolynomial(u, form)
-	wv := NewPolynomial(v, form)
-	ww := NewPolynomial(w, form)
+	wu := NewPolynomial(&u, form)
+	wv := NewPolynomial(&v, form)
+	ww := NewPolynomial(&w, form)
 
 	rr, err := Evaluate(f, form, wu, wv, ww)
 	if err != nil {

--- a/internal/generator/iop/template/expressions.test.go.tmpl
+++ b/internal/generator/iop/template/expressions.test.go.tmpl
@@ -13,9 +13,9 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	size := 64
-	u := make(fr.Vector, size)
-	v := make(fr.Vector, size)
-	w := make(fr.Vector, size)
+	u := make([]fr.Element, size)
+	v := make([]fr.Element, size)
+	w := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		u[i].SetUint64(uint64(i))
 		v[i].SetUint64(uint64(i + 1))

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -110,8 +110,6 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
 		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
@@ -134,7 +132,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 	if p.shift == 0 {
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
@@ -143,13 +141,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return p.polynomial.Evaluate(x)
+		return p.polynomial.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return p.polynomial.Evaluate(x)
+	return p.polynomial.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned; 
@@ -219,9 +217,9 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 }
 
 
-// Evaluate evaluates p at x.
+// evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -325,8 +323,6 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 
 func resize(p *polynomial, newSize uint64) {
 	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-	// some will mutate the original polynomial, some will not.
 	(*p.coefficients) = append((*p.coefficients), z...)
 }
 

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -59,28 +59,29 @@ type Polynomial struct {
 	blindedSize int
 }
 
-// NewPolynomial returned a Polynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+// NewPolynomial returned a Polynomial from the provided coefficients in the given form.
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients. 
+// It is the responsibility of the user to call the Clone method if the coefficients 
+// shouldn't be mutated.
+func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        coeffs.Len(),
+		blindedSize: coeffs.Len(),
 	}
 }
 
 // Shift the wrapped polynomial; it doesn't modify the underlying data structure,
 // but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *Polynomial) Shift(shift int) *Polynomial {
-	wp.shift = shift
-	return wp
+func (p *Polynomial) Shift(shift int) *Polynomial {
+	p.shift = shift
+	return p
 }
 
 // BlindedSize returns the the size of the polynomial when it is blinded. By
 // default blindedSize=Size, until the polynomial is blinded.
-func (wp *Polynomial) BlindedSize() int {
-	return wp.blindedSize
+func (p *Polynomial) BlindedSize() int {
+	return p.blindedSize
 }
 
 
@@ -89,29 +90,29 @@ func (wp *Polynomial) BlindedSize() int {
 // size of q. Sets the result to p and returns it.
 //
 // blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+// where n is the size of p. The size of p is modified since the underlying
+// polynomial is of bigger degree now. The new size is p.Size+1+blindingOrder.
 //
 // /!\ The code panics if wq is not in canonical, regular layout
-func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
+func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that p is in canonical basis
+	if p.Form != canonicalRegular {
 		panic("the input must be in canonical basis, regular layout")
 	}
 
 	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
 	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
+	newSize := p.size + blindingOrder + 1
 
-	// Resize wp. The size of wq might has already been increased
+	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
+	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
 		z := make(fr.Vector, offset)
 		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
+		(*p.coefficients) = append((*p.coefficients), z...)
 	}
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
@@ -119,66 +120,66 @@ func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
-	wp.blindedSize = newSize
+	p.blindedSize = newSize
 
-	return wp
+	return p
 }
 
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
-	if wp.shift == 0 {
-		return wp.polynomial.Evaluate(x)
+	if p.shift == 0 {
+		return p.polynomial.Evaluate(x)
 	}
 
 	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
+	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
+	if p.shift <= 5 {
+		g = smallExp(d.Generator, p.shift)
 		x.Mul(&x, &g)
-		return wp.polynomial.Evaluate(x)
+		return p.polynomial.Evaluate(x)
 	}
 
-	bs := big.NewInt(int64(wp.shift))
+	bs := big.NewInt(int64(p.shift))
 	g = *g.Exp(g, bs)
 	x.Mul(&x, &g)
-	return wp.polynomial.Evaluate(x)
+	return p.polynomial.Evaluate(x)
 }
 
-// Clone returns a deep copy of wp. The underlying polynomial is cloned; 
+// Clone returns a deep copy of p. The underlying polynomial is cloned; 
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
-	res := wp.ShallowClone()
-	res.polynomial = wp.polynomial.Clone(capacity...)
+func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := p.ShallowClone()
+	res.polynomial = p.polynomial.Clone(capacity...)
 	return res
 }
 
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// ShallowClone returns a shallow copy of p. The underlying polynomial coefficient
 // is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *Polynomial) ShallowClone() *Polynomial {
-	res := *wp
+func (p *Polynomial) ShallowClone() *Polynomial {
+	res := *p
 	return &res
 }
 
 
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *Polynomial) GetCoeff(i int) fr.Element {
+// GetCoeff returns the i-th entry of p, taking the layout in account.
+func (p *Polynomial) GetCoeff(i int) fr.Element {
 
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
+	n := p.coefficients.Len()
+	rho := n / p.size
+	if p.polynomial.Form.Layout == Regular {
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
+		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
+		return (*p.coefficients)[iRev]
 	}
 
 }
@@ -187,27 +188,34 @@ func (wp *Polynomial) GetCoeff(i int) fr.Element {
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	Coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
+}
+
+// Coefficients returns a slice on the underlying data structure.
+// TODO @gbotrel check indirection cost 
+func (p *polynomial) Coefficients() []fr.Element {
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
-	return &polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
+	return &polynomial{coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
 func (p *polynomial) Clone(capacity ...int) *polynomial {
-	c := len(p.Coefficients)
+	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
+	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		Coefficients:make(fr.Vector, len(p.Coefficients), c),
+		coefficients:&newCoeffs,
 		Form: p.Form,
 	}
-	copy(r.Coefficients, p.Coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
 
@@ -222,14 +230,14 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.Layout == Regular {
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[i])
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(len(p.Coefficients))))
-		for i := len(p.Coefficients) - 1; i >= 0; i-- {
+		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
+		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.Coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -244,7 +252,7 @@ func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
@@ -256,7 +264,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -269,20 +277,20 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeRegular,lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
-		d.FFT(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
-		d.FFT(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -300,16 +308,16 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -318,10 +326,10 @@ func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 }
 
 func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
+	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
-	p.Coefficients = append(p.Coefficients, z...)
+	(*p.coefficients) = append((*p.coefficients), z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
@@ -331,18 +339,18 @@ func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.Coefficients, fft.DIF)
-		d.FFT(p.Coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.Coefficients, fft.DIT)
-		d.FFT(p.Coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -157,7 +157,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.Clone(capacity...)
+	res.polynomial = p.polynomial.clone(capacity...)
 	return res
 }
 
@@ -272,7 +272,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 // Leaves p unchanged if p was already in Lagrange form.
 func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form 
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -301,7 +301,7 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 // Leaves p unchanged if p was already in Canonical form.
 func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular,canonicalBitReverse:
 		return p
@@ -334,7 +334,7 @@ func resize(p *polynomial, newSize uint64) {
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
 func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p, d.Cardinality)
+	resize(p.polynomial, d.Cardinality)
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -47,7 +47,7 @@ var (
 
 
 // Polynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
+// interpreted as P'(X)=P(\omega^{shift}X).
 // Size is the real size of the polynomial (seen as a vector).
 // For instance if len(P)=32 but P.Size=8, it means that P has been
 // extended (e.g. it is evaluated on a larger set) but P is a polynomial

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -43,27 +43,168 @@ var (
 	lagrangeCosetBitReverse = Form{LagrangeCoset, BitReverse}
 )
 
-// Polynomial represents a polynomial, the vector of coefficients
-// along with the basis and the layout.
+
+// Polynomial wraps a polynomial so that it is
+// interpreted as P'(X)=P(\omega^{s}X).
+// Size is the real size of the polynomial (seen as a vector).
+// For instance if len(P)=32 but P.Size=8, it means that P has been
+// extended (e.g. it is evaluated on a larger set) but P is a polynomial
+// of degree 7.
+// blindedSize is the size of the polynomial when it is blinded. By
+// default blindedSize=Size, until the polynomial is blinded.
 type Polynomial struct {
-	Coefficients []fr.Element
+	*polynomial
+	shift       int
+	size        int
+	blindedSize int
+}
+
+// NewPolynomial returned a Polynomial from p.
+// ! Warning this does not do a deep copy of p, and modifications on the wrapped
+// polynomial will modify the underlying coefficients of p.
+func NewPolynomial(coeffs fr.Vector, form Form) *Polynomial {
+	return &Polynomial{
+		polynomial:  newPolynomial(coeffs, form),
+		size:        len(coeffs),
+		blindedSize: len(coeffs),
+	}
+}
+
+// Shift the wrapped polynomial; it doesn't modify the underlying data structure,
+// but flag the Polynomial such that it will be interpreted as p(\omega^shift X)
+func (wp *Polynomial) Shift(shift int) *Polynomial {
+	wp.shift = shift
+	return wp
+}
+
+// BlindedSize returns the the size of the polynomial when it is blinded. By
+// default blindedSize=Size, until the polynomial is blinded.
+func (wp *Polynomial) BlindedSize() int {
+	return wp.blindedSize
+}
+
+
+// Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
+// where deg Q = blindingOrder and Q is random, and n is the
+// size of q. Sets the result to p and returns it.
+//
+// blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
+// where n is the size of wp. The size of wp is modified since the underlying
+// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
+//
+// /!\ The code panics if wq is not in canonical, regular layout
+func (wp *Polynomial) Blind(blindingOrder int) *Polynomial {
+	// check that wp is in canonical basis
+	if wp.Form != canonicalRegular {
+		panic("the input must be in canonical basis, regular layout")
+	}
+
+	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
+	// where n is the size of wq.
+	newSize := wp.size + blindingOrder + 1
+
+	// Resize wp. The size of wq might has already been increased
+	// (e.g. when the polynomial is evaluated on a larger domain),
+	// if that's the case we don't resize the polynomial.
+	offset := newSize - len(wp.Coefficients)
+	if offset > 0 {
+		z := make(fr.Vector, offset)
+		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
+		// some will mutate the original polynomial, some will not.
+		wp.Coefficients = append(wp.Coefficients, z...)
+	}
+
+	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
+	var r fr.Element
+
+	for i := 0; i <= blindingOrder; i++ {
+		r.SetRandom()
+		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
+		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
+	}
+	wp.blindedSize = newSize
+
+	return wp
+}
+
+
+// Evaluate evaluates p at x.
+// The code panics if the function is not in canonical form.
+func (wp *Polynomial) Evaluate(x fr.Element) fr.Element {
+
+	if wp.shift == 0 {
+		return wp.polynomial.Evaluate(x)
+	}
+
+	// TODO find a way to retrieve the root properly instead of re generating the fft domain
+	d := fft.NewDomain(uint64(wp.size))
+	var g fr.Element
+	if wp.shift <= 5 {
+		g = smallExp(d.Generator, wp.shift)
+		x.Mul(&x, &g)
+		return wp.polynomial.Evaluate(x)
+	}
+
+	bs := big.NewInt(int64(wp.shift))
+	g = *g.Exp(g, bs)
+	x.Mul(&x, &g)
+	return wp.polynomial.Evaluate(x)
+}
+
+// Clone returns a deep copy of wp. The underlying polynomial is cloned; 
+// see also ShallowClone to perform a ShallowClone on the underlying polynomial.
+// If capacity is provided, the new coefficient slice capacity will be set accordingly.
+func (wp *Polynomial) Clone(capacity ...int) *Polynomial {
+	res := wp.ShallowClone()
+	res.polynomial = wp.polynomial.Clone(capacity...)
+	return res
+}
+
+// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
+// is NOT cloned and both objects will point to the same coefficient vector.
+func (wp *Polynomial) ShallowClone() *Polynomial {
+	res := *wp
+	return &res
+}
+
+
+// GetCoeff returns the i-th entry of wp, taking the layout in account.
+func (wp *Polynomial) GetCoeff(i int) fr.Element {
+
+	n := len(wp.Coefficients)
+	rho := n / wp.size
+	if wp.polynomial.Form.Layout == Regular {
+		return wp.Coefficients[(i+rho*wp.shift)%n]
+	} else {
+		nn := uint64(64 - bits.TrailingZeros(uint(n)))
+		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
+		return wp.Coefficients[iRev]
+	}
+
+}
+
+
+// polynomial represents a polynomial, the vector of coefficients
+// along with the basis and the layout.
+type polynomial struct {
+	Coefficients fr.Vector
 	Form
 }
 
-// NewPolynomial creates a new polynomial. The slice coeff NOT copied
+// newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
-	return &Polynomial{Coefficients: coeffs, Form: form}
+func newPolynomial(coeffs fr.Vector, form Form) *polynomial {
+	return &polynomial{Coefficients: coeffs, Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.
-func (p *Polynomial) Clone(capacity ...int) *Polynomial {
+func (p *polynomial) Clone(capacity ...int) *polynomial {
 	c := len(p.Coefficients)
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
 	}
-	r := &Polynomial{
-		Coefficients:make([]fr.Element, len(p.Coefficients), c),
+	r := &polynomial{
+		Coefficients:make(fr.Vector, len(p.Coefficients), c),
 		Form: p.Form,
 	}
 	copy(r.Coefficients, p.Coefficients)
@@ -73,7 +214,7 @@ func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
-func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
+func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 	var r fr.Element
 	if p.Basis != Canonical {
@@ -99,7 +240,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *Polynomial) ToRegular() *Polynomial {
+func (p *polynomial) ToRegular() *polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -111,7 +252,7 @@ func (p *Polynomial) ToRegular() *Polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *Polynomial) ToBitReverse() *Polynomial {
+func (p *polynomial) ToBitReverse() *polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -122,7 +263,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
+func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 	id := p.Form 
 	resize(p, d.Cardinality)
 	switch id {
@@ -151,7 +292,7 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
+func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
 	id := p.Form
 	resize(p, d.Cardinality)
 	switch id {
@@ -176,15 +317,15 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	return p
 }
 
-func resize(p *Polynomial, newSize uint64) {
-	z := make([]fr.Element, int(newSize)-len(p.Coefficients))
+func resize(p *polynomial, newSize uint64) {
+	z := make(fr.Vector, int(newSize)-len(p.Coefficients))
 	// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
 	// some will mutate the original polynomial, some will not.
 	p.Coefficients = append(p.Coefficients, z...)
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
+func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
 	id := p.Form
 	resize(p, d.Cardinality)
 	switch id {
@@ -210,143 +351,4 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
-}
-
-// WrappedPolynomial wraps a polynomial so that it is
-// interpreted as P'(X)=P(\omega^{s}X).
-// Size is the real size of the polynomial (seen as a vector).
-// For instance if len(P)=32 but P.Size=8, it means that P has been
-// extended (e.g. it is evaluated on a larger set) but P is a polynomial
-// of degree 7.
-// blindedSize is the size of the polynomial when it is blinded. By
-// default blindedSize=Size, until the polynomial is blinded.
-type WrappedPolynomial struct {
-	*Polynomial
-	shift       int
-	size        int
-	blindedSize int
-}
-
-// NewWrappedPolynomial returned a WrappedPolynomial from p.
-// ! Warning this does not do a deep copy of p, and modifications on the wrapped
-// polynomial will modify the underlying coefficients of p.
-func NewWrappedPolynomial(p *Polynomial) *WrappedPolynomial {
-	return &WrappedPolynomial{
-		Polynomial:           p,
-		size:        len(p.Coefficients),
-		blindedSize: len(p.Coefficients),
-	}
-}
-
-// Shift the wrapped polynomial; it doesn't modify the underlying data structure,
-// but flag the WrappedPolynomial such that it will be interpreted as p(\omega^shift X)
-func (wp *WrappedPolynomial) Shift(shift int) *WrappedPolynomial {
-	wp.shift = shift
-	return wp
-}
-
-// BlindedSize returns the the size of the polynomial when it is blinded. By
-// default blindedSize=Size, until the polynomial is blinded.
-func (wp *WrappedPolynomial) BlindedSize() int {
-	return wp.blindedSize
-}
-
-
-// Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
-// where deg Q = blindingOrder and Q is random, and n is the
-// size of q. Sets the result to p and returns it.
-//
-// blindingOrder is the degree of Q, where the blinding is Q(X)*(X^{n}-1)
-// where n is the size of wp. The size of wp is modified since the underlying
-// polynomial is of bigger degree now. The new size is wp.Size+1+blindingOrder.
-//
-// /!\ The code panics if wq is not in canonical, regular layout
-func (wp *WrappedPolynomial) Blind(blindingOrder int) *WrappedPolynomial {
-	// check that wp is in canonical basis
-	if wp.Form != canonicalRegular {
-		panic("the input must be in canonical basis, regular layout")
-	}
-
-	// we add Q*(x^{n}-1) so the new size is deg(Q)+n+1
-	// where n is the size of wq.
-	newSize := wp.size + blindingOrder + 1
-
-	// Resize wp. The size of wq might has already been increased
-	// (e.g. when the polynomial is evaluated on a larger domain),
-	// if that's the case we don't resize the polynomial.
-	offset := newSize - len(wp.Coefficients)
-	if offset > 0 {
-		z := make([]fr.Element, offset)
-		// TODO @gbotrel that's a dangerous thing; subsequent methods behavior diverge:
-		// some will mutate the original polynomial, some will not.
-		wp.Coefficients = append(wp.Coefficients, z...)
-	}
-
-	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
-	var r fr.Element
-
-	for i := 0; i <= blindingOrder; i++ {
-		r.SetRandom()
-		wp.Coefficients[i].Sub(&wp.Coefficients[i], &r)
-		wp.Coefficients[i+wp.size].Add(&wp.Coefficients[i+wp.size], &r)
-	}
-	wp.blindedSize = newSize
-
-	return wp
-}
-
-
-// Evaluate evaluates p at x.
-// The code panics if the function is not in canonical form.
-func (wp *WrappedPolynomial) Evaluate(x fr.Element) fr.Element {
-
-	if wp.shift == 0 {
-		return wp.Polynomial.Evaluate(x)
-	}
-
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(wp.size))
-	var g fr.Element
-	if wp.shift <= 5 {
-		g = smallExp(d.Generator, wp.shift)
-		x.Mul(&x, &g)
-		return wp.Polynomial.Evaluate(x)
-	}
-
-	bs := big.NewInt(int64(wp.shift))
-	g = *g.Exp(g, bs)
-	x.Mul(&x, &g)
-	return wp.Polynomial.Evaluate(x)
-}
-
-// Clone returns a deep copy of wp. The underlying polynomial is cloned; 
-// see also ShallowClone to perform a ShallowClone on the underlying polynomial.
-// If capacity is provided, the new coefficient slice capacity will be set accordingly.
-func (wp *WrappedPolynomial) Clone(capacity ...int) *WrappedPolynomial {
-	res := wp.ShallowClone()
-	res.Polynomial = wp.Polynomial.Clone(capacity...)
-	return res
-}
-
-// ShallowClone returns a shallow copy of wp. The underlying polynomial coefficient
-// is NOT cloned and both objects will point to the same coefficient vector.
-func (wp *WrappedPolynomial) ShallowClone() *WrappedPolynomial {
-	res := *wp
-	return &res
-}
-
-
-// GetCoeff returns the i-th entry of wp, taking the layout in account.
-func (wp *WrappedPolynomial) GetCoeff(i int) fr.Element {
-
-	n := len(wp.Coefficients)
-	rho := n / wp.size
-	if wp.Polynomial.Form.Layout == Regular {
-		return wp.Coefficients[(i+rho*wp.shift)%n]
-	} else {
-		nn := uint64(64 - bits.TrailingZeros(uint(n)))
-		iRev := bits.Reverse64(uint64((i+rho*wp.shift)%n)) >> nn
-		return wp.Coefficients[iRev]
-	}
-
 }

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -107,11 +107,7 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 	// Resize p. The size of wq might has already been increased
 	// (e.g. when the polynomial is evaluated on a larger domain),
 	// if that's the case we don't resize the polynomial.
-	offset := newSize - p.coefficients.Len()
-	if offset > 0 {
-		z := make(fr.Vector, offset)
-		(*p.coefficients) = append((*p.coefficients), z...)
-	}
+	p.grow(newSize)
 
 	// blinding: we add Q(X)(X^{n}-1) to P, where deg(Q)=blindingOrder
 	var r fr.Element
@@ -269,7 +265,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 // Leaves p unchanged if p was already in Lagrange form.
 func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form 
-	resize(p.polynomial, d.Cardinality)
+	p.grow(int(d.Cardinality))
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
@@ -298,7 +294,7 @@ func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 // Leaves p unchanged if p was already in Canonical form.
 func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p.polynomial, d.Cardinality)
+	p.grow(int(d.Cardinality))
 	switch id {
 	case canonicalRegular,canonicalBitReverse:
 		return p
@@ -321,15 +317,17 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	return p
 }
 
-func resize(p *polynomial, newSize uint64) {
-	z := make(fr.Vector, int(newSize)-p.coefficients.Len())
-	(*p.coefficients) = append((*p.coefficients), z...)
+func (p *polynomial) grow(newSize int) {
+	offset := newSize - p.coefficients.Len()
+	if offset > 0 {
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
+	}
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
 func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
-	resize(p.polynomial, d.Cardinality)
+	p.grow(int(d.Cardinality))
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -25,6 +25,7 @@ const (
 	BitReverse
 )
 
+
 // Form describes the form of a polynomial.
 // TODO should be a regular enum?
 type Form struct {
@@ -32,16 +33,18 @@ type Form struct {
 	Layout Layout
 }
 
+
 // enum of the possible Form values for type-safe switches
 // in this package
 var (
-	canonicalRegular        = Form{Canonical, Regular}
-	canonicalBitReverse     = Form{Canonical, BitReverse}
-	lagrangeRegular         = Form{Lagrange, Regular}
-	lagrangeBitReverse      = Form{Lagrange, BitReverse}
-	lagrangeCosetRegular    = Form{LagrangeCoset, Regular}
+	canonicalRegular = Form{Canonical, Regular}
+	canonicalBitReverse = Form{Canonical, BitReverse}
+	lagrangeRegular = Form{Lagrange, Regular}
+	lagrangeBitReverse = Form{Lagrange, BitReverse}
+	lagrangeCosetRegular = Form{LagrangeCoset, Regular}
 	lagrangeCosetBitReverse = Form{LagrangeCoset, BitReverse}
 )
+
 
 // Polynomial wraps a polynomial so that it is
 // interpreted as P'(X)=P(\omega^{shift}X).
@@ -59,14 +62,14 @@ type Polynomial struct {
 }
 
 // NewPolynomial returned a Polynomial from the provided coefficients in the given form.
-// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
-// It is the responsibility of the user to call the Clone method if the coefficients
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients. 
+// It is the responsibility of the user to call the Clone method if the coefficients 
 // shouldn't be mutated.
-func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(coeffs),
-		blindedSize: len(coeffs),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -82,6 +85,7 @@ func (p *Polynomial) Shift(shift int) *Polynomial {
 func (p *Polynomial) BlindedSize() int {
 	return p.blindedSize
 }
+
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
 // where deg Q = blindingOrder and Q is random, and n is the
@@ -112,13 +116,14 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		p.coefficients[i].Sub(&p.coefficients[i], &r)
-		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
+		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
+		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
 	return p
 }
+
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
@@ -143,7 +148,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	return p.polynomial.evaluate(x)
 }
 
-// Clone returns a deep copy of p. The underlying polynomial is cloned;
+// Clone returns a deep copy of p. The underlying polynomial is cloned; 
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
@@ -159,37 +164,39 @@ func (p *Polynomial) ShallowClone() *Polynomial {
 	return &res
 }
 
+
 // GetCoeff returns the i-th entry of p, taking the layout in account.
 func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return p.coefficients[(i+rho*p.shift)%n]
+		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return p.coefficients[iRev]
+		return (*p.coefficients)[iRev]
 	}
 
 }
 
+
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients fr.Vector
+	coefficients *fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return p.coefficients
+	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -200,12 +207,13 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients: newCoeffs,
-		Form:         p.Form,
+		coefficients:&newCoeffs,
+		Form: p.Form,
 	}
-	copy(r.coefficients, p.coefficients)
+	copy((*r.coefficients), (*p.coefficients))
 	return r
 }
+
 
 // evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
@@ -218,13 +226,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
+			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
 		}
 	}
 
@@ -238,10 +246,11 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = Regular
 	return p
 }
+
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
@@ -249,7 +258,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse(p.coefficients)
+	fft.BitReverse((*p.coefficients))
 	p.Layout = BitReverse
 	return p
 }
@@ -257,25 +266,25 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
 func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
-	id := p.Form
+	id := p.Form 
 	p.grow(int(d.Cardinality))
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((p.coefficients), fft.DIT)
-	case lagrangeRegular, lagrangeBitReverse:
+		d.FFT((*p.coefficients), fft.DIT)
+	case lagrangeRegular,lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((p.coefficients), fft.DIF, true)
-		d.FFT((p.coefficients), fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((p.coefficients), fft.DIT, true)
-		d.FFT((p.coefficients), fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -289,20 +298,20 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
 	p.grow(int(d.Cardinality))
 	switch id {
-	case canonicalRegular, canonicalBitReverse:
+	case canonicalRegular,canonicalBitReverse:
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFTInverse((*p.coefficients), fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFTInverse((*p.coefficients), fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -313,7 +322,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
+		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
 	}
 }
 
@@ -324,18 +333,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse(p.coefficients, fft.DIF)
-		d.FFT(p.coefficients, fft.DIT, true)
+		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFT((*p.coefficients), fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse(p.coefficients, fft.DIT)
-		d.FFT(p.coefficients, fft.DIF, true)
+		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFT((*p.coefficients), fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -346,12 +355,14 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	return p
 }
 
-// WriteTo implements io.WriterTo
+
+
+// WriteTo implements io.WriterTo 
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
-	// encode coefficients
+	// encode coefficients 
 	n, err := p.polynomial.coefficients.WriteTo(w)
 	if err != nil {
-		return n, err
+		return n, err 
 	}
 
 	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
@@ -379,11 +390,12 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		p.polynomial.coefficients = make(fr.Vector, 0)
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {
-		return n, err
+		return n, err 
 	}
 
 	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
@@ -404,5 +416,5 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	p.size = int(data[3])
 	p.blindedSize = int(data[4])
 
-	return n, nil
+    return n, nil 
 }

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -203,8 +203,8 @@ func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
 	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
-// Clone returns a deep copy of the underlying data structure.
-func (p *polynomial) Clone(capacity ...int) *polynomial {
+// clone returns a deep copy of the underlying data structure.
+func (p *polynomial) clone(capacity ...int) *polynomial {
 	c := p.coefficients.Len()
 	if len(capacity) == 1 && capacity[0] > c {
 		c = capacity[0]
@@ -247,7 +247,7 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
-func (p *polynomial) ToRegular() *polynomial {
+func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
@@ -259,7 +259,7 @@ func (p *polynomial) ToRegular() *polynomial {
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
-func (p *polynomial) ToBitReverse() *polynomial {
+func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
@@ -270,7 +270,7 @@ func (p *polynomial) ToBitReverse() *polynomial {
 
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
-func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
 	id := p.Form 
 	resize(p, d.Cardinality)
 	switch id {
@@ -299,7 +299,7 @@ func (p *polynomial) ToLagrange(d *fft.Domain) *polynomial {
 
 // ToCanonical converts p to canonical form.
 // Leaves p unchanged if p was already in Canonical form.
-func (p *polynomial) ToCanonical(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
 	resize(p, d.Cardinality)
 	switch id {
@@ -332,7 +332,7 @@ func resize(p *polynomial, newSize uint64) {
 }
 
 // ToLagrangeCoset Sets p to q, in LagrangeCoset form and returns it.
-func (p *polynomial) ToLagrangeCoset(d *fft.Domain) *polynomial {
+func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	id := p.Form
 	resize(p, d.Cardinality)
 	switch id {

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -244,7 +244,6 @@ func (p *polynomial) Evaluate(x fr.Element) fr.Element {
 
 }
 
-
 // ToRegular changes the layout of p to Regular.
 // Leaves p unchanged if p's layout was already Regular.
 func (p *Polynomial) ToRegular() *Polynomial {

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -25,7 +25,6 @@ const (
 	BitReverse
 )
 
-
 // Form describes the form of a polynomial.
 // TODO should be a regular enum?
 type Form struct {
@@ -33,18 +32,16 @@ type Form struct {
 	Layout Layout
 }
 
-
 // enum of the possible Form values for type-safe switches
 // in this package
 var (
-	canonicalRegular = Form{Canonical, Regular}
-	canonicalBitReverse = Form{Canonical, BitReverse}
-	lagrangeRegular = Form{Lagrange, Regular}
-	lagrangeBitReverse = Form{Lagrange, BitReverse}
-	lagrangeCosetRegular = Form{LagrangeCoset, Regular}
+	canonicalRegular        = Form{Canonical, Regular}
+	canonicalBitReverse     = Form{Canonical, BitReverse}
+	lagrangeRegular         = Form{Lagrange, Regular}
+	lagrangeBitReverse      = Form{Lagrange, BitReverse}
+	lagrangeCosetRegular    = Form{LagrangeCoset, Regular}
 	lagrangeCosetBitReverse = Form{LagrangeCoset, BitReverse}
 )
-
 
 // Polynomial wraps a polynomial so that it is
 // interpreted as P'(X)=P(\omega^{shift}X).
@@ -62,14 +59,14 @@ type Polynomial struct {
 }
 
 // NewPolynomial returned a Polynomial from the provided coefficients in the given form.
-// A Polynomial can be seen as a "shared pointer" on a list of coefficients. 
-// It is the responsibility of the user to call the Clone method if the coefficients 
+// A Polynomial can be seen as a "shared pointer" on a list of coefficients.
+// It is the responsibility of the user to call the Clone method if the coefficients
 // shouldn't be mutated.
-func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
+func NewPolynomial(coeffs []fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        len(*coeffs),
-		blindedSize: len(*coeffs),
+		size:        len(coeffs),
+		blindedSize: len(coeffs),
 	}
 }
 
@@ -85,7 +82,6 @@ func (p *Polynomial) Shift(shift int) *Polynomial {
 func (p *Polynomial) BlindedSize() int {
 	return p.blindedSize
 }
-
 
 // Blind blinds a polynomial q by adding Q(X)*(X^{n}-1),
 // where deg Q = blindingOrder and Q is random, and n is the
@@ -116,14 +112,13 @@ func (p *Polynomial) Blind(blindingOrder int) *Polynomial {
 
 	for i := 0; i <= blindingOrder; i++ {
 		r.SetRandom()
-		(*p.coefficients)[i].Sub(&(*p.coefficients)[i], &r)
-		(*p.coefficients)[i+p.size].Add(&(*p.coefficients)[i+p.size], &r)
+		p.coefficients[i].Sub(&p.coefficients[i], &r)
+		p.coefficients[i+p.size].Add(&p.coefficients[i+p.size], &r)
 	}
 	p.blindedSize = newSize
 
 	return p
 }
-
 
 // Evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
@@ -148,7 +143,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	return p.polynomial.evaluate(x)
 }
 
-// Clone returns a deep copy of p. The underlying polynomial is cloned; 
+// Clone returns a deep copy of p. The underlying polynomial is cloned;
 // see also ShallowClone to perform a ShallowClone on the underlying polynomial.
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
@@ -164,39 +159,37 @@ func (p *Polynomial) ShallowClone() *Polynomial {
 	return &res
 }
 
-
 // GetCoeff returns the i-th entry of p, taking the layout in account.
 func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
 	if p.polynomial.Form.Layout == Regular {
-		return (*p.coefficients)[(i+rho*p.shift)%n]
+		return p.coefficients[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		iRev := bits.Reverse64(uint64((i+rho*p.shift)%n)) >> nn
-		return (*p.coefficients)[iRev]
+		return p.coefficients[iRev]
 	}
 
 }
 
-
 // polynomial represents a polynomial, the vector of coefficients
 // along with the basis and the layout.
 type polynomial struct {
-	coefficients *fr.Vector
+	coefficients fr.Vector
 	Form
 }
 
 // Coefficients returns a slice on the underlying data structure.
 func (p *polynomial) Coefficients() []fr.Element {
-	return (*p.coefficients)
+	return p.coefficients
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
-	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
+func newPolynomial(coeffs []fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: fr.Vector(coeffs), Form: form}
 }
 
 // clone returns a deep copy of the underlying data structure.
@@ -207,13 +200,12 @@ func (p *polynomial) clone(capacity ...int) *polynomial {
 	}
 	newCoeffs := make(fr.Vector, p.coefficients.Len(), c)
 	r := &polynomial{
-		coefficients:&newCoeffs,
-		Form: p.Form,
+		coefficients: newCoeffs,
+		Form:         p.Form,
 	}
-	copy((*r.coefficients), (*p.coefficients))
+	copy(r.coefficients, p.coefficients)
 	return r
 }
-
 
 // evaluate evaluates p at x.
 // The code panics if the function is not in canonical form.
@@ -226,13 +218,13 @@ func (p *polynomial) evaluate(x fr.Element) fr.Element {
 
 	if p.Layout == Regular {
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
-			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[i])
+			r.Mul(&r, &x).Add(&r, &p.coefficients[i])
 		}
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(p.coefficients.Len())))
 		for i := p.coefficients.Len() - 1; i >= 0; i-- {
 			iRev := bits.Reverse64(uint64(i)) >> nn
-			r.Mul(&r, &x).Add(&r, &(*p.coefficients)[iRev])
+			r.Mul(&r, &x).Add(&r, &p.coefficients[iRev])
 		}
 	}
 
@@ -246,11 +238,10 @@ func (p *Polynomial) ToRegular() *Polynomial {
 	if p.Layout == Regular {
 		return p
 	}
-	fft.BitReverse((*p.coefficients))
+	fft.BitReverse(p.coefficients)
 	p.Layout = Regular
 	return p
 }
-
 
 // ToBitReverse changes the layout of p to BitReverse.
 // Leaves p unchanged if p's layout was already BitReverse.
@@ -258,7 +249,7 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 	if p.Layout == BitReverse {
 		return p
 	}
-	fft.BitReverse((*p.coefficients))
+	fft.BitReverse(p.coefficients)
 	p.Layout = BitReverse
 	return p
 }
@@ -266,25 +257,25 @@ func (p *Polynomial) ToBitReverse() *Polynomial {
 // ToLagrange converts p to Lagrange form.
 // Leaves p unchanged if p was already in Lagrange form.
 func (p *Polynomial) ToLagrange(d *fft.Domain) *Polynomial {
-	id := p.Form 
+	id := p.Form
 	p.grow(int(d.Cardinality))
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((*p.coefficients), fft.DIF)
+		d.FFT((p.coefficients), fft.DIF)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((*p.coefficients), fft.DIT)
-	case lagrangeRegular,lagrangeBitReverse:
+		d.FFT((p.coefficients), fft.DIT)
+	case lagrangeRegular, lagrangeBitReverse:
 		return p
 	case lagrangeCosetRegular:
 		p.Layout = Regular
-		d.FFTInverse((*p.coefficients), fft.DIF, true)
-		d.FFT((*p.coefficients), fft.DIT)
+		d.FFTInverse((p.coefficients), fft.DIF, true)
+		d.FFT((p.coefficients), fft.DIT)
 	case lagrangeCosetBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((*p.coefficients), fft.DIT, true)
-		d.FFT((*p.coefficients), fft.DIF)
+		d.FFTInverse((p.coefficients), fft.DIT, true)
+		d.FFT((p.coefficients), fft.DIF)
 	default:
 		panic("unknown ID")
 	}
@@ -298,20 +289,20 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 	id := p.Form
 	p.grow(int(d.Cardinality))
 	switch id {
-	case canonicalRegular,canonicalBitReverse:
+	case canonicalRegular, canonicalBitReverse:
 		return p
 	case lagrangeRegular:
 		p.Layout = BitReverse
-		d.FFTInverse((*p.coefficients), fft.DIF)
+		d.FFTInverse(p.coefficients, fft.DIF)
 	case lagrangeBitReverse:
 		p.Layout = Regular
-		d.FFTInverse((*p.coefficients), fft.DIT)
+		d.FFTInverse(p.coefficients, fft.DIT)
 	case lagrangeCosetRegular:
 		p.Layout = BitReverse
-		d.FFTInverse((*p.coefficients), fft.DIF, true)
+		d.FFTInverse(p.coefficients, fft.DIF, true)
 	case lagrangeCosetBitReverse:
 		p.Layout = Regular
-		d.FFTInverse((*p.coefficients), fft.DIT, true)
+		d.FFTInverse(p.coefficients, fft.DIT, true)
 	default:
 		panic("unknown ID")
 	}
@@ -322,7 +313,7 @@ func (p *Polynomial) ToCanonical(d *fft.Domain) *Polynomial {
 func (p *polynomial) grow(newSize int) {
 	offset := newSize - p.coefficients.Len()
 	if offset > 0 {
-		(*p.coefficients) = append((*p.coefficients), make(fr.Vector, offset)...)
+		p.coefficients = append(p.coefficients, make(fr.Vector, offset)...)
 	}
 }
 
@@ -333,18 +324,18 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	switch id {
 	case canonicalRegular:
 		p.Layout = BitReverse
-		d.FFT((*p.coefficients), fft.DIF, true)
+		d.FFT(p.coefficients, fft.DIF, true)
 	case canonicalBitReverse:
 		p.Layout = Regular
-		d.FFT((*p.coefficients), fft.DIT, true)
+		d.FFT(p.coefficients, fft.DIT, true)
 	case lagrangeRegular:
 		p.Layout = Regular
-		d.FFTInverse((*p.coefficients), fft.DIF)
-		d.FFT((*p.coefficients), fft.DIT, true)
+		d.FFTInverse(p.coefficients, fft.DIF)
+		d.FFT(p.coefficients, fft.DIT, true)
 	case lagrangeBitReverse:
 		p.Layout = BitReverse
-		d.FFTInverse((*p.coefficients), fft.DIT)
-		d.FFT((*p.coefficients), fft.DIF, true)
+		d.FFTInverse(p.coefficients, fft.DIT)
+		d.FFT(p.coefficients, fft.DIF, true)
 	case lagrangeCosetRegular, lagrangeCosetBitReverse:
 		return p
 	default:
@@ -355,14 +346,12 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 	return p
 }
 
-
-
-// WriteTo implements io.WriterTo 
+// WriteTo implements io.WriterTo
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
-	// encode coefficients 
+	// encode coefficients
 	n, err := p.polynomial.coefficients.WriteTo(w)
 	if err != nil {
-		return n, err 
+		return n, err
 	}
 
 	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
@@ -390,12 +379,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 		p.polynomial = new(polynomial)
 	}
 	if p.polynomial.coefficients == nil {
-		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.polynomial.coefficients = make(fr.Vector, 0)
 	}
 	n, err := p.polynomial.coefficients.ReadFrom(r)
 	if err != nil {
-		return n, err 
+		return n, err
 	}
 
 	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
@@ -416,5 +404,5 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	p.size = int(data[3])
 	p.blindedSize = int(data[4])
 
-    return n, nil 
+	return n, nil
 }

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -63,11 +63,11 @@ type Polynomial struct {
 // A Polynomial can be seen as a "shared pointer" on a list of coefficients. 
 // It is the responsibility of the user to call the Clone method if the coefficients 
 // shouldn't be mutated.
-func NewPolynomial(coeffs *fr.Vector, form Form) *Polynomial {
+func NewPolynomial(coeffs *[]fr.Element, form Form) *Polynomial {
 	return &Polynomial{
 		polynomial:  newPolynomial(coeffs, form),
-		size:        coeffs.Len(),
-		blindedSize: coeffs.Len(),
+		size:        len(*coeffs),
+		blindedSize: len(*coeffs),
 	}
 }
 
@@ -193,15 +193,14 @@ type polynomial struct {
 }
 
 // Coefficients returns a slice on the underlying data structure.
-// TODO @gbotrel check indirection cost 
 func (p *polynomial) Coefficients() []fr.Element {
 	return (*p.coefficients)
 }
 
 // newPolynomial creates a new polynomial. The slice coeff NOT copied
 // but directly assigned to the new polynomial.
-func newPolynomial(coeffs *fr.Vector, form Form) *polynomial {
-	return &polynomial{coefficients: coeffs, Form: form}
+func newPolynomial(coeffs *[]fr.Element, form Form) *polynomial {
+	return &polynomial{coefficients: (*fr.Vector)(coeffs), Form: form}
 }
 
 // Clone returns a deep copy of the underlying data structure.

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -1,6 +1,8 @@
 import (
 	"math/big"
 	"math/bits"
+	"io"
+	"encoding/binary"
 
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/fft"
@@ -351,4 +353,68 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 
 	p.Basis = LagrangeCoset
 	return p
+}
+
+
+
+// WriteTo implements io.WriterTo 
+func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
+	// encode coefficients 
+	n, err := p.polynomial.coefficients.WriteTo(w)
+	if err != nil {
+		return n, err 
+	}
+
+	// encode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data = []uint32{
+		uint32(p.Basis),
+		uint32(p.Layout),
+		uint32(p.shift),
+		uint32(p.size),
+		uint32(p.blindedSize),
+	}
+	for _, v := range data {
+		err = binary.Write(w, binary.BigEndian, v)
+		if err != nil {
+			return n, err
+		}
+		n += 4
+	}
+	return n, nil
+}
+
+// ReadFrom implements io.ReaderFrom
+func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
+	// decode coefficients
+	if p.polynomial == nil {
+		p.polynomial = new(polynomial)
+	}
+	if p.polynomial.coefficients == nil {
+		v := make(fr.Vector, 0)
+		p.polynomial.coefficients = &v
+	}
+	n, err := p.polynomial.coefficients.ReadFrom(r)
+	if err != nil {
+		return n, err 
+	}
+
+	// decode Form.Basis, Form.Layout, shift, size & blindedSize as uint32
+	var data [5]uint32
+	var buf [4]byte
+	for i := range data {
+		read, err := io.ReadFull(r, buf[:4])
+		n += int64(read)
+		if err != nil {
+			return n, err
+		}
+		data[i] = binary.BigEndian.Uint32(buf[:4])
+	}
+
+	p.Basis = Basis(data[0])
+	p.Layout = Layout(data[1])
+	p.shift = int(data[2])
+	p.size = int(data[3])
+	p.blindedSize = int(data[4])
+
+    return n, nil 
 }

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -40,9 +40,9 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *fr.Vector {
+func randomVector(size int) *[]fr.Element {
 
-	r := make(fr.Vector, size)
+	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
@@ -52,7 +52,7 @@ func randomVector(size int) *fr.Vector {
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
@@ -240,7 +240,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -408,7 +408,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -577,7 +577,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.coefficients = c
+	p.coefficients = (*fr.Vector)(c)
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -45,13 +45,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *[]fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -61,7 +61,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -100,6 +100,7 @@ func TestGetCoeff(t *testing.T) {
 
 }
 
+
 func TestRoundTrip(t *testing.T) {
 	assert := require.New(t)
 	var buf bytes.Buffer
@@ -108,7 +109,7 @@ func TestRoundTrip(t *testing.T) {
 	d := fft.NewDomain(uint64(8))
 	blindingOrder := 2
 
-	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
 	p.Blind(blindingOrder)
 
 	// serialize
@@ -122,7 +123,7 @@ func TestRoundTrip(t *testing.T) {
 
 	assert.Equal(read, written, "number of bytes written != number of bytes read")
 
-	// compare
+	// compare 
 	assert.Equal(p.Basis, reconstructed.Basis)
 	assert.Equal(p.Layout, reconstructed.Layout)
 	assert.Equal(p.shift, reconstructed.shift)
@@ -141,7 +142,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
+	wp := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -257,13 +258,13 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q fr.Vector) bool {
+func cmpCoefficents(p, q *fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !p[i].Equal(&q[i]) {
-			return false
+		if !((*p)[i].Equal(&(*q)[i])){
+			return false 
 		}
 	}
 	return true

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -19,10 +19,10 @@ func TestEvaluation(t *testing.T) {
 	// regular layout
 	a := wp.Evaluate(d.Generator)
 	b := wps.Evaluate(d.Generator)
-	if !a.Equal(&ref.Coefficients[1]) {
+	if !a.Equal(&ref.Coefficients()[1]) {
 		t.Fatal("error evaluation")
 	}
-	if !b.Equal(&ref.Coefficients[1+shift]) {
+	if !b.Equal(&ref.Coefficients()[1+shift]) {
 		t.Fatal("error evaluation shifted")
 	}
 
@@ -31,32 +31,32 @@ func TestEvaluation(t *testing.T) {
 	wps.ToBitReverse()
 	a = wp.Evaluate(d.Generator)
 	b = wps.Evaluate(d.Generator)
-	if !a.Equal(&ref.Coefficients[1]) {
+	if !a.Equal(&ref.Coefficients()[1]) {
 		t.Fatal("error evaluation")
 	}
-	if !b.Equal(&ref.Coefficients[1+shift]) {
+	if !b.Equal(&ref.Coefficients()[1+shift]) {
 		t.Fatal("error evaluation shifted")
 	}
 
 }
 
-func randomVector(size int) []fr.Element {
+func randomVector(size int) *fr.Vector {
 
-	r := make([]fr.Element, size)
+	r := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return r
+	return &r
 }
 
 func TestGetCoeff(t *testing.T) {
 
 	size := 8
-	v := make([]fr.Element, size)
+	v := make(fr.Vector, size)
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -111,7 +111,7 @@ func TestBlinding(t *testing.T) {
 	wp.Basis = Canonical
 	wt := wp.Clone()
 	wt.Blind(blindingOrder)
-	if len(wt.Coefficients) != blindingOrder+size+1 {
+	if wt.coefficients.Len() != blindingOrder+size+1 {
 		t.Fatal("size of blinded polynomial is incorrect")
 	}
 	if wt.blindedSize != size+blindingOrder+1 {
@@ -148,8 +148,8 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
-	d.FFTInverse(r.Coefficients, fft.DIF)
-	fft.BitReverse(r.Coefficients)
+	d.FFTInverse(r.Coefficients(), fft.DIF)
+	fft.BitReverse(r.Coefficients())
 	return r
 }
 
@@ -158,7 +158,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
-	d.FFTInverse(r.Coefficients, fft.DIF)
+	d.FFTInverse(r.Coefficients(), fft.DIF)
 	return r
 }
 
@@ -175,7 +175,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
-	fft.BitReverse(r.Coefficients)
+	fft.BitReverse(r.Coefficients())
 	return r
 }
 
@@ -184,8 +184,8 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
-	d.FFTInverse(r.Coefficients, fft.DIF)
-	d.FFT(r.Coefficients, fft.DIT, true)
+	d.FFTInverse(r.Coefficients(), fft.DIF)
+	d.FFT(r.Coefficients(), fft.DIT, true)
 	return r
 }
 
@@ -194,9 +194,9 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
-	d.FFTInverse(r.Coefficients, fft.DIF)
-	d.FFT(r.Coefficients, fft.DIT, true)
-	fft.BitReverse(r.Coefficients)
+	d.FFTInverse(r.Coefficients(), fft.DIF)
+	d.FFT(r.Coefficients(), fft.DIT, true)
+	fft.BitReverse(r.Coefficients())
 	return r
 }
 
@@ -220,15 +220,16 @@ func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	}
 }
 
-func cmpCoefficents(p, q []fr.Element) bool {
-	if len(p) != len(q) {
+func cmpCoefficents(p, q *fr.Vector) bool {
+	if p.Len() != q.Len() {
 		return false
 	}
-	res := true
-	for i := 0; i < len(p); i++ {
-		res = res && (p[i].Equal(&q[i]))
+	for i := 0; i < p.Len(); i++ {
+		if !((*p)[i].Equal(&(*q)[i])){
+			return false 
+		}
 	}
-	return res
+	return true
 }
 
 func TestPutInLagrangeForm(t *testing.T) {
@@ -239,7 +240,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.Coefficients = c
+	p.coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -254,8 +255,8 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is BitReverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -271,7 +272,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is Regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -288,7 +289,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is Regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -304,8 +305,8 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is BitReverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -321,7 +322,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is Regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -337,8 +338,8 @@ func TestPutInLagrangeForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is BitReverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -366,8 +367,8 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
-	d.FFT(_p.Coefficients, fft.DIF)
-	fft.BitReverse(_p.Coefficients)
+	d.FFT(_p.Coefficients(), fft.DIF)
+	fft.BitReverse(_p.Coefficients())
 	return _p
 }
 
@@ -376,7 +377,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
-	d.FFT(_p.Coefficients, fft.DIF)
+	d.FFT(_p.Coefficients(), fft.DIF)
 	return _p
 }
 
@@ -385,8 +386,8 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
-	d.FFT(_p.Coefficients, fft.DIF, true)
-	fft.BitReverse(_p.Coefficients)
+	d.FFT(_p.Coefficients(), fft.DIF, true)
+	fft.BitReverse(_p.Coefficients())
 	return _p
 }
 
@@ -395,7 +396,7 @@ func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
-	d.FFT(_p.Coefficients, fft.DIF, true)
+	d.FFT(_p.Coefficients(), fft.DIF, true)
 	return _p
 }
 
@@ -407,7 +408,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.Coefficients = c
+	p.coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
 
@@ -422,7 +423,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -438,7 +439,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is bitReverse")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -454,8 +455,8 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is bitReverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(p.Coefficients, q.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(p.coefficients, q.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -471,7 +472,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -487,8 +488,8 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is BitReverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -504,7 +505,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -516,8 +517,8 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
-	d.FFTInverse(_p.Coefficients, fft.DIF, true)
-	fft.BitReverse(_p.Coefficients)
+	d.FFTInverse(_p.Coefficients(), fft.DIF, true)
+	fft.BitReverse(_p.Coefficients())
 	return _p
 }
 
@@ -526,7 +527,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
-	d.FFTInverse(_p.Coefficients, fft.DIF, true)
+	d.FFTInverse(_p.Coefficients(), fft.DIF, true)
 	return _p
 }
 
@@ -535,8 +536,8 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
-	d.FFTInverse(_p.Coefficients, fft.DIF, true)
-	d.FFT(_p.Coefficients, fft.DIT)
+	d.FFTInverse(_p.Coefficients(), fft.DIF, true)
+	d.FFT(_p.Coefficients(), fft.DIT)
 	return _p
 }
 
@@ -545,9 +546,9 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
-	d.FFTInverse(_p.Coefficients, fft.DIF, true)
-	d.FFT(_p.Coefficients, fft.DIT)
-	fft.BitReverse(_p.Coefficients)
+	d.FFTInverse(_p.Coefficients(), fft.DIF, true)
+	d.FFT(_p.Coefficients(), fft.DIT)
+	fft.BitReverse(_p.Coefficients())
 	return _p
 }
 
@@ -564,7 +565,7 @@ func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
-	fft.BitReverse(p.Coefficients)
+	fft.BitReverse(p.Coefficients())
 	return _p
 }
 
@@ -576,7 +577,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 	// reference vector in canonical-regular form
 	c := randomVector(size)
 	var p polynomial
-	p.Coefficients = c
+	p.coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular
 
@@ -591,8 +592,8 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is bit reverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -608,7 +609,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -624,7 +625,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -640,8 +641,8 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is bit reverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -657,7 +658,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != Regular {
 			t.Fatal("expected layout is regular")
 		}
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}
@@ -673,8 +674,8 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 		if q.Layout != BitReverse {
 			t.Fatal("expected layout is bit reverse")
 		}
-		fft.BitReverse(q.Coefficients)
-		if !cmpCoefficents(q.Coefficients, p.Coefficients) {
+		fft.BitReverse(q.Coefficients())
+		if !cmpCoefficents(q.coefficients, p.coefficients) {
 			t.Fatal("wrong coefficients")
 		}
 	}

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -3,6 +3,11 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/fft"
+
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+	"reflect"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -93,6 +98,39 @@ func TestGetCoeff(t *testing.T) {
 		}
 	}
 
+}
+
+
+func TestRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	var buf bytes.Buffer
+
+	size := 8
+	d := fft.NewDomain(uint64(8))
+	blindingOrder := 2
+
+	p := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p.Blind(blindingOrder)
+
+	// serialize
+	written, err := p.WriteTo(&buf)
+	assert.NoError(err)
+
+	// deserialize
+	var reconstructed Polynomial
+	read, err := reconstructed.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(read, written, "number of bytes written != number of bytes read")
+
+	// compare 
+	assert.Equal(p.Basis, reconstructed.Basis)
+	assert.Equal(p.Layout, reconstructed.Layout)
+	assert.Equal(p.shift, reconstructed.shift)
+	assert.Equal(p.size, reconstructed.size)
+	assert.Equal(p.blindedSize, reconstructed.blindedSize)
+	c1, c2 := p.Coefficients(), reconstructed.Coefficients()
+	assert.True(reflect.DeepEqual(c1, c2))
 }
 
 func TestBlinding(t *testing.T) {

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -11,9 +11,8 @@ func TestEvaluation(t *testing.T) {
 	shift := 2
 	d := fft.NewDomain(uint64(size))
 	c := randomVector(size)
-	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
-	wp := NewWrappedPolynomial(p)
-	wps := NewWrappedPolynomial(p).Shift(shift)
+	wp := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
+	wps := wp.ShallowClone().Shift(shift)
 	ref := wp.Clone()
 	ref.ToLagrange(d).ToRegular()
 
@@ -57,9 +56,8 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	p := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
-	wp := NewWrappedPolynomial(p)
-	wsp := NewWrappedPolynomial(p).Shift(1)
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
+	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
 
@@ -106,11 +104,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	var p Polynomial
-	p.Coefficients = randomVector(size)
-	p.Basis = Lagrange
-	p.Layout = Regular
-	wp := NewWrappedPolynomial(&p)
+	wp := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -147,10 +141,10 @@ func TestBlinding(t *testing.T) {
 // int(p.Basis)*4 + int(p.Layout)*2 + int(p.Status)
 // p is in Lagrange/Regular here. This function is for testing purpose
 // only.
-type TransfoTest func(p Polynomial, d *fft.Domain) Polynomial
+type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -160,7 +154,7 @@ func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -169,7 +163,7 @@ func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -177,7 +171,7 @@ func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -186,7 +180,7 @@ func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -196,7 +190,7 @@ func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -206,7 +200,7 @@ func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	return r
 }
 
-func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -244,7 +238,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -352,7 +346,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -360,7 +354,7 @@ func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -368,7 +362,7 @@ func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -378,7 +372,7 @@ func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -387,7 +381,7 @@ func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -397,7 +391,7 @@ func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -412,7 +406,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = Canonical
 	p.Layout = Regular
@@ -518,7 +512,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -528,7 +522,7 @@ func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -537,7 +531,7 @@ func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -547,7 +541,7 @@ func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -558,7 +552,7 @@ func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -566,7 +560,7 @@ func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
+func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -581,7 +575,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p Polynomial
+	var p polynomial
 	p.Coefficients = c
 	p.Basis = LagrangeCoset
 	p.Layout = Regular

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -144,7 +144,7 @@ func TestBlinding(t *testing.T) {
 type TransfoTest func(p polynomial, d *fft.Domain) polynomial
 
 // CANONICAL REGULAR
-func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange0(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = Regular
@@ -154,7 +154,7 @@ func fromLagrange0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange1(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Canonical
 	r.Layout = BitReverse
@@ -163,7 +163,7 @@ func fromLagrange1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange2(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = Regular
@@ -171,7 +171,7 @@ func fromLagrange2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange3(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = Lagrange
 	r.Layout = BitReverse
@@ -180,7 +180,7 @@ func fromLagrange3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange4(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = Regular
@@ -190,7 +190,7 @@ func fromLagrange4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange5(p *Polynomial, d *fft.Domain) *Polynomial {
 	r := p.Clone()
 	r.Basis = LagrangeCoset
 	r.Layout = BitReverse
@@ -200,7 +200,7 @@ func fromLagrange5(p *polynomial, d *fft.Domain) *polynomial {
 	return r
 }
 
-func fromLagrange(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	id := p.Form
 	switch id {
 	case canonicalRegular:
@@ -239,14 +239,11 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// reference vector in Lagrange-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrange(&p, domain)
+		_p := fromLagrange(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -263,7 +260,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrange1(&p, domain)
+		_p := fromLagrange1(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -279,7 +276,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrange2(&p, domain)
+		_p := fromLagrange2(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 
@@ -296,7 +293,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrange3(&p, domain)
+		_p := fromLagrange3(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -313,7 +310,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrange4(&p, domain)
+		_p := fromLagrange4(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -329,7 +326,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrange5(&p, domain)
+		_p := fromLagrange5(p, domain)
 		q := _p.Clone()
 		q.ToLagrange(domain)
 		if q.Basis != Lagrange {
@@ -347,7 +344,7 @@ func TestPutInLagrangeForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -355,7 +352,7 @@ func fromCanonical0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -363,7 +360,7 @@ func fromCanonical1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -373,7 +370,7 @@ func fromCanonical2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -382,7 +379,7 @@ func fromCanonical3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -392,7 +389,7 @@ func fromCanonical4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromCanonical5(p *polynomial, d *fft.Domain) *polynomial {
+func fromCanonical5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -407,14 +404,11 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = Canonical
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: Canonical, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromCanonical0(&p, domain)
+		_p := fromCanonical0(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -430,7 +424,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromCanonical1(&p, domain)
+		_p := fromCanonical1(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -446,7 +440,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromCanonical2(&p, domain)
+		_p := fromCanonical2(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -463,7 +457,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromCanonical3(&p, domain)
+		_p := fromCanonical3(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -479,7 +473,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromCanonical4(&p, domain)
+		_p := fromCanonical4(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -496,7 +490,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromCanonical5(&p, domain)
+		_p := fromCanonical5(p, domain)
 		q := _p.Clone()
 		q.ToCanonical(domain)
 		if q.Basis != Canonical {
@@ -513,7 +507,7 @@ func TestPutInCanonicalForm(t *testing.T) {
 }
 
 // CANONICAL REGULAR
-func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset0(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = Regular
@@ -523,7 +517,7 @@ func fromLagrangeCoset0(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // CANONICAL BITREVERSE
-func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset1(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Canonical
 	_p.Layout = BitReverse
@@ -532,7 +526,7 @@ func fromLagrangeCoset1(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE REGULAR
-func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset2(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = Regular
@@ -542,7 +536,7 @@ func fromLagrangeCoset2(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE BITREVERSE
-func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset3(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = Lagrange
 	_p.Layout = BitReverse
@@ -553,7 +547,7 @@ func fromLagrangeCoset3(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET REGULAR
-func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset4(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = Regular
@@ -561,7 +555,7 @@ func fromLagrangeCoset4(p *polynomial, d *fft.Domain) *polynomial {
 }
 
 // LAGRANGE_COSET BITREVERSE
-func fromLagrangeCoset5(p *polynomial, d *fft.Domain) *polynomial {
+func fromLagrangeCoset5(p *Polynomial, d *fft.Domain) *Polynomial {
 	_p := p.Clone()
 	_p.Basis = LagrangeCoset
 	_p.Layout = BitReverse
@@ -576,14 +570,11 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// reference vector in canonical-regular form
 	c := randomVector(size)
-	var p polynomial
-	p.coefficients = (*fr.Vector)(c)
-	p.Basis = LagrangeCoset
-	p.Layout = Regular
+	p := NewPolynomial(c, Form{Basis: LagrangeCoset, Layout: Regular})
 
 	// CANONICAL REGULAR
 	{
-		_p := fromLagrangeCoset0(&p, domain)
+		_p := fromLagrangeCoset0(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -600,7 +591,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// CANONICAL BITREVERSE
 	{
-		_p := fromLagrangeCoset1(&p, domain)
+		_p := fromLagrangeCoset1(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -616,7 +607,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE REGULAR
 	{
-		_p := fromLagrangeCoset2(&p, domain)
+		_p := fromLagrangeCoset2(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -632,7 +623,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE BITREVERSE
 	{
-		_p := fromLagrangeCoset3(&p, domain)
+		_p := fromLagrangeCoset3(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -649,7 +640,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET REGULAR
 	{
-		_p := fromLagrangeCoset4(&p, domain)
+		_p := fromLagrangeCoset4(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {
@@ -665,7 +656,7 @@ func TestPutInLagrangeCosetForm(t *testing.T) {
 
 	// LAGRANGE_COSET BITREVERSE
 	{
-		_p := fromLagrangeCoset5(&p, domain)
+		_p := fromLagrangeCoset5(p, domain)
 		q := _p.Clone()
 		q.ToLagrangeCoset(domain)
 		if q.Basis != LagrangeCoset {

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -45,13 +45,13 @@ func TestEvaluation(t *testing.T) {
 
 }
 
-func randomVector(size int) *[]fr.Element {
+func randomVector(size int) []fr.Element {
 
 	r := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
 		r[i].SetRandom()
 	}
-	return &r
+	return r
 }
 
 func TestGetCoeff(t *testing.T) {
@@ -61,7 +61,7 @@ func TestGetCoeff(t *testing.T) {
 	for i := 0; i < size; i++ {
 		v[i].SetUint64(uint64(i))
 	}
-	wp := NewPolynomial(&v, Form{Layout: Regular, Basis: Canonical})
+	wp := NewPolynomial(v, Form{Layout: Regular, Basis: Canonical})
 	wsp := wp.ShallowClone().Shift(1)
 
 	var aa, bb fr.Element
@@ -100,7 +100,6 @@ func TestGetCoeff(t *testing.T) {
 
 }
 
-
 func TestRoundTrip(t *testing.T) {
 	assert := require.New(t)
 	var buf bytes.Buffer
@@ -109,7 +108,7 @@ func TestRoundTrip(t *testing.T) {
 	d := fft.NewDomain(uint64(8))
 	blindingOrder := 2
 
-	p := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
+	p := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular}).ToCanonical(d).ToRegular()
 	p.Blind(blindingOrder)
 
 	// serialize
@@ -123,7 +122,7 @@ func TestRoundTrip(t *testing.T) {
 
 	assert.Equal(read, written, "number of bytes written != number of bytes read")
 
-	// compare 
+	// compare
 	assert.Equal(p.Basis, reconstructed.Basis)
 	assert.Equal(p.Layout, reconstructed.Layout)
 	assert.Equal(p.shift, reconstructed.shift)
@@ -142,7 +141,7 @@ func TestBlinding(t *testing.T) {
 	// generate a random polynomial in Lagrange form for the moment
 	// to check that an error is raised when the polynomial is not
 	// in canonical form.
-	wp := NewPolynomial(randomVector(size), Form{Basis:Lagrange, Layout: Regular})
+	wp := NewPolynomial(randomVector(size), Form{Basis: Lagrange, Layout: Regular})
 
 	// checks the blinding is correct: the evaluation of the blinded polynomial
 	// should be the same as the original on d's domain
@@ -258,13 +257,13 @@ func fromLagrange(p *Polynomial, d *fft.Domain) *Polynomial {
 	}
 }
 
-func cmpCoefficents(p, q *fr.Vector) bool {
+func cmpCoefficents(p, q fr.Vector) bool {
 	if p.Len() != q.Len() {
 		return false
 	}
 	for i := 0; i < p.Len(); i++ {
-		if !((*p)[i].Equal(&(*q)[i])){
-			return false 
+		if !p[i].Equal(&q[i]) {
+			return false
 		}
 	}
 	return true

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -26,19 +26,20 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
 	nn := uint64(64 - bits.TrailingZeros(uint(nbElmts)))
-	parallel.Execute(a.coefficients.Len(), func(start, end int) {
+	parallel.Execute(a.coefficients.Len(), func(start, end int){
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})
+	
 
 	res.ToCanonical(domains[1])
 

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -25,7 +25,7 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 
 	nbElmts := a.coefficients.Len()
 
-	coeffs := make(fr.Vector, a.coefficients.Len())
+	coeffs := make([]fr.Element, a.coefficients.Len())
 	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -26,20 +26,19 @@ func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, erro
 	nbElmts := a.coefficients.Len()
 
 	coeffs := make([]fr.Element, a.coefficients.Len())
-	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
+	res := NewPolynomial(coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
 	nn := uint64(64 - bits.TrailingZeros(uint(nbElmts)))
-	parallel.Execute(a.coefficients.Len(), func(start, end int){
+	parallel.Execute(a.coefficients.Len(), func(start, end int) {
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			(*res.coefficients)[iRev].
+			res.coefficients[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})
-	
 
 	res.ToCanonical(domains[1])
 

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -21,20 +21,21 @@ func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error
 	// prepare the evaluations of x^n-1 on the big domain's coset
 	xnMinusOneInverseLagrangeCoset := evaluateXnMinusOneDomainBigCoset(domains)
 
-	rho := len(a.Coefficients) / a.size
+	rho := a.coefficients.Len() / a.size
 
-	nbElmts := len(a.Coefficients)
+	nbElmts := a.coefficients.Len()
 
-	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
+	coeffs := make(fr.Vector, a.coefficients.Len())
+	res := NewPolynomial(&coeffs, Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 
 	nn := uint64(64 - bits.TrailingZeros(uint(nbElmts)))
-	parallel.Execute(len(a.Coefficients), func(start, end int){
+	parallel.Execute(a.coefficients.Len(), func(start, end int){
 		for i := start; i < end; i++ {
 			iRev := bits.Reverse64(uint64(i)) >> nn
 			c := a.GetCoeff(i)
-			res.Coefficients[iRev].
+			(*res.coefficients)[iRev].
 				Mul(&c, &xnMinusOneInverseLagrangeCoset[i%rho])
 		}
 	})

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -11,7 +11,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
+func DivideByXMinusOne(a *Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {

--- a/internal/generator/iop/template/quotient.go.tmpl
+++ b/internal/generator/iop/template/quotient.go.tmpl
@@ -11,7 +11,7 @@ import (
 // DivideByXMinusOne
 // The input must be in LagrangeCoset.
 // The result is in Canonical Regular.
-func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPolynomial, error) {
+func DivideByXMinusOne(a Polynomial, domains [2]*fft.Domain) (*Polynomial, error) {
 
 	// check that the basis is LagrangeCoset
 	if a.Basis != LagrangeCoset {
@@ -25,10 +25,7 @@ func DivideByXMinusOne(a WrappedPolynomial, domains [2]*fft.Domain) (*WrappedPol
 
 	nbElmts := len(a.Coefficients)
 
-	var p Polynomial
-	p.Form = Form{Layout: BitReverse, Basis: LagrangeCoset}
-	p.Coefficients = make([]fr.Element, len(a.Coefficients))
-	res := NewWrappedPolynomial(&p)
+	res := NewPolynomial(make([]fr.Element, len(a.Coefficients)), Form{Layout: BitReverse, Basis: LagrangeCoset})
 	res.size = a.size
 	res.blindedSize = a.blindedSize
 

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -19,7 +19,8 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	return NewPolynomial(make([]fr.Element, size), form)
+	v := make(fr.Vector, size)
+	return NewPolynomial(&v, form)
 }
 
 
@@ -49,12 +50,12 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients[i].SetRandom()
-		entries[1].Coefficients[i].SetRandom()
+		entries[0].Coefficients()[i].SetRandom()
+		entries[1].Coefficients()[i].SetRandom()
 		tmp := computex3(
-			[]fr.Element{entries[0].Coefficients[i],
-				entries[1].Coefficients[i]})
-		entries[2].Coefficients[i].Set(&tmp)
+			[]fr.Element{entries[0].Coefficients()[i],
+				entries[1].Coefficients()[i]})
+		entries[2].Coefficients()[i].Set(&tmp)
 
 		x := []fr.Element{
 			entries[0].GetCoeff(i),

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -19,7 +19,7 @@ func computex3(x []fr.Element) fr.Element {
 }
 
 func buildPoly(size int, form Form) *Polynomial {
-	v := make(fr.Vector, size)
+	v := make([]fr.Element, size)
 	return NewPolynomial(&v, form)
 }
 

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -20,8 +20,9 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(v, form)
+	return NewPolynomial(&v, form)
 }
+
 
 func TestDivideByXMinusOne(t *testing.T) {
 

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -18,8 +18,8 @@ func computex3(x []fr.Element) fr.Element {
 
 }
 
-func buildPoly(size int, form Form) *WrappedPolynomial {
-	return NewWrappedPolynomial(NewPolynomial(make([]fr.Element, size), form))
+func buildPoly(size int, form Form) *Polynomial {
+	return NewPolynomial(make([]fr.Element, size), form)
 }
 
 
@@ -42,7 +42,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	form := Form{Basis: Lagrange, Layout: Regular}
 
-	entries := make([]*WrappedPolynomial, nbEntries)
+	entries := make([]*Polynomial, nbEntries)
 	entries[0] = buildPoly(sizeSystem, form)
 	entries[1] = buildPoly(sizeSystem, form)
 	entries[2] = buildPoly(sizeSystem, form)

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -20,9 +20,8 @@ func computex3(x []fr.Element) fr.Element {
 
 func buildPoly(size int, form Form) *Polynomial {
 	v := make([]fr.Element, size)
-	return NewPolynomial(&v, form)
+	return NewPolynomial(v, form)
 }
-
 
 func TestDivideByXMinusOne(t *testing.T) {
 

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -49,7 +49,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(numerator[0].Coefficients)
+	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -67,9 +67,9 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 	var a, b, c, d fr.Element
 
@@ -84,32 +84,33 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		for j := 0; j < nbPolynomials; j++ {
 
 			if numerator[j].Layout == BitReverse {
-				a.Sub(&beta, &numerator[j].Coefficients[iRev])
+				a.Sub(&beta, &numerator[j].Coefficients()[iRev])
 			} else {
-				a.Sub(&beta, &numerator[j].Coefficients[i])
+				a.Sub(&beta, &numerator[j].Coefficients()[i])
 			}
 			b.Mul(&b, &a)
 
 			if denominator[j].Layout == BitReverse {
-				c.Sub(&beta, &denominator[j].Coefficients[iRev])
+				c.Sub(&beta, &denominator[j].Coefficients()[iRev])
 			} else {
-				c.Sub(&beta, &denominator[j].Coefficients[i])
+				c.Sub(&beta, &denominator[j].Coefficients()[i])
 			}
 			d.Mul(&d, &c)
 		}
 		// b = Πₖ (β-Pₖ(ωⁱ⁻¹))
 		// d = Πₖ (β-Qₖ(ωⁱ⁻¹))
 
-		res.Coefficients[i+1].Mul(&res.Coefficients[i], &b)
+		coeffs[i+1].Mul(&coeffs[i], &b)
 		t[i+1].Mul(&t[i], &d)
 
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
+	res.coefficients = &coeffs
 	res.Basis = expectedForm.Basis
 	res.Layout = expectedForm.Layout
 
@@ -144,7 +145,7 @@ func BuildRatioCopyConstraint(
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
-	n := len(entries[0].Coefficients)
+	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
 		return res, err
@@ -161,9 +162,9 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	res.Coefficients = make([]fr.Element, n)
+	coeffs := make(fr.Vector, n)
 	t := make([]fr.Element, n)
-	res.Coefficients[0].SetOne()
+	coeffs[0].SetOne()
 	t[0].SetOne()
 
 	parallel.Execute(n-1, func(start, end int){
@@ -183,33 +184,34 @@ func BuildRatioCopyConstraint(
 	
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
-					Add(&a, &p.Coefficients[idx])
+					Add(&a, &p.Coefficients()[idx])
 	
 				b.Mul(&b, &a)
 	
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
-					Add(&c, &p.Coefficients[idx])
+					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
 	
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
-			res.Coefficients[i+1].Set(&b)
+			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
 	
 
 	for i := 0; i < n-1; i++ {
-		res.Coefficients[i+1].Mul(&res.Coefficients[i+1], &res.Coefficients[i])
+		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
 		t[i+1].Mul(&t[i+1], &t[i])
 	}
 
 	t = fr.BatchInvert(t)
 	for i := 1; i < n; i++ {
-		res.Coefficients[i].Mul(&res.Coefficients[i], &t[i])
+		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
+	res.coefficients = &coeffs
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
@@ -224,24 +226,24 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 	p.Layout = expectedForm.Layout
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
 		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients, fft.DIF)
-		domain.FFT(p.Coefficients, fft.DIT, true)
+		domain.FFTInverse(p.Coefficients(), fft.DIF)
+		domain.FFT(p.Coefficients(), fft.DIT, true)
 		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients)
+			fft.BitReverse(p.Coefficients())
 		}
 		return
 	}
 
 	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients)
+		fft.BitReverse(p.Coefficients())
 	}
 
 }
@@ -252,10 +254,10 @@ func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)
-	n := len(pols[0][0].Coefficients)
+	n := pols[0][0].coefficients.Len()
 	for i := 0; i < m; i++ {
 		for j := 0; j < len(pols); j++ {
-			if len(pols[i][j].Coefficients) != n {
+			if pols[i][j].coefficients.Len() != n {
 				return ErrInconsistentSize
 			}
 		}

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -217,7 +217,6 @@ func BuildRatioCopyConstraint(
 }
 
 func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -34,7 +34,6 @@ var (
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
 func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (*Polynomial, error) {
 
-
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
 		return nil, ErrNumberPolynomials
@@ -109,7 +108,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -130,7 +129,6 @@ func BuildRatioCopyConstraint(
 	beta, gamma fr.Element,
 	expectedForm Form,
 	domain *fft.Domain) (*Polynomial, error) {
-
 
 	nbPolynomials := len(entries)
 
@@ -163,40 +161,39 @@ func BuildRatioCopyConstraint(
 	coeffs[0].SetOne()
 	t[0].SetOne()
 
-	parallel.Execute(n-1, func(start, end int){
+	parallel.Execute(n-1, func(start, end int) {
 		var a, b, c, d fr.Element
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		for i := start; i < end; i++ {
 			b.SetOne()
 			d.SetOne()
-	
+
 			iRev := int(bits.Reverse64(uint64(i)) >> nn)
-	
+
 			for j, p := range entries {
 				idx := i
 				if p.Layout == BitReverse {
 					idx = iRev
 				}
-	
+
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
 					Add(&a, &p.Coefficients()[idx])
-	
+
 				b.Mul(&b, &a)
-	
+
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
 					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
-	
+
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
 			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
-	
 
 	for i := 0; i < n-1; i++ {
 		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
@@ -208,7 +205,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(&coeffs, expectedForm)
+	res := NewPolynomial(coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -32,9 +32,9 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (Polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
@@ -127,13 +127,13 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*Polynomial,
+	entries []*polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (Polynomial, error) {
+	domain *fft.Domain) (polynomial, error) {
 
-	var res Polynomial
+	var res polynomial
 
 	nbPolynomials := len(entries)
 
@@ -218,7 +218,7 @@ func BuildRatioCopyConstraint(
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
 
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
@@ -248,7 +248,7 @@ func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*Polynomial) error {
+func checkSize(pols ...[]*polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -112,7 +112,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 }
@@ -210,35 +210,26 @@ func BuildRatioCopyConstraint(
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
+	putInExpectedForm(*res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
-	p.Basis = expectedForm.Basis
-	p.Layout = expectedForm.Layout
+func putInExpectedForm(p Polynomial, domain *fft.Domain, expectedForm Form) {
 
 	if expectedForm.Basis == Canonical {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		if expectedForm.Layout == Regular {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
+		p.ToCanonical(domain)
+	} else if expectedForm.Basis == Lagrange {
+		p.ToLagrange(domain)
+	} else {
+		p.ToLagrangeCoset(domain)
 	}
 
-	if expectedForm.Basis == LagrangeCoset {
-		domain.FFTInverse(p.Coefficients(), fft.DIF)
-		domain.FFT(p.Coefficients(), fft.DIT, true)
-		if expectedForm.Layout == BitReverse {
-			fft.BitReverse(p.Coefficients())
-		}
-		return
-	}
-
-	if expectedForm.Layout == BitReverse {
-		fft.BitReverse(p.Coefficients())
+	if expectedForm.Layout == Regular {
+		p.ToRegular()
+	} else {
+		p.ToBitReverse()
 	}
 
 }

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -34,6 +34,7 @@ var (
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
 func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (*Polynomial, error) {
 
+
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
 		return nil, ErrNumberPolynomials
@@ -108,7 +109,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
@@ -129,6 +130,7 @@ func BuildRatioCopyConstraint(
 	beta, gamma fr.Element,
 	expectedForm Form,
 	domain *fft.Domain) (*Polynomial, error) {
+
 
 	nbPolynomials := len(entries)
 
@@ -161,39 +163,40 @@ func BuildRatioCopyConstraint(
 	coeffs[0].SetOne()
 	t[0].SetOne()
 
-	parallel.Execute(n-1, func(start, end int) {
+	parallel.Execute(n-1, func(start, end int){
 		var a, b, c, d fr.Element
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
 		for i := start; i < end; i++ {
 			b.SetOne()
 			d.SetOne()
-
+	
 			iRev := int(bits.Reverse64(uint64(i)) >> nn)
-
+	
 			for j, p := range entries {
 				idx := i
 				if p.Layout == BitReverse {
 					idx = iRev
 				}
-
+	
 				a.Mul(&beta, &evaluationIDSmallDomain[i+j*n]).
 					Add(&a, &gamma).
 					Add(&a, &p.Coefficients()[idx])
-
+	
 				b.Mul(&b, &a)
-
+	
 				c.Mul(&beta, &evaluationIDSmallDomain[permutation[i+j*n]]).
 					Add(&c, &gamma).
 					Add(&c, &p.Coefficients()[idx])
 				d.Mul(&d, &c)
 			}
-
+	
 			// b = Πⱼ(Pⱼ(ωⁱ)+β*ωⁱνʲ+γ)
 			// d = Πⱼ(Qⱼ(ωⁱ)+β*σ(j*n+i)+γ)
 			coeffs[i+1].Set(&b)
 			t[i+1].Set(&d)
 		}
 	})
+	
 
 	for i := 0; i < n-1; i++ {
 		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
@@ -205,7 +208,7 @@ func BuildRatioCopyConstraint(
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res := NewPolynomial(coeffs, expectedForm)
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
 	putInExpectedForm(*res, domain, expectedForm)
 

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -32,27 +32,26 @@ var (
 // * Return: say beta=β, numerator = [P₁,...,P_m], denominator = [Q₁,..,Q_m]. The function
 // returns a polynomial whose evaluation on the j-th root of unity is
 // (Π_{k<j}Π_{i<m}(β-Pᵢ(ωᵏ)))/(β-Qᵢ(ωᵏ))
-func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (polynomial, error) {
+func BuildRatioShuffledVectors(numerator, denominator []*Polynomial, beta fr.Element, expectedForm Form, domain *fft.Domain) (*Polynomial, error) {
 
-	var res polynomial
 
 	// check that len(numerator)=len(denominator)
 	if len(numerator) != len(denominator) {
-		return res, ErrNumberPolynomials
+		return nil, ErrNumberPolynomials
 	}
 	nbPolynomials := len(numerator)
 
 	// check that the sizes are consistent
 	err := checkSize(numerator, denominator)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
 	n := numerator[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
 	// put every polynomials in Lagrange form. Also make sure
@@ -67,7 +66,7 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	coeffs := make(fr.Vector, n)
+	coeffs := make([]fr.Element, n)
 	t := make([]fr.Element, n)
 	coeffs[0].SetOne()
 	t[0].SetOne()
@@ -110,12 +109,10 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
 
-	res.coefficients = &coeffs
-	res.Basis = expectedForm.Basis
-	res.Layout = expectedForm.Layout
+	res := NewPolynomial(&coeffs, expectedForm)
 
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
+	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
 
 	return res, nil
 }
@@ -128,27 +125,26 @@ func BuildRatioShuffledVectors(numerator, denominator []*polynomial, beta fr.Ele
 // * beta, gamma challenges
 // * expectedForm expected form of the resulting polynomial
 func BuildRatioCopyConstraint(
-	entries []*polynomial,
+	entries []*Polynomial,
 	permutation []int64,
 	beta, gamma fr.Element,
 	expectedForm Form,
-	domain *fft.Domain) (polynomial, error) {
+	domain *fft.Domain) (*Polynomial, error) {
 
-	var res polynomial
 
 	nbPolynomials := len(entries)
 
 	// check that the sizes are consistent
 	err := checkSize(entries)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
 	// create the domain + some checks on the sizes of the polynomials
 	n := entries[0].coefficients.Len()
 	domain, err = buildDomain(n, domain)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
 	// put every polynomials in Lagrange form. Also make sure
@@ -162,7 +158,7 @@ func BuildRatioCopyConstraint(
 
 	// build the ratio (careful with the indices of
 	// the polynomials which are bit reversed)
-	coeffs := make(fr.Vector, n)
+	coeffs := make([]fr.Element, n)
 	t := make([]fr.Element, n)
 	coeffs[0].SetOne()
 	t[0].SetOne()
@@ -211,17 +207,17 @@ func BuildRatioCopyConstraint(
 	for i := 1; i < n; i++ {
 		coeffs[i].Mul(&coeffs[i], &t[i])
 	}
-	res.coefficients = &coeffs
 
+	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
-	putInExpectedFormFromLagrangeRegular(&res, domain, expectedForm)
+	putInExpectedFormFromLagrangeRegular(res, domain, expectedForm)
 
 	return res, nil
 
 }
 
-func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, expectedForm Form) {
-
+func putInExpectedFormFromLagrangeRegular(p *Polynomial, domain *fft.Domain, expectedForm Form) {
+	// TODO @gbotrel call the other methods
 	p.Basis = expectedForm.Basis
 	p.Layout = expectedForm.Layout
 
@@ -250,7 +246,7 @@ func putInExpectedFormFromLagrangeRegular(p *polynomial, domain *fft.Domain, exp
 
 // check that the polynomials are of the same size.
 // It assumes that pols contains slices of the same size.
-func checkSize(pols ...[]*polynomial) error {
+func checkSize(pols ...[]*Polynomial) error {
 
 	// check sizes between one another
 	m := len(pols)

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -27,7 +27,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -22,11 +22,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
 
-	numerator := make([]*Polynomial, nbPolynomials)
+	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(Polynomial)
+		numerator[i] = new(polynomial)
 		numerator[i].Coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
@@ -37,9 +37,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*Polynomial, nbPolynomials)
+	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(Polynomial)
+		denominator[i] = new(polynomial)
 		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
@@ -66,8 +66,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*Polynomial, nbPolynomials)
-	backupDenominator := make([]*Polynomial, nbPolynomials)
+	backupNumerator := make([]*polynomial, nbPolynomials)
+	backupDenominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -182,11 +182,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
-	res := make([]*Polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
+	res := make([]*polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(Polynomial)
+		res[i] = new(polynomial)
 		res[i].Form = form
 		res[i].Coefficients = make([]fr.Element, sizePolynomials)
 		for j := 0; j < sizePolynomials/2; j++ {
@@ -212,7 +212,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]Polynomial, nbPolynomials)
+	backupEntries := make([]polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupEntries[i] = *entries[i].Clone()
 	}

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -26,7 +26,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 
 	// get permutation
@@ -36,7 +36,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 	// concatenated
 	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -181,7 +181,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(&v, form)
+		res[i] = NewPolynomial(v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -22,14 +22,11 @@ func getPermutation(n, g int) []int {
 	return res
 }
 
-func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, []*polynomial, []int) {
+func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, []*Polynomial, []int) {
 
-	numerator := make([]*polynomial, nbPolynomials)
+	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = new(polynomial)
-		numerator[i].coefficients = (*fr.Vector)(randomVector(sizePolynomials))
-		numerator[i].Basis = Lagrange
-		numerator[i].Layout = Regular
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
 	}
 
 	// get permutation
@@ -37,13 +34,9 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 
 	// the denominator is the permuted version of the numerators
 	// concatenated
-	denominator := make([]*polynomial, nbPolynomials)
+	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = new(polynomial)
-		v := make(fr.Vector, sizePolynomials)
-		denominator[i].coefficients = &v
-		denominator[i].Basis = Lagrange
-		denominator[i].Layout = Regular
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -67,8 +60,8 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	numerator, denominator, _ := getPermutedPolynomials(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupNumerator := make([]*polynomial, nbPolynomials)
-	backupDenominator := make([]*polynomial, nbPolynomials)
+	backupNumerator := make([]*Polynomial, nbPolynomials)
+	backupDenominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		backupNumerator[i] = numerator[i].Clone()
 		backupDenominator[i] = denominator[i].Clone()
@@ -183,14 +176,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 // σ defined by:
 // σ = (12)(34)..(2n-1 2n)
 // so σ is a product of cycles length 2.
-func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*polynomial, []int64) {
-	res := make([]*polynomial, nbPolynomials)
+func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]*Polynomial, []int64) {
+	res := make([]*Polynomial, nbPolynomials)
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
-		res[i] = new(polynomial)
-		res[i].Form = form
-		v := make(fr.Vector, sizePolynomials)
-		res[i].coefficients = &v 
+		v := make([]fr.Element, sizePolynomials)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
@@ -214,9 +205,9 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	entries, sigma := getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials)
 
 	// save the originals for further tests with polynomials in different forms
-	backupEntries := make([]polynomial, nbPolynomials)
+	backupEntries := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		backupEntries[i] = *entries[i].Clone()
+		backupEntries[i] = entries[i].Clone()
 	}
 
 	// build the ratio polynomial

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -27,7 +27,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	numerator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = new(polynomial)
-		numerator[i].Coefficients = randomVector(sizePolynomials)
+		numerator[i].coefficients = randomVector(sizePolynomials)
 		numerator[i].Basis = Lagrange
 		numerator[i].Layout = Regular
 	}
@@ -40,7 +40,8 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 	denominator := make([]*polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
 		denominator[i] = new(polynomial)
-		denominator[i].Coefficients = make([]fr.Element, sizePolynomials)
+		v := make(fr.Vector, sizePolynomials)
+		denominator[i].coefficients = &v
 		denominator[i].Basis = Lagrange
 		denominator[i].Layout = Regular
 	}
@@ -49,7 +50,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*polynomial, 
 		od := sigma[i] % sizePolynomials
 		in := int(i / sizePolynomials)
 		on := i % sizePolynomials
-		denominator[in].Coefficients[on].Set(&numerator[id].Coefficients[od])
+		denominator[in].Coefficients()[on].Set(&numerator[id].Coefficients()[od])
 	}
 
 	return numerator, denominator, sigma
@@ -88,12 +89,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	b.SetOne()
 	d.SetOne()
 	for i := 0; i < nbPolynomials; i++ {
-		a.Sub(&beta, &numerator[i].Coefficients[sizePolynomials-1])
+		a.Sub(&beta, &numerator[i].Coefficients()[sizePolynomials-1])
 		b.Mul(&a, &b)
-		c.Sub(&beta, &denominator[i].Coefficients[sizePolynomials-1])
+		c.Sub(&beta, &denominator[i].Coefficients()[sizePolynomials-1])
 		d.Mul(&c, &d)
 	}
-	a.Mul(&b, &ratio.Coefficients[sizePolynomials-1]).
+	a.Mul(&b, &ratio.Coefficients()[sizePolynomials-1]).
 		Div(&a, &d)
 	var one fr.Element
 	one.SetOne()
@@ -105,11 +106,11 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	// bit reversed
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = backupNumerator[i].Clone()
-		fft.BitReverse(numerator[i].Coefficients)
+		fft.BitReverse(numerator[i].Coefficients())
 		numerator[i].Layout = BitReverse
 
 		denominator[i] = backupDenominator[i].Clone()
-		fft.BitReverse(denominator[i].Coefficients)
+		fft.BitReverse(denominator[i].Coefficients())
 		denominator[i].Layout = BitReverse
 	}
 	{
@@ -118,7 +119,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal(err)
 		}
@@ -128,13 +129,13 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	// canonical form, regular
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = backupNumerator[i].Clone()
-		domain.FFTInverse(numerator[i].Coefficients, fft.DIF)
-		fft.BitReverse(numerator[i].Coefficients)
+		domain.FFTInverse(numerator[i].Coefficients(), fft.DIF)
+		fft.BitReverse(numerator[i].Coefficients())
 		numerator[i].Basis = Canonical
 
 		denominator[i] = backupDenominator[i].Clone()
-		domain.FFTInverse(denominator[i].Coefficients, fft.DIF)
-		fft.BitReverse(denominator[i].Coefficients)
+		domain.FFTInverse(denominator[i].Coefficients(), fft.DIF)
+		fft.BitReverse(denominator[i].Coefficients())
 		denominator[i].Basis = Canonical
 	}
 	{
@@ -143,7 +144,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal("coefficients of ratio are not consistent")
 		}
@@ -153,12 +154,12 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	// canonical form, bit reverse
 	for i := 0; i < nbPolynomials; i++ {
 		numerator[i] = backupNumerator[i].Clone()
-		domain.FFTInverse(numerator[i].Coefficients, fft.DIF)
+		domain.FFTInverse(numerator[i].Coefficients(), fft.DIF)
 		numerator[i].Layout = BitReverse
 		numerator[i].Basis = Canonical
 
 		denominator[i] = backupDenominator[i].Clone()
-		domain.FFTInverse(denominator[i].Coefficients, fft.DIF)
+		domain.FFTInverse(denominator[i].Coefficients(), fft.DIF)
 		denominator[i].Layout = BitReverse
 		denominator[i].Basis = Canonical
 	}
@@ -168,7 +169,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal("coefficients of ratio are not consistent")
 		}
@@ -188,10 +189,11 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	for i := 0; i < nbPolynomials; i++ {
 		res[i] = new(polynomial)
 		res[i].Form = form
-		res[i].Coefficients = make([]fr.Element, sizePolynomials)
+		v := make(fr.Vector, sizePolynomials)
+		res[i].coefficients = &v 
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients[2*j].SetRandom()
-			res[i].Coefficients[2*j+1].Set(&res[i].Coefficients[2*j])
+			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
 	permutation := make([]int64, nbPolynomials*sizePolynomials)
@@ -235,16 +237,16 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	d.SetOne()
 	for i := 0; i < nbPolynomials; i++ {
 		a.Mul(&beta, &suppID[(i+1)*sizePolynomials-1]).
-			Add(&a, &entries[i].Coefficients[sizePolynomials-1]).
+			Add(&a, &entries[i].Coefficients()[sizePolynomials-1]).
 			Add(&a, &gamma)
 		b.Mul(&b, &a)
 
 		c.Mul(&beta, &suppID[sigma[(i+1)*sizePolynomials-1]]).
-			Add(&c, &entries[i].Coefficients[sizePolynomials-1]).
+			Add(&c, &entries[i].Coefficients()[sizePolynomials-1]).
 			Add(&c, &gamma)
 		d.Mul(&d, &c)
 	}
-	a.Mul(&b, &ratio.Coefficients[sizePolynomials-1]).
+	a.Mul(&b, &ratio.Coefficients()[sizePolynomials-1]).
 		Div(&a, &d)
 	var one fr.Element
 	one.SetOne()
@@ -256,7 +258,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	// bit reversed
 	for i := 0; i < nbPolynomials; i++ {
 		entries[i] = backupEntries[i].Clone()
-		fft.BitReverse(entries[i].Coefficients)
+		fft.BitReverse(entries[i].Coefficients())
 		entries[i].Layout = BitReverse
 	}
 	{
@@ -265,7 +267,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal(err)
 		}
@@ -275,8 +277,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	// canonical form, regular
 	for i := 0; i < nbPolynomials; i++ {
 		entries[i] = backupEntries[i].Clone()
-		domain.FFTInverse(entries[i].Coefficients, fft.DIF)
-		fft.BitReverse(entries[i].Coefficients)
+		domain.FFTInverse(entries[i].Coefficients(), fft.DIF)
+		fft.BitReverse(entries[i].Coefficients())
 		entries[i].Layout = Regular
 		entries[i].Basis = Canonical
 	}
@@ -286,7 +288,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal("coefficients of ratio are not consistent")
 		}
@@ -296,7 +298,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	// canonical form, bit reverse
 	for i := 0; i < nbPolynomials; i++ {
 		entries[i] = backupEntries[i].Clone()
-		domain.FFTInverse(entries[i].Coefficients, fft.DIF)
+		domain.FFTInverse(entries[i].Coefficients(), fft.DIF)
 		entries[i].Layout = BitReverse
 		entries[i].Basis = Canonical
 	}
@@ -307,7 +309,7 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkCoeffs := cmpCoefficents(_ratio.Coefficients, ratio.Coefficients)
+		checkCoeffs := cmpCoefficents(_ratio.coefficients, ratio.coefficients)
 		if !checkCoeffs {
 			t.Fatal("coefficients of ratio are not consistent")
 		}

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -26,7 +26,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 
 	numerator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
+		numerator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
 	}
 
 	// get permutation
@@ -36,7 +36,7 @@ func getPermutedPolynomials(sizePolynomials, nbPolynomials int) ([]*Polynomial, 
 	// concatenated
 	denominator := make([]*Polynomial, nbPolynomials)
 	for i := 0; i < nbPolynomials; i++ {
-		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis: Lagrange, Layout: Regular})
+		denominator[i] = NewPolynomial(randomVector(sizePolynomials), Form{Basis:Lagrange, Layout:Regular})
 	}
 	for i := 0; i < len(sigma); i++ {
 		id := int(sigma[i] / sizePolynomials)
@@ -181,7 +181,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 	form := Form{Layout: Regular, Basis: Lagrange}
 	for i := 0; i < nbPolynomials; i++ {
 		v := make([]fr.Element, sizePolynomials)
-		res[i] = NewPolynomial(v, form)
+		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
 			res[i].Coefficients()[2*j].SetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])

--- a/internal/generator/iop/template/utils.go.tmpl
+++ b/internal/generator/iop/template/utils.go.tmpl
@@ -2,49 +2,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 )
 
-// func printVector(v []fr.Element) {
-// 	fmt.Printf("[")
-// 	for i := 0; i < len(v); i++ {
-// 		fmt.Printf("Fr(%s), ", v[i].String())
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printPolynomials(p []*Polynomial) {
-// 	fmt.Printf("[\n")
-// 	for i := 0; i < len(p); i++ {
-// 		printVector(p[i].Coefficients)
-// 		fmt.Printf(",\n")
-// 	}
-// 	fmt.Printf("]\n")
-// }
-
-// func printLayout(f Form) {
-
-// 	if f.Basis == Canonical {
-// 		fmt.Printf("CANONICAL")
-// 	} else if f.Basis == LagrangeCoset {
-// 		fmt.Printf("LAGRANGE_COSET")
-// 	} else {
-// 		fmt.Printf("LAGRANGE")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Layout == Regular {
-// 		fmt.Printf("REGULAR")
-// 	} else {
-// 		fmt.Printf("BIT REVERSED")
-// 	}
-// 	fmt.Println("")
-
-// 	if f.Status == Locked {
-// 		fmt.Printf("LOCKED")
-// 	} else {
-// 		fmt.Printf("UNLOCKED")
-// 	}
-// 	fmt.Println("")
-// }
-
 //----------------------------------------------------
 // exp functions until 5
 


### PR DESCRIPTION
`iop` package methods / functions are more consistent, and takes as argument / return the same type `*iop.Polynomial` . 

There is now only `Polynomial` (previously `WrappedPolynomial`); the contract of this struct is consistent;

it is initialized with a pointer to a slice of field elements (the coefficients: `*[]fr.Element`) and any calls on `Polynomial` methods will **mutate** the original slice (even if it needs to grow for a FFT). 

The method `Clone() *Polynomial` performs a deep-copy and clones the underlying vector of coefficients.

The method `ShallowClone() *Polynomial` returns a new object with the same underlying coefficients; this allows modification of the `shift` `size` and `blindedSize` attributres (`Blind` method for example) without re-allocating. 


Additionally, `Polynomial` now implements `io.ReaderFrom` and `io.WriterTo`. 

- fix: vector marshal methods on pointer type
- feat: support for Vector encode / decode in Marshal
- refactor: merge Polynomial and WrappedPolynomial
- refactor: make Coefficients private and expose Slice access
- recfactor: fix constructor with []fr.Element input
- remove more apis with unexposed struct
- remove more apis with unexposed struct
- remove more apis with unexposed struct
- refactor: most consistent APIs
- style :code cleaning
- refactor: resize -> grow
- feat: added WriterTo and ReaderFrom to Polynomial
