### PR TITLE
fix: mods smaller than 5; overestimating nbword

### DIFF
--- a/field/generator/config/field_test.go
+++ b/field/generator/config/field_test.go
@@ -201,7 +201,11 @@ func genField(t *testing.T) gopter.Gen {
 		genField := func() *FieldConfig {
 
 			nbWords := minNbWords + mrand.Intn(maxNbWords-minNbWords) //#nosec G404 -- This is a false positive
-			bitLen := nbWords*64 - 1 - mrand.Intn(64)                 //#nosec G404 -- This is a false positive
+			bitLen := nbWords*64 - mrand.Intn(64)                     //#nosec G404 -- This is a false positive
+
+			if bitLen < 2 {
+				bitLen = 2
+			}
 
 			modulus, err := rand.Prime(rand.Reader, bitLen)
 			if err != nil {


### PR DESCRIPTION
Fixing two small bugs in the codegen-time field implementation test case generator

1. For fields of size 64n bits the word count was incorrectly computed as n+1
2. Sometimes the test case generator expected modulus bit length of size 1 or 0 bits.