### PR TITLE
Perf: BN254 Miller loop

### DIFF
--- a/ecc/bls12-377/pairing.go
+++ b/ecc/bls12-377/pairing.go
@@ -139,7 +139,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i == len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l)
+		qProj[k].doubleStep(&l)
 		// line eval
 		l.r0.MulByElement(&l.r0, &p[k].Y)
 		l.r1.MulByElement(&l.r1, &p[k].X)
@@ -151,7 +151,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l)
+			qProj[k].doubleStep(&l)
 			// line eval
 			l.r0.MulByElement(&l.r0, &p[k].Y)
 			l.r1.MulByElement(&l.r1, &p[k].X)
@@ -163,7 +163,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		}
 
 		for k := 0; k < n; k++ {
-			qProj[k].AddMixedStep(&l, &q[k])
+			qProj[k].addMixedStep(&l, &q[k])
 			// line eval
 			l.r0.MulByElement(&l.r0, &p[k].Y)
 			l.r1.MulByElement(&l.r1, &p[k].X)
@@ -174,9 +174,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E2
@@ -215,9 +215,9 @@ func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E2

--- a/ecc/bls12-378/pairing.go
+++ b/ecc/bls12-378/pairing.go
@@ -138,7 +138,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i == len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l1)
+		qProj[k].doubleStep(&l1)
 		// line eval
 		l1.r1.MulByElement(&l1.r1, &p[k].X)
 		l1.r2.MulByElement(&l1.r2, &p[k].Y)
@@ -150,7 +150,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l1)
+			qProj[k].doubleStep(&l1)
 			// line eval
 			l1.r1.MulByElement(&l1.r1, &p[k].X)
 			l1.r2.MulByElement(&l1.r2, &p[k].Y)
@@ -158,7 +158,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			if loopCounter[i] == 0 {
 				result.MulBy014(&l1.r0, &l1.r1, &l1.r2)
 			} else {
-				qProj[k].AddMixedStep(&l2, &q[k])
+				qProj[k].addMixedStep(&l2, &q[k])
 				// line eval
 				l2.r1.MulByElement(&l2.r1, &p[k].X)
 				l2.r2.MulByElement(&l2.r2, &p[k].Y)
@@ -173,9 +173,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(l *lineEvaluation) {
+func (p *g2Proj) doubleStep(l *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E2
@@ -215,9 +215,9 @@ func (p *g2Proj) DoubleStep(l *lineEvaluation) {
 
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(l *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(l *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E2

--- a/ecc/bls12-381/pairing.go
+++ b/ecc/bls12-381/pairing.go
@@ -138,12 +138,12 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i == len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l1)
+		qProj[k].doubleStep(&l1)
 		// line eval
 		l1.r1.MulByElement(&l1.r1, &p[k].X)
 		l1.r2.MulByElement(&l1.r2, &p[k].Y)
 
-		qProj[k].AddMixedStep(&l2, &q[k])
+		qProj[k].addMixedStep(&l2, &q[k])
 		// line eval
 		l2.r1.MulByElement(&l2.r1, &p[k].X)
 		l2.r2.MulByElement(&l2.r2, &p[k].Y)
@@ -158,7 +158,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l1)
+			qProj[k].doubleStep(&l1)
 			// line eval
 			l1.r1.MulByElement(&l1.r1, &p[k].X)
 			l1.r2.MulByElement(&l1.r2, &p[k].Y)
@@ -166,7 +166,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			if loopCounter[i] == 0 {
 				result.MulBy014(&l1.r0, &l1.r1, &l1.r2)
 			} else {
-				qProj[k].AddMixedStep(&l2, &q[k])
+				qProj[k].addMixedStep(&l2, &q[k])
 				// line eval
 				l2.r1.MulByElement(&l2.r1, &p[k].X)
 				l2.r2.MulByElement(&l2.r2, &p[k].Y)
@@ -184,9 +184,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(l *lineEvaluation) {
+func (p *g2Proj) doubleStep(l *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E2
@@ -226,9 +226,9 @@ func (p *g2Proj) DoubleStep(l *lineEvaluation) {
 
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(l *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(l *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E2

--- a/ecc/bls24-315/pairing.go
+++ b/ecc/bls24-315/pairing.go
@@ -149,7 +149,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l)
+		qProj[k].doubleStep(&l)
 		// line evaluation
 		l.r0.MulByElement(&l.r0, &p[k].Y)
 		l.r1.MulByElement(&l.r1, &p[k].X)
@@ -161,21 +161,21 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l)
+			qProj[k].doubleStep(&l)
 			// line evaluation
 			l.r0.MulByElement(&l.r0, &p[k].Y)
 			l.r1.MulByElement(&l.r1, &p[k].X)
 			result.MulBy034(&l.r0, &l.r1, &l.r2)
 
 			if loopCounter[i] == 1 {
-				qProj[k].AddMixedStep(&l, &q[k])
+				qProj[k].addMixedStep(&l, &q[k])
 				// line evaluation
 				l.r0.MulByElement(&l.r0, &p[k].Y)
 				l.r1.MulByElement(&l.r1, &p[k].X)
 				result.MulBy034(&l.r0, &l.r1, &l.r2)
 
 			} else if loopCounter[i] == -1 {
-				qProj[k].AddMixedStep(&l, &qNeg[k])
+				qProj[k].addMixedStep(&l, &qNeg[k])
 				// line evaluation
 				l.r0.MulByElement(&l.r0, &p[k].Y)
 				l.r1.MulByElement(&l.r1, &p[k].X)
@@ -189,9 +189,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E4
@@ -230,9 +230,9 @@ func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E4

--- a/ecc/bls24-317/pairing.go
+++ b/ecc/bls24-317/pairing.go
@@ -153,7 +153,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i == len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l)
+		qProj[k].doubleStep(&l)
 		// line evaluation
 		l.r1.MulByElement(&l.r1, &p[k].X)
 		l.r2.MulByElement(&l.r2, &p[k].Y)
@@ -165,21 +165,21 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l)
+			qProj[k].doubleStep(&l)
 			// line evaluation
 			l.r1.MulByElement(&l.r1, &p[k].X)
 			l.r2.MulByElement(&l.r2, &p[k].Y)
 			result.MulBy014(&l.r0, &l.r1, &l.r2)
 
 			if loopCounter[i] == 1 {
-				qProj[k].AddMixedStep(&l, &q[k])
+				qProj[k].addMixedStep(&l, &q[k])
 				// line evaluation
 				l.r1.MulByElement(&l.r1, &p[k].X)
 				l.r2.MulByElement(&l.r2, &p[k].Y)
 				result.MulBy014(&l.r0, &l.r1, &l.r2)
 
 			} else if loopCounter[i] == -1 {
-				qProj[k].AddMixedStep(&l, &qNeg[k])
+				qProj[k].addMixedStep(&l, &qNeg[k])
 				// line evaluation
 				l.r1.MulByElement(&l.r1, &p[k].X)
 				l.r2.MulByElement(&l.r2, &p[k].Y)
@@ -191,9 +191,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E4
@@ -232,9 +232,9 @@ func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Neg(&H)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E4

--- a/ecc/bn254/pairing.go
+++ b/ecc/bn254/pairing.go
@@ -151,7 +151,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i == len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		qProj[k].DoubleStep(&l)
+		qProj[k].doubleStep(&l)
 		// line evaluation
 		l.r0.MulByElement(&l.r0, &p[k].Y)
 		l.r1.MulByElement(&l.r1, &p[k].X)
@@ -163,13 +163,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		result.Square(&result)
 
 		for k := 0; k < n; k++ {
-			qProj[k].DoubleStep(&l)
+			qProj[k].doubleStep(&l)
 			// line evaluation
 			l.r0.MulByElement(&l.r0, &p[k].Y)
 			l.r1.MulByElement(&l.r1, &p[k].X)
 
 			if loopCounter[i] == 1 {
-				qProj[k].AddMixedStep(&l0, &q[k])
+				qProj[k].addMixedStep(&l0, &q[k])
 				// line evaluation
 				l0.r0.MulByElement(&l0.r0, &p[k].Y)
 				l0.r1.MulByElement(&l0.r1, &p[k].X)
@@ -177,7 +177,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				result.Mul(&result, &tmp)
 
 			} else if loopCounter[i] == -1 {
-				qProj[k].AddMixedStep(&l0, &qNeg[k])
+				qProj[k].addMixedStep(&l0, &qNeg[k])
 				// line evaluation
 				l0.r0.MulByElement(&l0.r0, &p[k].Y)
 				l0.r1.MulByElement(&l0.r1, &p[k].X)
@@ -199,11 +199,11 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		Q2.X.MulByNonResidue2Power2(&q[k].X)
 		Q2.Y.MulByNonResidue2Power3(&q[k].Y).Neg(&Q2.Y)
 
-		qProj[k].AddMixedStep(&l0, &Q1)
+		qProj[k].addMixedStep(&l0, &Q1)
 		l0.r0.MulByElement(&l0.r0, &p[k].Y)
 		l0.r1.MulByElement(&l0.r1, &p[k].X)
 
-		qProj[k].AddMixedStepLineOnly(&l, &Q2)
+		qProj[k].addMixedStepLineOnly(&l, &Q2)
 		l.r0.MulByElement(&l.r0, &p[k].Y)
 		l.r1.MulByElement(&l.r1, &p[k].X)
 		tmp.Mul034by034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
@@ -213,9 +213,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fptower.E2
@@ -254,9 +254,9 @@ func (p *g2Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fptower.E2
@@ -291,10 +291,10 @@ func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 	evaluations.r2.Set(&J)
 }
 
-// AddMixedStepLineOnly computes the line through p in Homogenous projective
+// addMixedStepLineOnly computes the line through p in Homogenous projective
 // coordinates and a in affine coordinates. It does not compute the resulting
 // point p+a.
-func (p *g2Proj) AddMixedStepLineOnly(evaluations *lineEvaluation, a *G2Affine) {
+func (p *g2Proj) addMixedStepLineOnly(evaluations *lineEvaluation, a *G2Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, t2, J fptower.E2

--- a/ecc/bn254/pairing.go
+++ b/ecc/bn254/pairing.go
@@ -203,7 +203,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		l0.r0.MulByElement(&l0.r0, &p[k].Y)
 		l0.r1.MulByElement(&l0.r1, &p[k].X)
 
-		qProj[k].AddMixedStep(&l, &Q2)
+		qProj[k].AddMixedStepLineOnly(&l, &Q2)
 		l.r0.MulByElement(&l.r0, &p[k].Y)
 		l.r1.MulByElement(&l.r1, &p[k].X)
 		tmp.Mul034by034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
@@ -289,4 +289,26 @@ func (p *g2Proj) AddMixedStep(evaluations *lineEvaluation, a *G2Affine) {
 	evaluations.r0.Set(&L)
 	evaluations.r1.Neg(&O)
 	evaluations.r2.Set(&J)
+}
+
+// AddMixedStepLineOnly computes the line through p in Homogenous projective
+// coordinates and a in affine coordinates. It does not compute the resulting
+// point p+a.
+func (p *g2Proj) AddMixedStepLineOnly(evaluations *lineEvaluation, a *G2Affine) {
+
+	// get some Element from our pool
+	var Y2Z1, X2Z1, O, L, t2, J fptower.E2
+	Y2Z1.Mul(&a.Y, &p.z)
+	O.Sub(&p.y, &Y2Z1)
+	X2Z1.Mul(&a.X, &p.z)
+	L.Sub(&p.x, &X2Z1)
+	t2.Mul(&L, &a.Y)
+	J.Mul(&a.X, &O).
+		Sub(&J, &t2)
+
+	// Line evaluation
+	evaluations.r0.Set(&L)
+	evaluations.r1.Neg(&O)
+	evaluations.r2.Set(&J)
+
 }

--- a/ecc/bw6-633/pairing.go
+++ b/ecc/bw6-633/pairing.go
@@ -214,13 +214,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 		// l_{p0,p1}(q)
 		pProj01[k].Set(&pProj0[k])
-		pProj01[k].AddMixedStep(&l01[k], &p1[k])
+		pProj01[k].addMixedStep(&l01[k], &p1[k])
 		l01[k].r1.Mul(&l01[k].r1, &q[k].X)
 		l01[k].r0.Mul(&l01[k].r0, &q[k].Y)
 
 		// l_{-p0,p1}(q)
 		pProj10[k].Neg(&pProj0[k])
-		pProj10[k].AddMixedStep(&l10[k], &p1[k])
+		pProj10[k].addMixedStep(&l10[k], &p1[k])
 		l10[k].r1.Mul(&l10[k].r1, &q[k].X)
 		l10[k].r0.Mul(&l10[k].r0, &q[k].Y)
 	}
@@ -236,7 +236,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i = len(loopCounter)-2
 	for k := 0; k < n; k++ {
-		pProj0[k].DoubleStep(&l0)
+		pProj0[k].doubleStep(&l0)
 		l0.r1.Mul(&l0.r1, &q[k].X)
 		l0.r0.Mul(&l0.r0, &q[k].Y)
 		result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
@@ -249,14 +249,14 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		j = loopCounter0[i]*3 + loopCounter1[i]
 
 		for k := 0; k < n; k++ {
-			pProj0[k].DoubleStep(&l0)
+			pProj0[k].doubleStep(&l0)
 			l0.r1.Mul(&l0.r1, &q[k].X)
 			l0.r0.Mul(&l0.r0, &q[k].Y)
 
 			switch j {
 			case -4:
 				tmp.Neg(&p01[k])
-				pProj0[k].AddMixedStep(&l, &tmp)
+				pProj0[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -264,13 +264,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -3:
 				tmp.Neg(&p1[k])
-				pProj0[k].AddMixedStep(&l, &tmp)
+				pProj0[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case -2:
-				pProj0[k].AddMixedStep(&l, &p10[k])
+				pProj0[k].addMixedStep(&l, &p10[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l10[k].r0, &l10[k].r1, &l10[k].r2)
@@ -278,7 +278,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -1:
 				tmp.Neg(&p0[k])
-				pProj0[k].AddMixedStep(&l, &tmp)
+				pProj0[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
@@ -286,27 +286,27 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			case 0:
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
 			case 1:
-				pProj0[k].AddMixedStep(&l, &p0[k])
+				pProj0[k].addMixedStep(&l, &p0[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 2:
 				tmp.Neg(&p10[k])
-				pProj0[k].AddMixedStep(&l, &tmp)
+				pProj0[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l10[k].r0, &l10[k].r1, &l10[k].r2)
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2).
 					Mul(&result, &ss)
 			case 3:
-				pProj0[k].AddMixedStep(&l, &p1[k])
+				pProj0[k].addMixedStep(&l, &p1[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 4:
-				pProj0[k].AddMixedStep(&l, &p01[k])
+				pProj0[k].addMixedStep(&l, &p01[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -321,9 +321,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g1Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fp.Element
@@ -366,9 +366,9 @@ func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) AddMixedStep(evaluations *lineEvaluation, a *G1Affine) {
+func (p *g1Proj) addMixedStep(evaluations *lineEvaluation, a *G1Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fp.Element

--- a/ecc/bw6-756/pairing.go
+++ b/ecc/bw6-756/pairing.go
@@ -191,13 +191,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 		// l_{p0,p1}(q)
 		pProj01[k].Set(&pProj1[k])
-		pProj01[k].AddMixedStep(&l01[k], &p0[k])
+		pProj01[k].addMixedStep(&l01[k], &p0[k])
 		l01[k].r1.Mul(&l01[k].r1, &q[k].X)
 		l01[k].r0.Mul(&l01[k].r0, &q[k].Y)
 
 		// l_{p0,-p1}(q)
 		pProj10[k].Neg(&pProj1[k])
-		pProj10[k].AddMixedStep(&l10[k], &p0[k])
+		pProj10[k].addMixedStep(&l10[k], &p0[k])
 		l10[k].r1.Mul(&l10[k].r1, &q[k].X)
 		l10[k].r0.Mul(&l10[k].r0, &q[k].Y)
 	}
@@ -213,7 +213,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i = len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		pProj1[k].DoubleStep(&l0)
+		pProj1[k].doubleStep(&l0)
 		l0.r1.Mul(&l0.r1, &q[k].X)
 		l0.r0.Mul(&l0.r0, &q[k].Y)
 		result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
@@ -227,14 +227,14 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		j = loopCounter1[i]*3 + loopCounter0[i]
 
 		for k := 0; k < n; k++ {
-			pProj1[k].DoubleStep(&l0)
+			pProj1[k].doubleStep(&l0)
 			l0.r1.Mul(&l0.r1, &q[k].X)
 			l0.r0.Mul(&l0.r0, &q[k].Y)
 
 			switch j {
 			case -4:
 				tmp.Neg(&p01[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -242,13 +242,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -3:
 				tmp.Neg(&p1[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case -2:
-				pProj1[k].AddMixedStep(&l, &p10[k])
+				pProj1[k].addMixedStep(&l, &p10[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -256,7 +256,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -1:
 				tmp.Neg(&p0[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
@@ -264,27 +264,27 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			case 0:
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
 			case 1:
-				pProj1[k].AddMixedStep(&l, &p0[k])
+				pProj1[k].addMixedStep(&l, &p0[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 2:
 				tmp.Neg(&p10[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2).
 					Mul(&result, &ss)
 			case 3:
-				pProj1[k].AddMixedStep(&l, &p1[k])
+				pProj1[k].addMixedStep(&l, &p1[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 4:
-				pProj1[k].AddMixedStep(&l, &p01[k])
+				pProj1[k].addMixedStep(&l, &p01[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -299,9 +299,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g1Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fp.Element
@@ -341,9 +341,9 @@ func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) AddMixedStep(evaluations *lineEvaluation, a *G1Affine) {
+func (p *g1Proj) addMixedStep(evaluations *lineEvaluation, a *G1Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fp.Element

--- a/ecc/bw6-761/pairing.go
+++ b/ecc/bw6-761/pairing.go
@@ -190,13 +190,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 		// l_{p0,p1}(q)
 		pProj01[k].Set(&pProj1[k])
-		pProj01[k].AddMixedStep(&l01[k], &p0[k])
+		pProj01[k].addMixedStep(&l01[k], &p0[k])
 		l01[k].r1.Mul(&l01[k].r1, &q[k].X)
 		l01[k].r0.Mul(&l01[k].r0, &q[k].Y)
 
 		// l_{p0,-p1}(q)
 		pProj10[k].Neg(&pProj1[k])
-		pProj10[k].AddMixedStep(&l10[k], &p0[k])
+		pProj10[k].addMixedStep(&l10[k], &p0[k])
 		l10[k].r1.Mul(&l10[k].r1, &q[k].X)
 		l10[k].r0.Mul(&l10[k].r0, &q[k].Y)
 	}
@@ -212,7 +212,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 	// i = len(loopCounter) - 2
 	for k := 0; k < n; k++ {
-		pProj1[k].DoubleStep(&l0)
+		pProj1[k].doubleStep(&l0)
 		l0.r1.Mul(&l0.r1, &q[k].X)
 		l0.r0.Mul(&l0.r0, &q[k].Y)
 		result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
@@ -226,14 +226,14 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		j = loopCounter1[i]*3 + loopCounter0[i]
 
 		for k := 0; k < n; k++ {
-			pProj1[k].DoubleStep(&l0)
+			pProj1[k].doubleStep(&l0)
 			l0.r1.Mul(&l0.r1, &q[k].X)
 			l0.r0.Mul(&l0.r0, &q[k].Y)
 
 			switch j {
 			case -4:
 				tmp.Neg(&p01[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -241,13 +241,13 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -3:
 				tmp.Neg(&p1[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case -2:
-				pProj1[k].AddMixedStep(&l, &p10[k])
+				pProj1[k].addMixedStep(&l, &p10[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -255,7 +255,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 					Mul(&result, &ss)
 			case -1:
 				tmp.Neg(&p0[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
@@ -263,27 +263,27 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			case 0:
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2)
 			case 1:
-				pProj1[k].AddMixedStep(&l, &p0[k])
+				pProj1[k].addMixedStep(&l, &p0[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 2:
 				tmp.Neg(&p10[k])
-				pProj1[k].AddMixedStep(&l, &tmp)
+				pProj1[k].addMixedStep(&l, &tmp)
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
 				result.MulBy034(&l0.r0, &l0.r1, &l0.r2).
 					Mul(&result, &ss)
 			case 3:
-				pProj1[k].AddMixedStep(&l, &p1[k])
+				pProj1[k].addMixedStep(&l, &p1[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l0.r0, &l0.r1, &l0.r2)
 				result.Mul(&result, &ss)
 			case 4:
-				pProj1[k].AddMixedStep(&l, &p01[k])
+				pProj1[k].addMixedStep(&l, &p01[k])
 				l.r1.Mul(&l.r1, &q[k].X)
 				l.r0.Mul(&l.r0, &q[k].Y)
 				ss.Mul034By034(&l.r0, &l.r1, &l.r2, &l01[k].r0, &l01[k].r1, &l01[k].r2)
@@ -298,9 +298,9 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	return result, nil
 }
 
-// DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
+func (p *g1Proj) doubleStep(evaluations *lineEvaluation) {
 
 	// get some Element from our pool
 	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fp.Element
@@ -342,9 +342,9 @@ func (p *g1Proj) DoubleStep(evaluations *lineEvaluation) {
 	evaluations.r2.Set(&I)
 }
 
-// AddMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
 // https://eprint.iacr.org/2013/722.pdf (Section 4.3)
-func (p *g1Proj) AddMixedStep(evaluations *lineEvaluation, a *G1Affine) {
+func (p *g1Proj) addMixedStep(evaluations *lineEvaluation, a *G1Affine) {
 
 	// get some Element from our pool
 	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fp.Element


### PR DESCRIPTION
Actually we don't need to compute a full `AddMixedStep` [here](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bn254/pairing.go#L206). We just need the line that goes through `qProj` and `Q2` but not the new `qProj` (`=qProj+Q2`) as it won't be used after that. 
This PR introduces the private function `addMixedStepLineOnly` that only computes the line and not the resulting point, and makes `AddMixedStep` and `DoubleStep` private for all curves.

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkMillerLoop-2               210243        209380        -0.41%
BenchmarkMultiMiller/2_pairs-2      353040        352036        -0.28%
BenchmarkMultiMiller/3_pairs-2      495552        493883        -0.34%
BenchmarkMultiMiller/4_pairs-2      637746        635996        -0.27%
BenchmarkMultiMiller/5_pairs-2      779299        777806        -0.19%
BenchmarkMultiMiller/6_pairs-2      921408        919538        -0.20%
BenchmarkMultiMiller/7_pairs-2      1063256       1061098       -0.20%
BenchmarkMultiMiller/8_pairs-2      1206537       1202637       -0.32%
BenchmarkMultiMiller/9_pairs-2      1346727       1342862       -0.29%
BenchmarkMultiMiller/10_pairs-2     1488339       1485146       -0.21%
```