### PR TITLE
feat: add ECDSA public key recover from message, signature and recovery info

### DIFF
--- a/ecc/bls12-377/bls12-377.go
+++ b/ecc/bls12-377/bls12-377.go
@@ -40,6 +40,9 @@ import (
 // ID bls377 ID
 const ID = ecc.BLS12_377
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -97,7 +100,7 @@ type E6 = fptower.E6
 type E12 = fptower.E12
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(1)
 	// D-twist
 	twist.A1.SetUint64(1)
@@ -151,5 +154,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bls12-377/bls12-377.go
+++ b/ecc/bls12-377/bls12-377.go
@@ -42,8 +42,6 @@ const ID = ecc.BLS12_377
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // twist

--- a/ecc/bls12-377/bls12-377.go
+++ b/ecc/bls12-377/bls12-377.go
@@ -148,3 +148,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bls12-377/ecdsa/ecdsa.go
+++ b/ecc/bls12-377/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bls12-378/bls12-378.go
+++ b/ecc/bls12-378/bls12-378.go
@@ -145,3 +145,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bls12-378/bls12-378.go
+++ b/ecc/bls12-378/bls12-378.go
@@ -40,6 +40,9 @@ import (
 // ID bls378 ID
 const ID = ecc.BLS12_378
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -94,7 +97,7 @@ type E6 = fptower.E6
 type E12 = fptower.E12
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(1)
 	bTwistCurveCoeff.A1.SetUint64(1) // M-twist
 
@@ -148,5 +151,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bls12-378/bls12-378.go
+++ b/ecc/bls12-378/bls12-378.go
@@ -42,8 +42,6 @@ const ID = ecc.BLS12_378
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // bTwistCurveCoeff b coeff of the twist (defined over 𝔽p²) curve

--- a/ecc/bls12-378/ecdsa/ecdsa.go
+++ b/ecc/bls12-378/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bls12-381/bls12-381.go
+++ b/ecc/bls12-381/bls12-381.go
@@ -42,8 +42,6 @@ const ID = ecc.BLS12_381
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // twist

--- a/ecc/bls12-381/bls12-381.go
+++ b/ecc/bls12-381/bls12-381.go
@@ -140,3 +140,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bls12-381/bls12-381.go
+++ b/ecc/bls12-381/bls12-381.go
@@ -40,6 +40,9 @@ import (
 // ID bls381 ID
 const ID = ecc.BLS12_381
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -86,7 +89,7 @@ var endo struct {
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(4)
 	// M-twist
 	twist.A0.SetUint64(1)
@@ -143,5 +146,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bls12-381/ecdsa/ecdsa.go
+++ b/ecc/bls12-381/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bls24-315/bls24-315.go
+++ b/ecc/bls24-315/bls24-315.go
@@ -161,3 +161,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bls24-315/bls24-315.go
+++ b/ecc/bls24-315/bls24-315.go
@@ -43,8 +43,6 @@ const ID = ecc.BLS24_315
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // twist

--- a/ecc/bls24-315/bls24-315.go
+++ b/ecc/bls24-315/bls24-315.go
@@ -41,6 +41,9 @@ import (
 // ID bls315 ID
 const ID = ecc.BLS24_315
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -101,7 +104,7 @@ type E12 = fptower.E12
 type E24 = fptower.E24
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(1)
 	// D-twist
 	twist.B1.SetOne()
@@ -164,5 +167,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bls24-315/ecdsa/ecdsa.go
+++ b/ecc/bls24-315/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bls24-317/bls24-317.go
+++ b/ecc/bls24-317/bls24-317.go
@@ -41,6 +41,9 @@ import (
 // ID bls317 ID
 const ID = ecc.BLS24_317
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -87,7 +90,7 @@ var endo struct {
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(4)
 	// M-twist
 	twist.B1.SetOne()
@@ -152,5 +155,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bls24-317/bls24-317.go
+++ b/ecc/bls24-317/bls24-317.go
@@ -43,8 +43,6 @@ const ID = ecc.BLS24_317
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // twist

--- a/ecc/bls24-317/bls24-317.go
+++ b/ecc/bls24-317/bls24-317.go
@@ -149,3 +149,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bls24-317/ecdsa/ecdsa.go
+++ b/ecc/bls24-317/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bn254/bn254.go
+++ b/ecc/bn254/bn254.go
@@ -154,3 +154,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bn254/bn254.go
+++ b/ecc/bn254/bn254.go
@@ -56,8 +56,6 @@ const ID = ecc.BN254
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // twist

--- a/ecc/bn254/bn254.go
+++ b/ecc/bn254/bn254.go
@@ -54,6 +54,9 @@ import (
 // ID bn254 ID
 const ID = ecc.BN254
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -100,7 +103,7 @@ var endo struct {
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(3)
 	// D-twist
 	twist.A0.SetUint64(9)
@@ -157,5 +160,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bn254/ecdsa/ecdsa.go
+++ b/ecc/bn254/ecdsa/ecdsa.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
+	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -107,6 +108,54 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
+// RecoverP recovers the value P (prover commitment) when creating a signature.
+// It uses the recovery information v and part of the decomposed signature r. It
+// is used internally for recovering the public key.
+func RecoverP(v uint, r *big.Int) (*bn254.G1Affine, error) {
+	if r.Cmp(fr.Modulus()) >= 0 {
+		return nil, errors.New("r is larger than modulus")
+	}
+	if r.Cmp(big.NewInt(0)) <= 0 {
+		return nil, errors.New("r is negative")
+	}
+	x := new(big.Int).Set(r)
+	// if x is r or r+N
+	xChoice := (v & 2) >> 1
+	// if y is y or -y
+	yChoice := v & 1
+	// decompose limbs into big.Int value
+	// conditional +n based on xChoice
+	kn := big.NewInt(int64(xChoice))
+	kn.Mul(kn, fr.Modulus())
+	x.Add(x, kn)
+	// y^2 = x^3+ax+b
+	a, b := bn254.CurveCoefficients()
+	y := new(big.Int).Exp(x, big.NewInt(3), fp.Modulus())
+	if !a.IsZero() {
+		y.Add(y, new(big.Int).Mul(a.BigInt(new(big.Int)), x))
+	}
+	y.Add(y, b.BigInt(new(big.Int)))
+	y.Mod(y, fp.Modulus())
+	// y = sqrt(y^2)
+	if y.ModSqrt(y, fp.Modulus()) == nil {
+		return nil, errors.New("no square root")
+	}
+	// y2 is -y
+	y2 := new(big.Int).Sub(fp.Modulus(), y)
+	// if yChoice == 0, return min(y, y2), else max(y, y2)
+	if (y.Cmp(y2) < 0) == (yChoice == 0) {
+		return &bn254.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y),
+		}, nil
+	} else {
+		return &bn254.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y2),
+		}, nil
+	}
+}
+
 type zr struct{}
 
 // Read replaces the contents of dst with zeros. It is safe for concurrent use.
@@ -182,27 +231,31 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 	return &pub
 }
 
-// Sign performs the ECDSA signature
+// SignForRecover performs the ECDSA signature and returns public key recovery information
 //
 // k ← 𝔽r (random)
 // P = k ⋅ g1Gen
 // r = x_P (mod order)
 // s = k⁻¹ . (m + sk ⋅ r)
-// signature = {r, s}
+// v = (div(x_P, order)<<1) || y_P[-1]
 //
 // SEC 1, Version 2.0, Section 4.1.3
-func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
-	scalar, r, s, kInv := new(big.Int), new(big.Int), new(big.Int), new(big.Int)
+func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
+	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
+	halfp.Div(halfp, big.NewInt(2))
+	r, s = new(big.Int), new(big.Int)
+
+	scalar, kInv := new(big.Int), new(big.Int)
 	scalar.SetBytes(privKey.scalar[:sizeFr])
 	for {
 		for {
 			csprng, err := nonce(privKey, message)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			k, err := randFieldElement(csprng)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 
 			var P bn254.G1Affine
@@ -210,6 +263,12 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+			// set how many times we overflow the scalar field
+			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
+			// set if y is small or big
+			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
+				v |= 1
+			}
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {
@@ -226,7 +285,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			hFunc.Reset()
 			_, err := hFunc.Write(dataToHash[:])
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			hramBin := hFunc.Sum(nil)
 			m = HashToInt(hramBin)
@@ -242,6 +301,23 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 		}
 	}
 
+	return v, r, s, nil
+}
+
+// Sign performs the ECDSA signature
+//
+// k ← 𝔽r (random)
+// P = k ⋅ g1Gen
+// r = x_P (mod order)
+// s = k⁻¹ . (m + sk ⋅ r)
+// signature = {r, s}
+//
+// SEC 1, Version 2.0, Section 4.1.3
+func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
+	_, r, s, err := privKey.SignForRecover(message, hFunc)
+	if err != nil {
+		return nil, err
+	}
 	var sig Signature
 	r.FillBytes(sig.R[:sizeFr])
 	s.FillBytes(sig.S[:sizeFr])

--- a/ecc/bn254/ecdsa/ecdsa.go
+++ b/ecc/bn254/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bn254/ecdsa/ecdsa_test.go
+++ b/ecc/bn254/ecdsa/ecdsa_test.go
@@ -62,6 +62,31 @@ func TestECDSA(t *testing.T) {
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
+func TestRecoverPublicKey(t *testing.T) {
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	properties := gopter.NewProperties(parameters)
+	properties.Property("[BN254] test public key recover", prop.ForAll(
+		func() bool {
+			sk, err := GenerateKey(rand.Reader)
+			if err != nil {
+				return false
+			}
+			pk := sk.PublicKey
+			msg := []byte("test")
+			v, r, s, err := sk.SignForRecover(msg, nil)
+			if err != nil {
+				return false
+			}
+			var recovered PublicKey
+			if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+				return false
+			}
+			return pk.Equal(&recovered)
+		},
+	))
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
 
 // ------------------------------------------------------------
 // benches
@@ -86,5 +111,22 @@ func BenchmarkVerifyECDSA(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		privKey.PublicKey.Verify(sig, msg, nil)
+	}
+}
+func BenchmarkRecoverPublicKey(b *testing.B) {
+	sk, err := GenerateKey(rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg := []byte("bench")
+	v, r, s, err := sk.SignForRecover(msg, sha256.New())
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		var recovered PublicKey
+		if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/ecc/bn254/ecdsa/marshal.go
+++ b/ecc/bn254/ecdsa/marshal.go
@@ -19,6 +19,10 @@ package ecdsa
 import (
 	"crypto/subtle"
 	"io"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
 // Bytes returns the binary representation of the public key
@@ -50,6 +54,28 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 	}
 	n += sizeFp
 	return n, nil
+}
+
+// RecoverFrom recovers the public key from the message msg, recovery
+// information v and decompose signature {r,s}. If recovery succeeded, the
+// methods sets the current public key to the recovered value. Otherwise returns
+// error and leaves current public key unchanged.
+func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	P, err := RecoverP(v, r)
+	if err != nil {
+		return err
+	}
+	z := HashToInt(msg)
+	rinv := new(big.Int).ModInverse(r, fr.Modulus())
+	u1 := new(big.Int).Mul(z, rinv)
+	u1.Neg(u1)
+	u1.Mod(u1, fr.Modulus())
+	u2 := new(big.Int).Mul(s, rinv)
+	u2.Mod(u2, fr.Modulus())
+	var Q bn254.G1Jac
+	Q.JointScalarMultiplicationBase(P, u1, u2)
+	pk.A.FromJacobian(&Q)
+	return nil
 }
 
 // Bytes returns the binary representation of pk,

--- a/ecc/bw6-633/bw6-633.go
+++ b/ecc/bw6-633/bw6-633.go
@@ -125,3 +125,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bw6-633/bw6-633.go
+++ b/ecc/bw6-633/bw6-633.go
@@ -40,8 +40,6 @@ const ID = ecc.BW6_633
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // bTwistCurveCoeff b coeff of the twist (defined over 𝔽p) curve

--- a/ecc/bw6-633/bw6-633.go
+++ b/ecc/bw6-633/bw6-633.go
@@ -38,6 +38,9 @@ import (
 // ID BW6_633 ID
 const ID = ecc.BW6_633
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -76,7 +79,7 @@ var glvBasis ecc.Lattice
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(4)
 	bTwistCurveCoeff.SetUint64(8) // M-twist
 
@@ -128,5 +131,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bw6-633/ecdsa/ecdsa.go
+++ b/ecc/bw6-633/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bw6-756/bw6-756.go
+++ b/ecc/bw6-756/bw6-756.go
@@ -124,3 +124,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bw6-756/bw6-756.go
+++ b/ecc/bw6-756/bw6-756.go
@@ -40,8 +40,6 @@ const ID = ecc.BW6_756
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // bTwistCurveCoeff b coeff of the twist (defined over 𝔽p) curve

--- a/ecc/bw6-756/bw6-756.go
+++ b/ecc/bw6-756/bw6-756.go
@@ -38,6 +38,9 @@ import (
 // ID BW6_756 ID
 const ID = ecc.BW6_756
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -76,7 +79,7 @@ var glvBasis ecc.Lattice
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetOne()
 	bTwistCurveCoeff.MulByNonResidue(&bCurveCoeff)
 
@@ -127,5 +130,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bw6-756/ecdsa/ecdsa.go
+++ b/ecc/bw6-756/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/bw6-761/bw6-761.go
+++ b/ecc/bw6-761/bw6-761.go
@@ -42,8 +42,6 @@ const ID = ecc.BW6_761
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // bTwistCurveCoeff b coeff of the twist (defined over 𝔽p) curve

--- a/ecc/bw6-761/bw6-761.go
+++ b/ecc/bw6-761/bw6-761.go
@@ -40,6 +40,9 @@ import (
 // ID BW6_761 ID
 const ID = ecc.BW6_761
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -78,7 +81,7 @@ var glvBasis ecc.Lattice
 var xGen big.Int
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetOne().Neg(&bCurveCoeff)
 	// M-twist
 	bTwistCurveCoeff.SetUint64(4)
@@ -129,5 +132,5 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/bw6-761/bw6-761.go
+++ b/ecc/bw6-761/bw6-761.go
@@ -126,3 +126,8 @@ func Generators() (g1Jac G1Jac, g2Jac G2Jac, g1Aff G1Affine, g2Aff G2Affine) {
 	g2Jac = g2Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/bw6-761/ecdsa/ecdsa.go
+++ b/ecc/bw6-761/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/secp256k1/ecdsa/ecdsa.go
+++ b/ecc/secp256k1/ecdsa/ecdsa.go
@@ -33,7 +33,9 @@ import (
 	"github.com/consensys/gnark-crypto/signature"
 )
 
-var errInvalidSig = errors.New("invalid signature")
+var (
+	errNoSqrt = errors.New("no square root")
+)
 
 const (
 	sizeFr         = fr.Bytes
@@ -108,6 +110,48 @@ func HashToInt(hash []byte) *big.Int {
 		ret.Rsh(ret, uint(excess))
 	}
 	return ret
+}
+
+// RecoverP recovers the value P (prover commitment) when creating a signature.
+// It uses the recovery information v and part of the decomposed signature r. It
+// is used internally for recovering the public key.
+func RecoverP(v uint, r *big.Int) (*secp256k1.G1Affine, error) {
+	x := new(big.Int).Set(r)
+	// if x is r or r+N
+	xChoice := (v & 15) >> 1
+	// if y is y or -y
+	yChoice := v & 1
+	// decompose limbs into big.Int value
+	// conditional +n based on xChoice
+	kn := big.NewInt(int64(xChoice))
+	kn.Mul(kn, fr.Modulus())
+	x.Add(x, kn)
+	// y^2 = x^3+ax+b
+	a, b := secp256k1.CurveCoefficients()
+	y := new(big.Int).Exp(x, big.NewInt(3), fp.Modulus())
+	if !a.IsZero() {
+		y.Add(y, new(big.Int).Mul(a.BigInt(new(big.Int)), x))
+	}
+	y.Add(y, b.BigInt(new(big.Int)))
+	y.Mod(y, fp.Modulus())
+	// y = sqrt(y^2)
+	if y.ModSqrt(y, fp.Modulus()) == nil {
+		return nil, errNoSqrt
+	}
+	// y2 is -y
+	y2 := new(big.Int).Sub(fp.Modulus(), y)
+	// if yChoice == 0, return min(y, y2), else max(y, y2)
+	if (y.Cmp(y2) < 0) == (yChoice == 0) {
+		return &secp256k1.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y),
+		}, nil
+	} else {
+		return &secp256k1.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y2),
+		}, nil
+	}
 }
 
 type zr struct{}
@@ -185,27 +229,29 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 	return &pub
 }
 
-// Sign performs the ECDSA signature
+// SignForRecover performs the ECDSA signature and returns public key recovery information
 //
 // k ← 𝔽r (random)
 // P = k ⋅ g1Gen
 // r = x_P (mod order)
 // s = k⁻¹ . (m + sk ⋅ r)
-// signature = {r, s}
+// v = (div(x_P, order)<<1) || y_P[-1]
 //
 // SEC 1, Version 2.0, Section 4.1.3
-func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
-	scalar, r, s, kInv := new(big.Int), new(big.Int), new(big.Int), new(big.Int)
+func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
+	r, s = new(big.Int), new(big.Int)
+
+	scalar, kInv := new(big.Int), new(big.Int)
 	scalar.SetBytes(privKey.scalar[:sizeFr])
 	for {
 		for {
 			csprng, err := nonce(privKey, message)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			k, err := randFieldElement(csprng)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 
 			var P secp256k1.G1Affine
@@ -213,6 +259,11 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+			// set how many times we overflow the scalar field
+			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
+			// set if high bit is 1 or 0
+			v |= P.Y.BigInt(new(big.Int)).Bit(fp.Modulus().BitLen() - 1)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break
@@ -228,7 +279,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			hFunc.Reset()
 			_, err := hFunc.Write(dataToHash[:])
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			hramBin := hFunc.Sum(nil)
 			m = HashToInt(hramBin)
@@ -244,6 +295,23 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 		}
 	}
 
+	return v, r, s, nil
+}
+
+// Sign performs the ECDSA signature
+//
+// k ← 𝔽r (random)
+// P = k ⋅ g1Gen
+// r = x_P (mod order)
+// s = k⁻¹ . (m + sk ⋅ r)
+// signature = {r, s}
+//
+// SEC 1, Version 2.0, Section 4.1.3
+func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
+	_, r, s, err := privKey.SignForRecover(message, hFunc)
+	if err != nil {
+		return nil, err
+	}
 	var sig Signature
 	r.FillBytes(sig.R[:sizeFr])
 	s.FillBytes(sig.S[:sizeFr])

--- a/ecc/secp256k1/ecdsa/ecdsa_test.go
+++ b/ecc/secp256k1/ecdsa/ecdsa_test.go
@@ -62,6 +62,31 @@ func TestECDSA(t *testing.T) {
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
+func TestRecoverPublicKey(t *testing.T) {
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	properties := gopter.NewProperties(parameters)
+	properties.Property("[SECP256K1] test public key recover", prop.ForAll(
+		func() bool {
+			sk, err := GenerateKey(rand.Reader)
+			if err != nil {
+				return false
+			}
+			pk := sk.PublicKey
+			msg := []byte("test")
+			v, r, s, err := sk.SignForRecover(msg, nil)
+			if err != nil {
+				return false
+			}
+			var recovered PublicKey
+			if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+				return false
+			}
+			return pk.Equal(&recovered)
+		},
+	))
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
 
 // ------------------------------------------------------------
 // benches
@@ -86,5 +111,22 @@ func BenchmarkVerifyECDSA(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		privKey.PublicKey.Verify(sig, msg, nil)
+	}
+}
+func BenchmarkRecoverPublicKey(b *testing.B) {
+	sk, err := GenerateKey(rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg := []byte("bench")
+	v, r, s, err := sk.SignForRecover(msg, sha256.New())
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		var recovered PublicKey
+		if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/ecc/secp256k1/ecdsa/marshal.go
+++ b/ecc/secp256k1/ecdsa/marshal.go
@@ -18,7 +18,10 @@ package ecdsa
 
 import (
 	"crypto/subtle"
+	"github.com/consensys/gnark-crypto/ecc/secp256k1"
+	"github.com/consensys/gnark-crypto/ecc/secp256k1/fr"
 	"io"
+	"math/big"
 )
 
 // Bytes returns the binary representation of the public key
@@ -50,6 +53,28 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 	}
 	n += sizeFp
 	return n, nil
+}
+
+// RecoverFrom recovers the public key from the message msg, recovery
+// information v and decompose signature {r,s}. If recovery succeeded, the
+// methods sets the current public key to the recovered value. Otherwise returns
+// error and leaves current public key unchanged.
+func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	P, err := RecoverP(v, r)
+	if err != nil {
+		return err
+	}
+	z := HashToInt(msg)
+	rinv := new(big.Int).ModInverse(r, fr.Modulus())
+	u1 := new(big.Int).Mul(z, rinv)
+	u1.Neg(u1)
+	u1.Mod(u1, fr.Modulus())
+	u2 := new(big.Int).Mul(s, rinv)
+	u2.Mod(u2, fr.Modulus())
+	var Q secp256k1.G1Jac
+	Q.JointScalarMultiplicationBase(P, u1, u2)
+	pk.A.FromJacobian(&Q)
+	return nil
 }
 
 // Bytes returns the binary representation of pk,

--- a/ecc/secp256k1/ecdsa/marshal.go
+++ b/ecc/secp256k1/ecdsa/marshal.go
@@ -18,10 +18,11 @@ package ecdsa
 
 import (
 	"crypto/subtle"
-	"github.com/consensys/gnark-crypto/ecc/secp256k1"
-	"github.com/consensys/gnark-crypto/ecc/secp256k1/fr"
 	"io"
 	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256k1"
+	"github.com/consensys/gnark-crypto/ecc/secp256k1/fr"
 )
 
 // Bytes returns the binary representation of the public key

--- a/ecc/secp256k1/secp256k1.go
+++ b/ecc/secp256k1/secp256k1.go
@@ -89,3 +89,8 @@ func Generators() (g1Jac G1Jac, g1Aff G1Affine) {
 	g1Jac = g1Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/secp256k1/secp256k1.go
+++ b/ecc/secp256k1/secp256k1.go
@@ -41,8 +41,6 @@ const ID = ecc.SECP256K1
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
 // generator of the r-torsion group

--- a/ecc/secp256k1/secp256k1.go
+++ b/ecc/secp256k1/secp256k1.go
@@ -39,6 +39,9 @@ import (
 // ID secp256k1 ID
 const ID = ecc.SECP256K1
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+b
 var bCurveCoeff fp.Element
 
@@ -63,7 +66,7 @@ var lambdaGLV big.Int
 var glvBasis ecc.Lattice
 
 func init() {
-
+	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(7)
 
 	g1Gen.X.SetString("55066263022277343669578718895168534326250603453777594175500187360389116729240")
@@ -92,5 +95,5 @@ func Generators() (g1Jac G1Jac, g1Aff G1Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/ecc/stark-curve/ecdsa/ecdsa.go
+++ b/ecc/stark-curve/ecdsa/ecdsa.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
+	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -107,6 +108,54 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
+// RecoverP recovers the value P (prover commitment) when creating a signature.
+// It uses the recovery information v and part of the decomposed signature r. It
+// is used internally for recovering the public key.
+func RecoverP(v uint, r *big.Int) (*starkcurve.G1Affine, error) {
+	if r.Cmp(fr.Modulus()) >= 0 {
+		return nil, errors.New("r is larger than modulus")
+	}
+	if r.Cmp(big.NewInt(0)) <= 0 {
+		return nil, errors.New("r is negative")
+	}
+	x := new(big.Int).Set(r)
+	// if x is r or r+N
+	xChoice := (v & 2) >> 1
+	// if y is y or -y
+	yChoice := v & 1
+	// decompose limbs into big.Int value
+	// conditional +n based on xChoice
+	kn := big.NewInt(int64(xChoice))
+	kn.Mul(kn, fr.Modulus())
+	x.Add(x, kn)
+	// y^2 = x^3+ax+b
+	a, b := starkcurve.CurveCoefficients()
+	y := new(big.Int).Exp(x, big.NewInt(3), fp.Modulus())
+	if !a.IsZero() {
+		y.Add(y, new(big.Int).Mul(a.BigInt(new(big.Int)), x))
+	}
+	y.Add(y, b.BigInt(new(big.Int)))
+	y.Mod(y, fp.Modulus())
+	// y = sqrt(y^2)
+	if y.ModSqrt(y, fp.Modulus()) == nil {
+		return nil, errors.New("no square root")
+	}
+	// y2 is -y
+	y2 := new(big.Int).Sub(fp.Modulus(), y)
+	// if yChoice == 0, return min(y, y2), else max(y, y2)
+	if (y.Cmp(y2) < 0) == (yChoice == 0) {
+		return &starkcurve.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y),
+		}, nil
+	} else {
+		return &starkcurve.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y2),
+		}, nil
+	}
+}
+
 type zr struct{}
 
 // Read replaces the contents of dst with zeros. It is safe for concurrent use.
@@ -182,27 +231,31 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 	return &pub
 }
 
-// Sign performs the ECDSA signature
+// SignForRecover performs the ECDSA signature and returns public key recovery information
 //
 // k ← 𝔽r (random)
 // P = k ⋅ g1Gen
 // r = x_P (mod order)
 // s = k⁻¹ . (m + sk ⋅ r)
-// signature = {r, s}
+// v = (div(x_P, order)<<1) || y_P[-1]
 //
 // SEC 1, Version 2.0, Section 4.1.3
-func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
-	scalar, r, s, kInv := new(big.Int), new(big.Int), new(big.Int), new(big.Int)
+func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
+	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
+	halfp.Div(halfp, big.NewInt(2))
+	r, s = new(big.Int), new(big.Int)
+
+	scalar, kInv := new(big.Int), new(big.Int)
 	scalar.SetBytes(privKey.scalar[:sizeFr])
 	for {
 		for {
 			csprng, err := nonce(privKey, message)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			k, err := randFieldElement(csprng)
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 
 			var P starkcurve.G1Affine
@@ -210,6 +263,12 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+			// set how many times we overflow the scalar field
+			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
+			// set if y is small or big
+			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
+				v |= 1
+			}
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {
@@ -226,7 +285,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			hFunc.Reset()
 			_, err := hFunc.Write(dataToHash[:])
 			if err != nil {
-				return nil, err
+				return 0, nil, nil, err
 			}
 			hramBin := hFunc.Sum(nil)
 			m = HashToInt(hramBin)
@@ -242,6 +301,23 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 		}
 	}
 
+	return v, r, s, nil
+}
+
+// Sign performs the ECDSA signature
+//
+// k ← 𝔽r (random)
+// P = k ⋅ g1Gen
+// r = x_P (mod order)
+// s = k⁻¹ . (m + sk ⋅ r)
+// signature = {r, s}
+//
+// SEC 1, Version 2.0, Section 4.1.3
+func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
+	_, r, s, err := privKey.SignForRecover(message, hFunc)
+	if err != nil {
+		return nil, err
+	}
 	var sig Signature
 	r.FillBytes(sig.R[:sizeFr])
 	s.FillBytes(sig.S[:sizeFr])

--- a/ecc/stark-curve/ecdsa/ecdsa.go
+++ b/ecc/stark-curve/ecdsa/ecdsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -32,8 +31,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fr"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes
@@ -213,6 +210,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break

--- a/ecc/stark-curve/ecdsa/marshal.go
+++ b/ecc/stark-curve/ecdsa/marshal.go
@@ -19,6 +19,10 @@ package ecdsa
 import (
 	"crypto/subtle"
 	"io"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/stark-curve"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fr"
 )
 
 // Bytes returns the binary representation of the public key
@@ -50,6 +54,28 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 	}
 	n += sizeFp
 	return n, nil
+}
+
+// RecoverFrom recovers the public key from the message msg, recovery
+// information v and decompose signature {r,s}. If recovery succeeded, the
+// methods sets the current public key to the recovered value. Otherwise returns
+// error and leaves current public key unchanged.
+func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	P, err := RecoverP(v, r)
+	if err != nil {
+		return err
+	}
+	z := HashToInt(msg)
+	rinv := new(big.Int).ModInverse(r, fr.Modulus())
+	u1 := new(big.Int).Mul(z, rinv)
+	u1.Neg(u1)
+	u1.Mod(u1, fr.Modulus())
+	u2 := new(big.Int).Mul(s, rinv)
+	u2.Mod(u2, fr.Modulus())
+	var Q starkcurve.G1Jac
+	Q.JointScalarMultiplicationBase(P, u1, u2)
+	pk.A.FromJacobian(&Q)
+	return nil
 }
 
 // Bytes returns the binary representation of pk,

--- a/ecc/stark-curve/stark_curve.go
+++ b/ecc/stark-curve/stark_curve.go
@@ -69,3 +69,8 @@ func Generators() (g1Jac G1Jac, g1Aff G1Affine) {
 	g1Jac = g1Gen
 	return
 }
+
+// CurveCoefficients returns the a, b coefficients of the curve equation.
+func CurveCoefficients() (a, b fp.Element) {
+	return a, bCurveCoeff
+}

--- a/ecc/stark-curve/stark_curve.go
+++ b/ecc/stark-curve/stark_curve.go
@@ -38,8 +38,6 @@ const ID = ecc.STARK_CURVE
 
 // aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
 var aCurveCoeff fp.Element
-
-// bCurveCoeff b coeff of the curve Y²=X³+x+b
 var bCurveCoeff fp.Element
 
 // generator of the r-torsion group

--- a/ecc/stark-curve/stark_curve.go
+++ b/ecc/stark-curve/stark_curve.go
@@ -36,6 +36,9 @@ import (
 // ID stark_curve ID
 const ID = ecc.STARK_CURVE
 
+// aCurveCoeff is the a coefficients of the curve Y²=X³+ax+b
+var aCurveCoeff fp.Element
+
 // bCurveCoeff b coeff of the curve Y²=X³+x+b
 var bCurveCoeff fp.Element
 
@@ -48,7 +51,7 @@ var g1GenAff G1Affine
 var g1Infinity G1Jac
 
 func init() {
-
+	aCurveCoeff.SetUint64(1)
 	bCurveCoeff.SetString("3141592653589793238462643383279502884197169399375105820974944592307816406665")
 
 	g1Gen.X.SetString("874739451078007766457464989774322083649278607533249481151382481072868806602")
@@ -72,5 +75,5 @@ func Generators() (g1Jac G1Jac, g1Aff G1Affine) {
 
 // CurveCoefficients returns the a, b coefficients of the curve equation.
 func CurveCoefficients() (a, b fp.Element) {
-	return a, bCurveCoeff
+	return aCurveCoeff, bCurveCoeff
 }

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -17,12 +17,6 @@ import (
 	"github.com/consensys/gnark-crypto/signature"
 )
 
-{{- if eq .Name "secp256k1" }}
-var (
-	errNoSqrt = errors.New("no square root")
-)
-{{- end }}
-
 const (
 	sizeFr         = fr.Bytes
 	sizeFp         = fp.Bytes
@@ -112,9 +106,17 @@ func HashToInt(hash []byte) *big.Int {
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
 func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
+	if r.Cmp(fr.Modulus()) >= 0 {
+		return nil, errors.New("r is larger than modulus")
+	}
+	if r.Cmp(big.NewInt(0)) <= 0 {
+	    return nil, errors.New("r is negative")
+	}
 	x := new(big.Int).Set(r)
+	{{/* actually we want use a mask which corresponds to maximum cofactor of the curve. But this is when
+	we generalize the implementation over arbitrary curve.*/}}
 	// if x is r or r+N
-	xChoice := (v & 15) >> 1
+	xChoice := (v & 2) >> 1
 	// if y is y or -y
 	yChoice := v & 1
 	// decompose limbs into big.Int value
@@ -132,7 +134,7 @@ func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
 	y.Mod(y, fp.Modulus())
 	// y = sqrt(y^2)
 	if y.ModSqrt(y, fp.Modulus()) == nil {
-		return nil, errNoSqrt
+		return nil, errors.New("no square root")
 	}
 	// y2 is -y
 	y2 := new(big.Int).Sub(fp.Modulus(), y)

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -4,6 +4,9 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
+	{{- if eq .Name "secp256k1" }}
+	"errors"
+	{{- end }}
 	"hash"
 	"io"
 	"math/big"
@@ -13,6 +16,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fp"
 	"github.com/consensys/gnark-crypto/signature"
 )
+
+{{- if eq .Name "secp256k1" }}
+var (
+	errNoSqrt = errors.New("no square root")
+)
+{{- end }}
 
 const (
 	sizeFr         = fr.Bytes
@@ -98,6 +107,50 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
+{{- if eq .Name "secp256k1"}}
+// RecoverP recovers the value P (prover commitment) when creating a signature.
+// It uses the recovery information v and part of the decomposed signature r. It
+// is used internally for recovering the public key.
+func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
+	x := new(big.Int).Set(r)
+	// if x is r or r+N
+	xChoice := (v & 15) >> 1
+	// if y is y or -y
+	yChoice := v & 1
+	// decompose limbs into big.Int value
+	// conditional +n based on xChoice
+	kn := big.NewInt(int64(xChoice))
+	kn.Mul(kn, fr.Modulus())
+	x.Add(x, kn)
+	// y^2 = x^3+ax+b
+	a, b := {{ .CurvePackage }}.CurveCoefficients()
+	y := new(big.Int).Exp(x, big.NewInt(3), fp.Modulus())
+	if !a.IsZero() {
+		y.Add(y, new(big.Int).Mul(a.BigInt(new(big.Int)), x))
+	}
+	y.Add(y, b.BigInt(new(big.Int)))
+	y.Mod(y, fp.Modulus())
+	// y = sqrt(y^2)
+	if y.ModSqrt(y, fp.Modulus()) == nil {
+		return nil, errNoSqrt
+	}
+	// y2 is -y
+	y2 := new(big.Int).Sub(fp.Modulus(), y)
+	// if yChoice == 0, return min(y, y2), else max(y, y2)
+	if (y.Cmp(y2) < 0) == (yChoice == 0) {
+		return &{{ .CurvePackage }}.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y),
+		}, nil
+	} else {
+		return &{{ .CurvePackage }}.G1Affine{
+			X: *new(fp.Element).SetBigInt(x),
+			Y: *new(fp.Element).SetBigInt(y2),
+		}, nil
+	}
+}
+{{- end}}
+
 type zr struct{}
 
 // Read replaces the contents of dst with zeros. It is safe for concurrent use.
@@ -173,6 +226,97 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 	return &pub
 }
 
+{{- if eq .Name "secp256k1"}}
+// SignForRecover performs the ECDSA signature and returns public key recovery information
+//
+// k ← 𝔽r (random)
+// P = k ⋅ g1Gen
+// r = x_P (mod order)
+// s = k⁻¹ . (m + sk ⋅ r)
+// v = (div(x_P, order)<<1) || y_P[-1]
+//
+// SEC 1, Version 2.0, Section 4.1.3
+func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
+	r, s = new(big.Int), new(big.Int)
+
+	scalar, kInv := new(big.Int), new(big.Int)
+	scalar.SetBytes(privKey.scalar[:sizeFr])
+	for {
+		for {
+			csprng, err := nonce(privKey, message)
+			if err != nil {
+				return 0, nil, nil, err
+			}
+			k, err := randFieldElement(csprng)
+			if err != nil {
+				return 0, nil, nil, err
+			}
+
+			var P {{ .CurvePackage }}.G1Affine
+			P.ScalarMultiplicationBase(k)
+			kInv.ModInverse(k, order)
+
+			P.X.BigInt(r)
+			// set how many times we overflow the scalar field
+			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
+			// set if high bit is 1 or 0
+			v |= P.Y.BigInt(new(big.Int)).Bit(fp.Modulus().BitLen() - 1)
+
+			r.Mod(r, order)
+			if r.Sign() != 0 {
+				break
+			}
+		}
+		s.Mul(r, scalar)
+
+		var m *big.Int
+		if hFunc != nil {
+			// compute the hash of the message as an integer
+			dataToHash := make([]byte, len(message))
+			copy(dataToHash[:], message[:])
+			hFunc.Reset()
+			_, err := hFunc.Write(dataToHash[:])
+			if err != nil {
+				return 0, nil, nil, err
+			}
+			hramBin := hFunc.Sum(nil)
+			m = HashToInt(hramBin)
+		} else {
+			m = HashToInt(message)
+		}
+
+		s.Add(m, s).
+			Mul(kInv, s).
+			Mod(s, order) // order != 0
+		if s.Sign() != 0 {
+			break
+		}
+	}
+
+	return v, r, s, nil
+}
+
+// Sign performs the ECDSA signature
+//
+// k ← 𝔽r (random)
+// P = k ⋅ g1Gen
+// r = x_P (mod order)
+// s = k⁻¹ . (m + sk ⋅ r)
+// signature = {r, s}
+//
+// SEC 1, Version 2.0, Section 4.1.3
+func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error) {
+	_, r, s, err := privKey.SignForRecover(message, hFunc)
+	if err != nil {
+		return nil, err
+	}
+	var sig Signature
+	r.FillBytes(sig.R[:sizeFr])
+	s.FillBytes(sig.S[:sizeFr])
+
+	return sig.Bytes(), nil
+}
+{{- else }}
 // Sign performs the ECDSA signature
 //
 // k ← 𝔽r (random)
@@ -201,6 +345,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			kInv.ModInverse(k, order)
 
 			P.X.BigInt(r)
+
 			r.Mod(r, order)
 			if r.Sign() != 0 {
 				break
@@ -208,7 +353,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 		}
 		s.Mul(r, scalar)
 
-        var m *big.Int
+		var m *big.Int
 		if hFunc != nil {
 			// compute the hash of the message as an integer
 			dataToHash := make([]byte, len(message))
@@ -222,13 +367,13 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 			m = HashToInt(hramBin)
 		} else {
 			m = HashToInt(message)
- 		}
+		}
 
 		s.Add(m, s).
 			Mul(kInv, s).
 			Mod(s, order) // order != 0
 		if s.Sign() != 0 {
-            break
+			break
 		}
 	}
 
@@ -238,6 +383,7 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 
 	return sig.Bytes(), nil
 }
+{{- end }}
 
 // Verify validates the ECDSA signature
 //

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -113,7 +113,7 @@ func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
 	    return nil, errors.New("r is negative")
 	}
 	x := new(big.Int).Set(r)
-	{{/* actually we want use a mask which corresponds to maximum cofactor of the curve. But this is when
+	{{- /* actually we want use a mask which corresponds to maximum cofactor of the curve. But this is when
 	we generalize the implementation over arbitrary curve.*/}}
 	// if x is r or r+N
 	xChoice := (v & 2) >> 1

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	"errors"
 	"hash"
 	"io"
 	"math/big"
@@ -14,8 +13,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fp"
 	"github.com/consensys/gnark-crypto/signature"
 )
-
-var errInvalidSig = errors.New("invalid signature")
 
 const (
 	sizeFr         = fr.Bytes

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -239,6 +239,8 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 //
 // SEC 1, Version 2.0, Section 4.1.3
 func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
+	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
+	halfp.Div(halfp, big.NewInt(2))
 	r, s = new(big.Int), new(big.Int)
 
 	scalar, kInv := new(big.Int), new(big.Int)
@@ -261,8 +263,10 @@ func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v ui
 			P.X.BigInt(r)
 			// set how many times we overflow the scalar field
 			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
-			// set if high bit is 1 or 0
-			v |= P.Y.BigInt(new(big.Int)).Bit(fp.Modulus().BitLen() - 1)
+			// set if y is small or big
+			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
+				v |= 1
+			}
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"crypto/subtle"
-	{{- if eq .Name "secp256k1" }}
+	{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 	"errors"
 	{{- end }}
 	"hash"
@@ -101,7 +101,7 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
-{{- if eq .Name "secp256k1"}}
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 // RecoverP recovers the value P (prover commitment) when creating a signature.
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
@@ -228,7 +228,7 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 	return &pub
 }
 
-{{- if eq .Name "secp256k1"}}
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 // SignForRecover performs the ECDSA signature and returns public key recovery information
 //
 // k ← 𝔽r (random)

--- a/internal/generator/ecdsa/template/ecdsa.test.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.test.go.tmpl
@@ -45,7 +45,7 @@ func TestECDSA(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-{{- if eq .Name "secp256k1"}}
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 func TestRecoverPublicKey(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
@@ -99,7 +99,7 @@ func BenchmarkVerifyECDSA(b *testing.B) {
 	}
 }
 
-{{- if eq .Name "secp256k1"}}
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 func BenchmarkRecoverPublicKey(b *testing.B) {
 	sk, err := GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/generator/ecdsa/template/ecdsa.test.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.test.go.tmpl
@@ -45,6 +45,34 @@ func TestECDSA(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
+{{- if eq .Name "secp256k1"}}
+func TestRecoverPublicKey(t *testing.T) {
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	properties := gopter.NewProperties(parameters)
+	properties.Property("[{{ toUpper .Name }}] test public key recover", prop.ForAll(
+		func() bool {
+			sk, err := GenerateKey(rand.Reader)
+			if err != nil {
+				return false
+			}
+			pk := sk.PublicKey
+			msg := []byte("test")
+			v, r, s, err := sk.SignForRecover(msg, nil)
+			if err != nil {
+				return false
+			}
+			var recovered PublicKey
+			if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+				return false
+			}
+			return pk.Equal(&recovered)
+		},
+	))
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+{{- end }}
+
 // ------------------------------------------------------------
 // benches
 
@@ -70,3 +98,23 @@ func BenchmarkVerifyECDSA(b *testing.B) {
 		privKey.PublicKey.Verify(sig, msg, nil)
 	}
 }
+
+{{- if eq .Name "secp256k1"}}
+func BenchmarkRecoverPublicKey(b *testing.B) {
+	sk, err := GenerateKey(rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg := []byte("bench")
+	v, r, s, err := sk.SignForRecover(msg, sha256.New())
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		var recovered PublicKey
+		if err = recovered.RecoverFrom(msg, v, r, s); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+{{- end }}

--- a/internal/generator/ecdsa/template/marshal.go.tmpl
+++ b/internal/generator/ecdsa/template/marshal.go.tmpl
@@ -1,6 +1,14 @@
 import (
 	"crypto/subtle"
 	"io"
+	{{- if eq .Name "secp256k1"}}
+	"math/big"
+	{{- end  }}
+
+	{{- if eq .Name "secp256k1"}}
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
+	{{- end }}
 )
 
 // Bytes returns the binary representation of the public key
@@ -37,6 +45,30 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 	n += sizeFp
 	return n, nil
 }
+
+{{- if eq .Name "secp256k1"}}
+// RecoverFrom recovers the public key from the message msg, recovery
+// information v and decompose signature {r,s}. If recovery succeeded, the
+// methods sets the current public key to the recovered value. Otherwise returns
+// error and leaves current public key unchanged.
+func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	P, err := RecoverP(v, r)
+	if err != nil {
+		return err
+	}
+	z := HashToInt(msg)
+	rinv := new(big.Int).ModInverse(r, fr.Modulus())
+	u1 := new(big.Int).Mul(z, rinv)
+	u1.Neg(u1)
+	u1.Mod(u1, fr.Modulus())
+	u2 := new(big.Int).Mul(s, rinv)
+	u2.Mod(u2, fr.Modulus())
+	var Q {{ .CurvePackage }}.G1Jac
+	Q.JointScalarMultiplicationBase(P, u1, u2)
+	pk.A.FromJacobian(&Q)
+	return nil
+}
+{{- end }}
 
 // Bytes returns the binary representation of pk,
 // as byte array publicKey||scalar

--- a/internal/generator/ecdsa/template/marshal.go.tmpl
+++ b/internal/generator/ecdsa/template/marshal.go.tmpl
@@ -1,11 +1,9 @@
 import (
 	"crypto/subtle"
 	"io"
-	{{- if eq .Name "secp256k1"}}
+	{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 	"math/big"
-	{{- end  }}
 
-	{{- if eq .Name "secp256k1"}}
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	{{- end }}
@@ -46,7 +44,7 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 	return n, nil
 }
 
-{{- if eq .Name "secp256k1"}}
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
 // RecoverFrom recovers the public key from the message msg, recovery
 // information v and decompose signature {r,s}. If recovery succeeded, the
 // methods sets the current public key to the recovered value. Otherwise returns


### PR DESCRIPTION
Works for secp256k1, but not yet for the other curves as for computing y from x I need b from the curve equation, but it doesn't seem to be readily available outside the main curve package.

@yelhousni, do you have suggestions?