### PR TITLE
perf: tweaks in iop/ kzg/ packages

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -844,12 +845,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -859,7 +860,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-377/fr/fft/domain.go
+++ b/ecc/bls12-377/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("8065159656716812877374967518403273466521432693661810619979959746626482506078")
-	const maxOrderRoot uint64 = 47
 	domain.FrMultiplicativeGen.SetUint64(22)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("8065159656716812877374967518403273466521432693661810619979959746626482506078")
+	const maxOrderRoot uint64 = 47
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bls12-377/fr/fft/domain.go
+++ b/ecc/bls12-377/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bls12-377/fr/fft/domain.go
+++ b/ecc/bls12-377/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bls12-377/fr/iop/ratios.go
+++ b/ecc/bls12-377/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bls12-378/fp/element.go
+++ b/ecc/bls12-378/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -844,12 +845,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -859,7 +860,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-378/fr/element.go
+++ b/ecc/bls12-378/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-378/fr/fft/domain.go
+++ b/ecc/bls12-378/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("4045585818372166415418670827807793147093034396422209590578257013290761627990")
-	const maxOrderRoot uint64 = 42
 	domain.FrMultiplicativeGen.SetUint64(22)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("4045585818372166415418670827807793147093034396422209590578257013290761627990")
+	const maxOrderRoot uint64 = 42
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bls12-378/fr/fft/domain.go
+++ b/ecc/bls12-378/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bls12-378/fr/fft/domain.go
+++ b/ecc/bls12-378/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bls12-378/fr/iop/polynomial.go
+++ b/ecc/bls12-378/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bls12-378/fr/iop/ratios.go
+++ b/ecc/bls12-378/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bls12-378/fr/kzg/kzg.go
+++ b/ecc/bls12-378/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-378"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -844,12 +845,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -859,7 +860,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls12-381/fr/fft/domain.go
+++ b/ecc/bls12-381/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bls12-381/fr/fft/domain.go
+++ b/ecc/bls12-381/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
-	const maxOrderRoot uint64 = 32
 	domain.FrMultiplicativeGen.SetUint64(7)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
+	const maxOrderRoot uint64 = 32
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bls12-381/fr/fft/domain.go
+++ b/ecc/bls12-381/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bls12-381/fr/iop/ratios.go
+++ b/ecc/bls12-381/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -765,12 +766,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -780,7 +781,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls24-315/fr/fft/domain.go
+++ b/ecc/bls24-315/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("1792993287828780812362846131493071959406149719416102105453370749552622525216")
-	const maxOrderRoot uint64 = 22
 	domain.FrMultiplicativeGen.SetUint64(7)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("1792993287828780812362846131493071959406149719416102105453370749552622525216")
+	const maxOrderRoot uint64 = 22
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bls24-315/fr/fft/domain.go
+++ b/ecc/bls24-315/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bls24-315/fr/fft/domain.go
+++ b/ecc/bls24-315/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bls24-315/fr/iop/ratios.go
+++ b/ecc/bls24-315/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bls24-315/fr/kzg/kzg.go
+++ b/ecc/bls24-315/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -765,12 +766,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -780,7 +781,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bls24-317/fr/fft/domain.go
+++ b/ecc/bls24-317/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("16532287748948254263922689505213135976137839535221842169193829039521719560631")
-	const maxOrderRoot uint64 = 60
 	domain.FrMultiplicativeGen.SetUint64(7)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("16532287748948254263922689505213135976137839535221842169193829039521719560631")
+	const maxOrderRoot uint64 = 60
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bls24-317/fr/fft/domain.go
+++ b/ecc/bls24-317/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bls24-317/fr/fft/domain.go
+++ b/ecc/bls24-317/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bls24-317/fr/iop/ratios.go
+++ b/ecc/bls24-317/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bls24-317/fr/kzg/kzg.go
+++ b/ecc/bls24-317/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bn254/fr/fft/domain.go
+++ b/ecc/bn254/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("19103219067921713944291392827692070036145651957329286315305642004821462161904")
-	const maxOrderRoot uint64 = 28
 	domain.FrMultiplicativeGen.SetUint64(5)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("19103219067921713944291392827692070036145651957329286315305642004821462161904")
+	const maxOrderRoot uint64 = 28
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bn254/fr/fft/domain.go
+++ b/ecc/bn254/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bn254/fr/fft/domain.go
+++ b/ecc/bn254/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bn254/fr/iop/ratios.go
+++ b/ecc/bn254/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -1220,12 +1221,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -1235,7 +1236,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -765,12 +766,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -780,7 +781,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-633/fr/fft/domain.go
+++ b/ecc/bw6-633/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bw6-633/fr/fft/domain.go
+++ b/ecc/bw6-633/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("4991787701895089137426454739366935169846548798279261157172811661565882460884369603588700158257")
-	const maxOrderRoot uint64 = 20
 	domain.FrMultiplicativeGen.SetUint64(13)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("4991787701895089137426454739366935169846548798279261157172811661565882460884369603588700158257")
+	const maxOrderRoot uint64 = 20
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bw6-633/fr/fft/domain.go
+++ b/ecc/bw6-633/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bw6-633/fr/iop/ratios.go
+++ b/ecc/bw6-633/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bw6-756/fp/element.go
+++ b/ecc/bw6-756/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -1444,12 +1445,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -1459,7 +1460,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-756/fr/element.go
+++ b/ecc/bw6-756/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -844,12 +845,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -859,7 +860,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-756/fr/fft/domain.go
+++ b/ecc/bw6-756/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bw6-756/fr/fft/domain.go
+++ b/ecc/bw6-756/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("199251335866470442271346949249090720992237796757894062992204115206570647302191425225605716521843542790404563904580")
-	const maxOrderRoot uint64 = 41
 	domain.FrMultiplicativeGen.SetUint64(5)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("199251335866470442271346949249090720992237796757894062992204115206570647302191425225605716521843542790404563904580")
+	const maxOrderRoot uint64 = 41
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bw6-756/fr/fft/domain.go
+++ b/ecc/bw6-756/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bw6-756/fr/iop/polynomial.go
+++ b/ecc/bw6-756/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bw6-756/fr/iop/ratios.go
+++ b/ecc/bw6-756/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bw6-756/fr/kzg/kzg.go
+++ b/ecc/bw6-756/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-756"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -1444,12 +1445,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -1459,7 +1460,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -844,12 +845,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -859,7 +860,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/bw6-761/fr/fft/domain.go
+++ b/ecc/bw6-761/fr/fft/domain.go
@@ -71,10 +71,7 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 
-	rootOfUnity.SetString("32863578547254505029601261939868325669770508939375122462904745766352256812585773382134936404344547323199885654433")
-	const maxOrderRoot uint64 = 46
 	domain.FrMultiplicativeGen.SetUint64(15)
 
 	if len(shift) != 0 {
@@ -82,15 +79,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -101,6 +94,27 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+
+	rootOfUnity.SetString("32863578547254505029601261939868325669770508939375122462904745766352256812585773382134936404344547323199885654433")
+	const maxOrderRoot uint64 = 46
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/ecc/bw6-761/fr/fft/domain.go
+++ b/ecc/bw6-761/fr/fft/domain.go
@@ -112,7 +112,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/ecc/bw6-761/fr/fft/domain.go
+++ b/ecc/bw6-761/fr/fft/domain.go
@@ -96,6 +96,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -146,11 +146,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -18,6 +18,7 @@ package iop
 
 import (
 	"errors"
+	"math/big"
 	"math/bits"
 	"runtime"
 	"sync"
@@ -347,9 +348,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail.
 		// in practice now we call with nbCopies = 3;
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -344,6 +344,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail.
+		// in practice now we call with nbCopies = 3;
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/ecc/bw6-761/fr/iop/ratios.go
+++ b/ecc/bw6-761/fr/iop/ratios.go
@@ -345,8 +345,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail.
-		// in practice now we call with nbCopies = 3;
 		i := i
 
 		var coset fr.Element

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -26,6 +26,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -275,14 +277,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+
+	for i := 1; i < len(polynomials); i++ {
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j := start; j < end; j++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -720,12 +721,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -735,7 +736,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -720,12 +721,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -735,7 +736,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -692,12 +693,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -707,7 +708,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/field/generator/internal/templates/element/base.go
+++ b/field/generator/internal/templates/element/base.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
+	"github.com/bits-and-blooms/bitset"
 )
 
 // {{.ElementName}} represents a field element stored on {{.NbWords}} words (uint64)
@@ -564,12 +565,12 @@ func BatchInvert(a []{{.ElementName}}) []{{.ElementName}} {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i:=0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -579,7 +580,7 @@ func BatchInvert(a []{{.ElementName}}) []{{.ElementName}} {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/consensys/gnark-crypto/field/hash"
 	"github.com/consensys/gnark-crypto/field/pool"
 )
@@ -506,12 +507,12 @@ func BatchInvert(a []Element) []Element {
 		return res
 	}
 
-	zeroes := make([]bool, len(a))
+	zeroes := bitset.New(uint(len(a)))
 	accumulator := One()
 
 	for i := 0; i < len(a); i++ {
 		if a[i].IsZero() {
-			zeroes[i] = true
+			zeroes.Set(uint(i))
 			continue
 		}
 		res[i] = accumulator
@@ -521,7 +522,7 @@ func BatchInvert(a []Element) []Element {
 	accumulator.Inverse(&accumulator)
 
 	for i := len(a) - 1; i >= 0; i-- {
-		if zeroes[i] {
+		if zeroes.Test(uint(i)) {
 			continue
 		}
 		res[i].Mul(&res[i], &accumulator)

--- a/internal/generator/fft/template/domain.go.tmpl
+++ b/internal/generator/fft/template/domain.go.tmpl
@@ -136,7 +136,6 @@ func Generator(m uint64) (fr.Element, error) {
 		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
 	}
 
-	// Generator = FinerGenerator^2 has order x
 	expo := uint64(1 << (maxOrderRoot - logx))
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x

--- a/internal/generator/fft/template/domain.go.tmpl
+++ b/internal/generator/fft/template/domain.go.tmpl
@@ -53,42 +53,23 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.Cardinality = uint64(x)
 
 	// generator of the largest 2-adic subgroup
-	var rootOfUnity fr.Element
 	{{if eq .Name "bls12-378"}}
-		rootOfUnity.SetString("4045585818372166415418670827807793147093034396422209590578257013290761627990")
-		const maxOrderRoot uint64 = 42
         domain.FrMultiplicativeGen.SetUint64(22)
 	{{else if eq .Name "bls12-377"}}
-		rootOfUnity.SetString("8065159656716812877374967518403273466521432693661810619979959746626482506078")
-		const maxOrderRoot uint64 = 47
         domain.FrMultiplicativeGen.SetUint64(22)
 	{{else if eq .Name "bls12-381"}}
-		rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
-		const maxOrderRoot uint64 = 32
         domain.FrMultiplicativeGen.SetUint64(7)
 	{{else if eq .Name "bn254"}}
-		rootOfUnity.SetString("19103219067921713944291392827692070036145651957329286315305642004821462161904")
-		const maxOrderRoot uint64 = 28
         domain.FrMultiplicativeGen.SetUint64(5)
 	{{else if eq .Name "bw6-761"}}
-		rootOfUnity.SetString("32863578547254505029601261939868325669770508939375122462904745766352256812585773382134936404344547323199885654433")
-		const maxOrderRoot uint64 = 46
         domain.FrMultiplicativeGen.SetUint64(15)
 	{{else if eq .Name "bw6-756"}}
-        rootOfUnity.SetString("199251335866470442271346949249090720992237796757894062992204115206570647302191425225605716521843542790404563904580")
-        const maxOrderRoot uint64 = 41
         domain.FrMultiplicativeGen.SetUint64(5)
     {{else if eq .Name "bw6-633"}}
-		rootOfUnity.SetString("4991787701895089137426454739366935169846548798279261157172811661565882460884369603588700158257")
-		const maxOrderRoot uint64 = 20
         domain.FrMultiplicativeGen.SetUint64(13)
 	{{else if eq .Name "bls24-315"}}
-		rootOfUnity.SetString("1792993287828780812362846131493071959406149719416102105453370749552622525216")
-       const maxOrderRoot uint64 = 22
         domain.FrMultiplicativeGen.SetUint64(7)
 	{{else if eq .Name "bls24-317"}}
-		rootOfUnity.SetString("16532287748948254263922689505213135976137839535221842169193829039521719560631")
-       const maxOrderRoot uint64 = 60
         domain.FrMultiplicativeGen.SetUint64(7)
 	{{end}}
 
@@ -97,15 +78,11 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	}
 	domain.FrMultiplicativeGenInv.Inverse(&domain.FrMultiplicativeGen)
 
-	// find generator for Z/2^(log(m))Z
-	logx := uint64(bits.TrailingZeros64(x))
-	if logx > maxOrderRoot {
-		panic(fmt.Sprintf("m (%d) is too big: the required root of unity does not exist", m))
+	var err error 
+	domain.Generator, err = Generator(m)
+	if err != nil {
+		panic(err)
 	}
-
-	// Generator = FinerGenerator^2 has order x
-	expo := uint64(1 << (maxOrderRoot - logx))
-	domain.Generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	domain.GeneratorInv.Inverse(&domain.Generator)
 	domain.CardinalityInv.SetUint64(uint64(x)).Inverse(&domain.CardinalityInv)
 
@@ -116,6 +93,52 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	domain.reverseCosetTables()
 
 	return domain
+}
+
+func Generator(m uint64) (fr.Element, error) {
+	x := ecc.NextPowerOfTwo(m)
+
+	var rootOfUnity fr.Element
+	{{if eq .Name "bls12-378"}}
+		rootOfUnity.SetString("4045585818372166415418670827807793147093034396422209590578257013290761627990")
+		const maxOrderRoot uint64 = 42
+	{{else if eq .Name "bls12-377"}}
+		rootOfUnity.SetString("8065159656716812877374967518403273466521432693661810619979959746626482506078")
+		const maxOrderRoot uint64 = 47
+	{{else if eq .Name "bls12-381"}}
+		rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
+		const maxOrderRoot uint64 = 32
+	{{else if eq .Name "bn254"}}
+		rootOfUnity.SetString("19103219067921713944291392827692070036145651957329286315305642004821462161904")
+		const maxOrderRoot uint64 = 28
+	{{else if eq .Name "bw6-761"}}
+		rootOfUnity.SetString("32863578547254505029601261939868325669770508939375122462904745766352256812585773382134936404344547323199885654433")
+		const maxOrderRoot uint64 = 46
+	{{else if eq .Name "bw6-756"}}
+        rootOfUnity.SetString("199251335866470442271346949249090720992237796757894062992204115206570647302191425225605716521843542790404563904580")
+        const maxOrderRoot uint64 = 41
+    {{else if eq .Name "bw6-633"}}
+		rootOfUnity.SetString("4991787701895089137426454739366935169846548798279261157172811661565882460884369603588700158257")
+		const maxOrderRoot uint64 = 20
+	{{else if eq .Name "bls24-315"}}
+		rootOfUnity.SetString("1792993287828780812362846131493071959406149719416102105453370749552622525216")
+       const maxOrderRoot uint64 = 22
+	{{else if eq .Name "bls24-317"}}
+		rootOfUnity.SetString("16532287748948254263922689505213135976137839535221842169193829039521719560631")
+       const maxOrderRoot uint64 = 60
+	{{end}}
+
+	// find generator for Z/2^(log(m))Z
+	logx := uint64(bits.TrailingZeros64(x))
+	if logx > maxOrderRoot {
+		return fr.Element{}, fmt.Errorf("m (%d) is too big: the required root of unity does not exist", m)
+	}
+
+	// Generator = FinerGenerator^2 has order x
+	expo := uint64(1 << (maxOrderRoot - logx))
+	var generator fr.Element
+	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
+	return generator, nil
 }
 
 func (d *Domain) reverseCosetTables() {

--- a/internal/generator/fft/template/domain.go.tmpl
+++ b/internal/generator/fft/template/domain.go.tmpl
@@ -95,6 +95,8 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	return domain
 }
 
+// Generator returns a generator for Z/2^(log(m))Z
+// or an error if m is too big (required root of unity doesn't exist)
 func Generator(m uint64) (fr.Element, error) {
 	x := ecc.NextPowerOfTwo(m)
 

--- a/internal/generator/iop/template/polynomial.go.tmpl
+++ b/internal/generator/iop/template/polynomial.go.tmpl
@@ -133,11 +133,13 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 		return p.polynomial.evaluate(x)
 	}
 
-	// TODO find a way to retrieve the root properly instead of re generating the fft domain
-	d := fft.NewDomain(uint64(p.size))
 	var g fr.Element
 	if p.shift <= 5 {
-		g = smallExp(d.Generator, p.shift)
+		gen, err := fft.Generator(uint64(p.size))
+		if err != nil {
+			panic(err)
+		}
+		g = smallExp(gen, p.shift)
 		x.Mul(&x, &g)
 		return p.polynomial.evaluate(x)
 	}

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -330,8 +330,6 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
-		// TODO with a very small domain cardinality and lots of poly, this could fail. 
-		// in practice now we call with nbCopies = 3; 
 		i := i
 
 		var coset fr.Element

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -1,6 +1,7 @@
 import (
 	"errors"
 	"math/bits"
+	"math/big"
 	"runtime"
 	"sync"
 
@@ -332,9 +333,20 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 		// TODO with a very small domain cardinality and lots of poly, this could fail. 
 		// in practice now we call with nbCopies = 3; 
 		i := i
+
+		var coset fr.Element
+		if i == 1 {
+			coset = domain.FrMultiplicativeGen
+		} else {
+			if len(domain.CosetTable) > i {
+				coset = domain.CosetTable[i]
+			} else {
+				coset.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(i)))
+			}
+		}
+
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {
-				coset := domain.CosetTable[i]
 				for j := start; j < end; j++ {
 					res[i*sizePoly+j].Mul(&res[j], &coset)
 				}

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -329,6 +329,8 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	var wg sync.WaitGroup
 	wg.Add(nbCopies - 1)
 	for i := 1; i < nbCopies; i++ {
+		// TODO with a very small domain cardinality and lots of poly, this could fail. 
+		// in practice now we call with nbCopies = 3; 
 		i := i
 		go func() {
 			parallel.Execute(sizePoly, func(start, end int) {

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -204,9 +204,12 @@ func BuildRatioCopyConstraint(
 	}
 
 	t = fr.BatchInvert(t)
-	for i := 1; i < n; i++ {
-		coeffs[i].Mul(&coeffs[i], &t[i])
-	}
+	parallel.Execute(n-1, func(start, end int){
+		for i := start; i < end; i++ {
+			coeffs[i+1].Mul(&coeffs[i+1], &t[i+1])
+		}
+	})
+	
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
@@ -289,19 +292,25 @@ func buildDomain(n int, domain *fft.Domain) (*fft.Domain, error) {
 // nbCopies is the number of cosets of the roots of unity that are needed, including the set of
 // roots of unity itself.
 func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Element {
-
+	
 	res := make([]fr.Element, uint64(nbCopies)*domain.Cardinality)
 	sizePoly := int(domain.Cardinality)
 
-	res[0].SetOne()
-	for i := 0; i < sizePoly-1; i++ {
+	// len(domain.Twiddle) == sizePoly / 2
+	copy(res, domain.Twiddles[0]) 
+	// remaining ones.
+	for i := (sizePoly/2) - 1; i < sizePoly-1; i++ {
 		res[i+1].Mul(&res[i], &domain.Generator)
 	}
 	for i := 1; i < nbCopies; i++ {
-		copy(res[i*sizePoly:], res[(i-1)*sizePoly:i*int(domain.Cardinality)])
-		for j := 0; j < sizePoly; j++ {
-			res[i*sizePoly+j].Mul(&res[i*sizePoly+j], &domain.FrMultiplicativeGen)
-		}
+		// TODO @gbotrel maybe use same logic as FFT precompute exp table here.
+		parallel.Execute(sizePoly, func(start, end int) {
+			// hint the compiler to keep that hot variable on the stack.
+			gen := domain.FrMultiplicativeGen 
+			for j := start; j < end; j++ {
+				res[i*sizePoly+j].Mul(&res[(i-1)*sizePoly+j], &gen)
+			}
+		})
 	}
 
 	return res

--- a/internal/generator/iop/template/ratios.go.tmpl
+++ b/internal/generator/iop/template/ratios.go.tmpl
@@ -1,6 +1,8 @@
 import (
 	"errors"
 	"math/bits"
+	"runtime"
+	"sync"
 
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	
@@ -196,20 +198,39 @@ func BuildRatioCopyConstraint(
 			t[i+1].Set(&d)
 		}
 	})
-	
 
-	for i := 0; i < n-1; i++ {
-		coeffs[i+1].Mul(&coeffs[i+1], &coeffs[i])
-		t[i+1].Mul(&t[i+1], &t[i])
+	chCoeffs := make(chan struct{},1)
+	go func() {
+		for i := 2; i < n; i++ {
+			// ignoring coeffs[0]
+			coeffs[i].Mul(&coeffs[i], &coeffs[i-1])
+		}
+		close(chCoeffs)
+	}()
+
+	for i := 2; i < n; i++ {
+		// ignoring t[0]
+		t[i].Mul(&t[i], &t[i-1])
+	}
+	<-chCoeffs
+
+	// rough ratio inverse to mul; see if it makes sense to parallelize the batch inverse. 
+	const ratioInvMul = 1000 / 17
+	nbTasks := runtime.NumCPU()
+	if ratio := n / ratioInvMul; ratio < nbTasks {
+		nbTasks = ratio
 	}
 
-	t = fr.BatchInvert(t)
-	parallel.Execute(n-1, func(start, end int){
+
+	parallel.Execute(n-1, func(start, end int) {
+		// ignoring t[0] and coeff[0]
+		start++
+		end++
+		tInv := fr.BatchInvert(t[start:end])
 		for i := start; i < end; i++ {
-			coeffs[i+1].Mul(&coeffs[i+1], &t[i+1])
+			coeffs[i].Mul(&coeffs[i], &tInv[i-start])
 		}
-	})
-	
+	}, nbTasks)
 
 	res := NewPolynomial(&coeffs, expectedForm)
 	// at this stage the result is in Lagrange form, Regular layout
@@ -302,16 +323,25 @@ func getSupportIdentityPermutation(nbCopies int, domain *fft.Domain) []fr.Elemen
 	for i := (sizePoly/2) - 1; i < sizePoly-1; i++ {
 		res[i+1].Mul(&res[i], &domain.Generator)
 	}
-	for i := 1; i < nbCopies; i++ {
-		// TODO @gbotrel maybe use same logic as FFT precompute exp table here.
-		parallel.Execute(sizePoly, func(start, end int) {
-			// hint the compiler to keep that hot variable on the stack.
-			gen := domain.FrMultiplicativeGen 
-			for j := start; j < end; j++ {
-				res[i*sizePoly+j].Mul(&res[(i-1)*sizePoly+j], &gen)
-			}
-		})
+	if nbCopies <= 1 {
+		return res
 	}
+	var wg sync.WaitGroup
+	wg.Add(nbCopies - 1)
+	for i := 1; i < nbCopies; i++ {
+		i := i
+		go func() {
+			parallel.Execute(sizePoly, func(start, end int) {
+				coset := domain.CosetTable[i]
+				for j := start; j < end; j++ {
+					res[i*sizePoly+j].Mul(&res[j], &coset)
+				}
+			}, (runtime.NumCPU() / (nbCopies - 1)) + 1)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 
 	return res
 }

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -8,6 +8,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/fiat-shamir"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 var (
@@ -257,14 +259,21 @@ func BatchOpenSinglePoint(polynomials [][]fr.Element, digests []Digest, point fr
 	// gamma n in parallel, before reducing into foldedPolynomials
 	foldedPolynomials := make([]fr.Element, largestPoly)
 	copy(foldedPolynomials, polynomials[0])
-	acc := gamma
-	var pj fr.Element
+	gammas := make([]fr.Element, len(polynomials))
+	gammas[0] = gamma
+	for i := 1 ; i < len(polynomials); i++ {
+		gammas[i].Mul(&gammas[i-1], &gamma)
+	}
+	
 	for i := 1; i < len(polynomials); i++ {
-		for j := 0; j < len(polynomials[i]); j++ {
-			pj.Mul(&polynomials[i][j], &acc)
-			foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
-		}
-		acc.Mul(&acc, &gamma)
+		i := i
+		parallel.Execute(len(polynomials[i]), func(start, end int) {
+			var pj fr.Element
+			for j:= start; j < end; j ++ {
+				pj.Mul(&polynomials[i][j], &gammas[i-1])
+				foldedPolynomials[j].Add(&foldedPolynomials[j], &pj)
+			}
+		})
 	}
 
 	// compute H


### PR DESCRIPTION
* `fft` exposes `Generator()` method. 
* field.BatchInvert uses `bitset` instead of `[]bool` 
* iop / kzg packages have some loops parallelized. 

(context of this PR; plonk prover perf on 96cores)
