### PR TITLE
Run tests with Go 1.19 and 1.20

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 on: pull_request
-env: 
+env:
   GOPROXY: "https://proxy.golang.org"
 
 name: pull_request
@@ -10,7 +10,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - name: checkout code
       uses: actions/checkout@v2
       with:
@@ -39,11 +39,11 @@ jobs:
         git update-index --assume-unchanged go.mod
         git update-index --assume-unchanged go.sum
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after runing go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi
-  
+
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x, 1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs:
@@ -72,12 +72,12 @@ jobs:
         go test -p=1 -v -timeout=30m ./...
         go test -p=1 -tags=purego -v -timeout=30m ./...
     - name: Test (32 bits & race)
-      if: (matrix.os == 'ubuntu-latest') && (matrix.go-version == '1.18.x')
+      if: (matrix.os == 'ubuntu-latest') && (matrix.go-version == '1.19.x')
       run: |
           go test -p=1 -v -timeout=30m -short -race  ./ecc/bn254/...
           go test -p=1 -v -timeout=30m -short -tags=noadx  ./ecc/bn254/...
           GOARCH=386 go test -p=1 -timeout=30m -short -v  ./ecc/bn254/...
-  
+
   slack-workflow-status-failed:
     if: failure()
     name: post workflow status to slack

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ### Go version
 
-`gnark-crypto` is tested with the last 2 major releases of Go (1.17 and 1.18).
+`gnark-crypto` is tested with the last 2 major releases of Go (currently 1.19 and 1.20).
 
 ### Install `gnark-crypto`
 


### PR DESCRIPTION
The README indicates that `gnark-crypto` is tested on the latest two major releases. With the [recent release of Go 1.20](https://go.dev/doc/go1.20), these two versions should now be 1.19 and 1.20.

* Update the GitHub PR workflow with new versions.
  * Also delete some trailing whitespace there.
* Update README to reflect this change.
  * It was slightly out-of-date btw.