### PR TITLE
make `mapToCurve` public to allow for custom cofactor clearing

### DIFF
--- a/ecc/bls12-377/hash_to_g1.go
+++ b/ecc/bls12-377/hash_to_g1.go
@@ -166,9 +166,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{17252667382019449424, 8408110001211059699, 18415587021986261264, 10797086888535946954, 9462758283094809199, 54995354010328751}
 	var sswuIsoCurveCoeffB = fp.Element{11130294635325289193, 6502679372128844082, 15863297759487624914, 16270683149854112145, 3560014356538878812, 27923742146399959}
@@ -268,7 +268,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -287,7 +287,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -305,8 +305,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bls12-377/hash_to_g1_test.go
+++ b/ecc/bls12-377/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls12-377/hash_to_g2.go
+++ b/ecc/bls12-377/hash_to_g2.go
@@ -613,9 +613,9 @@ func g2MulByZ(z *fptower.E2, x *fptower.E2) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve2 implements the SSWU map
+// MapToCurve2 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve2(u *fptower.E2) G2Affine {
+func MapToCurve2(u *fptower.E2) G2Affine {
 
 	var sswuIsoCurveCoeffA = fptower.E2{
 		A0: fp.Element{4274545572028848265, 14157081418478689358, 13123833976752631407, 4466041663276938746, 9062541850312583986, 90030181981586611},
@@ -739,7 +739,7 @@ func g2Sgn0(z *fptower.E2) uint64 {
 
 // MapToG2 invokes the SSWU map, and guarantees that the result is in g2
 func MapToG2(u fptower.E2) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	//this is in an isogenous curve
 	g2Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -758,7 +758,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&fptower.E2{
+	res = MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
@@ -779,11 +779,11 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&fptower.E2{
+	Q0 := MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
-	Q1 := mapToCurve2(&fptower.E2{
+	Q1 := MapToCurve2(&fptower.E2{
 		A0: u[2+0],
 		A1: u[2+1],
 	})

--- a/ecc/bls12-377/hash_to_g2_test.go
+++ b/ecc/bls12-377/hash_to_g2_test.go
@@ -95,7 +95,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fptower.E2) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !isOnE2Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -118,7 +118,7 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -126,12 +126,12 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range hashToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls12-378/hash_to_g1.go
+++ b/ecc/bls12-378/hash_to_g1.go
@@ -168,9 +168,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{15314533651602404840, 3999629397495592995, 17991228730268553058, 13253234862282888158, 4784493033884022421, 276795783356562829}
 	var sswuIsoCurveCoeffB = fp.Element{10499526804702755432, 6768914877862902950, 8287496811509120276, 9263962031121981469, 5075273437274786541, 60255618913255595}
@@ -270,7 +270,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -289,7 +289,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -307,8 +307,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bls12-378/hash_to_g1_test.go
+++ b/ecc/bls12-378/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls12-378/hash_to_g2.go
+++ b/ecc/bls12-378/hash_to_g2.go
@@ -21,7 +21,7 @@ import (
 
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-4.1
 // Shallue and van de Woestijne method, works for any elliptic curve in Weierstrass curve
-func svdwMapG2(u fptower.E2) G2Affine {
+func MapToCurve2(u fptower.E2) G2Affine {
 
 	var res G2Affine
 
@@ -91,7 +91,7 @@ func svdwMapG2(u fptower.E2) G2Affine {
 // MapToG2 maps an fp.Element to a point on the curve using the Shallue and van de Woestijne map
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-2.2.1
 func MapToG2(t fptower.E2) G2Affine {
-	res := svdwMapG2(t)
+	res := MapToCurve2(t)
 	res.ClearCofactor(&res)
 	return res
 }

--- a/ecc/bls12-381/hash_to_g1.go
+++ b/ecc/bls12-381/hash_to_g1.go
@@ -177,9 +177,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{3415322872136444497, 9675504606121301699, 13284745414851768802, 2873609449387478652, 2897906769629812789, 1536947672689614213}
 	var sswuIsoCurveCoeffB = fp.Element{18129637713272545760, 11144507692959411567, 10108153527111632324, 9745270364868568433, 14587922135379007624, 469008097655535723}
@@ -279,7 +279,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -298,7 +298,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -316,8 +316,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bls12-381/hash_to_g1_test.go
+++ b/ecc/bls12-381/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls12-381/hash_to_g2.go
+++ b/ecc/bls12-381/hash_to_g2.go
@@ -213,9 +213,9 @@ func g2MulByZ(z *fptower.E2, x *fptower.E2) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve2 implements the SSWU map
+// MapToCurve2 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve2(u *fptower.E2) G2Affine {
+func MapToCurve2(u *fptower.E2) G2Affine {
 
 	var sswuIsoCurveCoeffA = fptower.E2{
 		A0: fp.Element{0},
@@ -339,7 +339,7 @@ func g2Sgn0(z *fptower.E2) uint64 {
 
 // MapToG2 invokes the SSWU map, and guarantees that the result is in g2
 func MapToG2(u fptower.E2) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	//this is in an isogenous curve
 	g2Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -358,7 +358,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&fptower.E2{
+	res = MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
@@ -379,11 +379,11 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&fptower.E2{
+	Q0 := MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
-	Q1 := mapToCurve2(&fptower.E2{
+	Q1 := MapToCurve2(&fptower.E2{
 		A0: u[2+0],
 		A1: u[2+1],
 	})

--- a/ecc/bls12-381/hash_to_g2_test.go
+++ b/ecc/bls12-381/hash_to_g2_test.go
@@ -95,7 +95,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fptower.E2) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !isOnE2Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -118,7 +118,7 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -126,12 +126,12 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range hashToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls24-315/hash_to_g1.go
+++ b/ecc/bls24-315/hash_to_g1.go
@@ -168,9 +168,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{5402807948305211529, 9163880483319140034, 7646126700453841420, 11071466103913358468, 124200740526673728}
 	var sswuIsoCurveCoeffB = fp.Element{16058189711238232929, 8302337653269510588, 11411933349841587630, 8954038365926617417, 177308873523699836}
@@ -270,7 +270,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -289,7 +289,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -307,8 +307,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bls24-315/hash_to_g1_test.go
+++ b/ecc/bls24-315/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls24-315/hash_to_g2.go
+++ b/ecc/bls24-315/hash_to_g2.go
@@ -21,7 +21,7 @@ import (
 
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-4.1
 // Shallue and van de Woestijne method, works for any elliptic curve in Weierstrass curve
-func svdwMapG2(u fptower.E4) G2Affine {
+func MapToCurve2(u fptower.E4) G2Affine {
 
 	var res G2Affine
 
@@ -98,7 +98,7 @@ func svdwMapG2(u fptower.E4) G2Affine {
 // MapToG2 maps an fp.Element to a point on the curve using the Shallue and van de Woestijne map
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-2.2.1
 func MapToG2(t fptower.E4) G2Affine {
-	res := svdwMapG2(t)
+	res := MapToCurve2(t)
 	res.ClearCofactor(&res)
 	return res
 }

--- a/ecc/bls24-317/hash_to_g1.go
+++ b/ecc/bls24-317/hash_to_g1.go
@@ -145,9 +145,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{2751493217506761890, 10508083672876982400, 9568653941102734201, 1934905759174260726, 590687129635764257}
 	var sswuIsoCurveCoeffB = fp.Element{14477170886729819615, 1154054877908840441, 13400991584556574205, 3277375072715511934, 979998381373634863}
@@ -247,7 +247,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -266,7 +266,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -284,8 +284,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bls24-317/hash_to_g1_test.go
+++ b/ecc/bls24-317/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bls24-317/hash_to_g2.go
+++ b/ecc/bls24-317/hash_to_g2.go
@@ -21,7 +21,7 @@ import (
 
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-4.1
 // Shallue and van de Woestijne method, works for any elliptic curve in Weierstrass curve
-func svdwMapG2(u fptower.E4) G2Affine {
+func MapToCurve2(u fptower.E4) G2Affine {
 
 	var res G2Affine
 
@@ -97,7 +97,7 @@ func svdwMapG2(u fptower.E4) G2Affine {
 // MapToG2 maps an fp.Element to a point on the curve using the Shallue and van de Woestijne map
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06#section-2.2.1
 func MapToG2(t fptower.E4) G2Affine {
-	res := svdwMapG2(t)
+	res := MapToCurve2(t)
 	res.ClearCofactor(&res)
 	return res
 }

--- a/ecc/bn254/hash_to_g1.go
+++ b/ecc/bn254/hash_to_g1.go
@@ -20,10 +20,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 )
 
-// mapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
+// MapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
 // No cofactor clearing or isogeny
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#straightline-svdw
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 	var tv1, tv2, tv3, tv4 fp.Element
 	var x1, x2, x3, gx1, gx2, gx, x, y fp.Element
 	var one fp.Element
@@ -112,7 +112,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SVDW map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	return res
 }
 
@@ -128,7 +128,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	return res, nil
 }
@@ -143,8 +143,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	var _Q0, _Q1 G1Jac
 	_Q0.FromAffine(&Q0)

--- a/ecc/bn254/hash_to_g1_test.go
+++ b/ecc/bn254/hash_to_g1_test.go
@@ -57,7 +57,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !g.IsOnCurve() {
 				t.Log("SVDW output not on curve")
@@ -74,18 +74,18 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
 
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}
 }

--- a/ecc/bn254/hash_to_g2.go
+++ b/ecc/bn254/hash_to_g2.go
@@ -21,10 +21,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/internal/fptower"
 )
 
-// mapToCurve2 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
+// MapToCurve2 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
 // No cofactor clearing or isogeny
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#straightline-svdw
-func mapToCurve2(u *fptower.E2) G2Affine {
+func MapToCurve2(u *fptower.E2) G2Affine {
 	var tv1, tv2, tv3, tv4 fptower.E2
 	var x1, x2, x3, gx1, gx2, gx, x, y fptower.E2
 	var one fptower.E2
@@ -143,7 +143,7 @@ func g2Sgn0(z *fptower.E2) uint64 {
 
 // MapToG2 invokes the SVDW map, and guarantees that the result is in g2
 func MapToG2(u fptower.E2) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	res.ClearCofactor(&res)
 	return res
 }
@@ -160,7 +160,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&fptower.E2{
+	res = MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
@@ -179,11 +179,11 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&fptower.E2{
+	Q0 := MapToCurve2(&fptower.E2{
 		A0: u[0],
 		A1: u[1],
 	})
-	Q1 := mapToCurve2(&fptower.E2{
+	Q1 := MapToCurve2(&fptower.E2{
 		A0: u[2+0],
 		A1: u[2+1],
 	})

--- a/ecc/bn254/hash_to_g2_test.go
+++ b/ecc/bn254/hash_to_g2_test.go
@@ -59,7 +59,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fptower.E2) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !g.IsOnCurve() {
 				t.Log("SVDW output not on curve")
@@ -76,18 +76,18 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
 
 	for _, c := range hashToG2Vector.cases {
 		var u fptower.E2
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}
 }

--- a/ecc/bw6-633/hash_to_g1.go
+++ b/ecc/bw6-633/hash_to_g1.go
@@ -169,9 +169,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{12925890271846221020, 6355149021182850637, 12305199997029221454, 3176370205483940054, 1111744716227392272, 1674946515969267914, 9082444721826297409, 17859522351279563418, 11442187008395780520, 4206825732020662}
 	var sswuIsoCurveCoeffB = fp.Element{1447342806075484185, 5642327672839545870, 16783436050687675045, 2630023864181351186, 5909133526915342434, 1057352115267779153, 1923190814798170064, 13280701548970829092, 3305076617946573429, 29606717104036842}
@@ -271,7 +271,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -290,7 +290,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -308,8 +308,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bw6-633/hash_to_g1_test.go
+++ b/ecc/bw6-633/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bw6-633/hash_to_g2.go
+++ b/ecc/bw6-633/hash_to_g2.go
@@ -143,9 +143,9 @@ func g2MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve2 implements the SSWU map
+// MapToCurve2 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve2(u *fp.Element) G2Affine {
+func MapToCurve2(u *fp.Element) G2Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{13503940466125084703, 3000707982748310797, 1529397070312683242, 9240962296298654443, 4577258595340312235, 16046828875439788343, 7236093083337192433, 2860564553402019540, 5160479239841632821, 65394042426465165}
 	var sswuIsoCurveCoeffB = fp.Element{4170590011558214244, 9101648159034903675, 4256739633972552875, 7483080556638609334, 12430228215152656439, 9977400640742476476, 15847011074743951739, 17768582661138350292, 10869631430819016060, 64187107279947172}
@@ -245,7 +245,7 @@ func g2Sgn0(z *fp.Element) uint64 {
 
 // MapToG2 invokes the SSWU map, and guarantees that the result is in g2
 func MapToG2(u fp.Element) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	//this is in an isogenous curve
 	g2Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -264,7 +264,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&u[0])
+	res = MapToCurve2(&u[0])
 
 	//this is in an isogenous curve
 	g2Isogeny(&res)
@@ -282,8 +282,8 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&u[0])
-	Q1 := mapToCurve2(&u[1])
+	Q0 := MapToCurve2(&u[0])
+	Q1 := MapToCurve2(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g2Isogeny(&Q0)

--- a/ecc/bw6-633/hash_to_g2_test.go
+++ b/ecc/bw6-633/hash_to_g2_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !isOnE2Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range hashToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bw6-756/hash_to_g1.go
+++ b/ecc/bw6-756/hash_to_g1.go
@@ -168,9 +168,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{6087387690755251612, 7643068232434215576, 6195945763281467660, 97569654519975969, 1505434147110560758, 12342644747290341982, 14059794106692380317, 15229664573794943703, 16908793757593141664, 1949816925291208189, 9451095697369482684, 234190359239853}
 	var sswuIsoCurveCoeffB = fp.Element{18446744073709458379, 881299893533802495, 4886355625346099349, 6225448195760991771, 6629400315996169345, 12607886696045185322, 7201730065066775519, 1932403901886200506, 8616600553259348813, 6369175937589644082, 7499857803942196586, 3773119276850162}
@@ -270,7 +270,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -289,7 +289,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -307,8 +307,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bw6-756/hash_to_g1_test.go
+++ b/ecc/bw6-756/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bw6-756/hash_to_g2.go
+++ b/ecc/bw6-756/hash_to_g2.go
@@ -240,9 +240,9 @@ func g2MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve2 implements the SSWU map
+// MapToCurve2 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve2(u *fp.Element) G2Affine {
+func MapToCurve2(u *fp.Element) G2Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{11188695195863236139, 18339800635248689929, 13644954250665578253, 16122525194076552550, 1985822167495960177, 11021218035968661748, 12951199075167016614, 18080500199774882647, 3065668365127963650, 1810223365641727596, 18249180996905802984, 4351293214471385}
 	var sswuIsoCurveCoeffB = fp.Element{3597427888115195847, 8485485194496420669, 9451115945982544412, 10217463679676360079, 3023875305953960937, 5866766270380139867, 15059909646037855295, 1065687373540957157, 12978541562777068958, 18112033168403904062, 11632286302244735111, 1469792042332206}
@@ -342,7 +342,7 @@ func g2Sgn0(z *fp.Element) uint64 {
 
 // MapToG2 invokes the SSWU map, and guarantees that the result is in g2
 func MapToG2(u fp.Element) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	//this is in an isogenous curve
 	g2Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -361,7 +361,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&u[0])
+	res = MapToCurve2(&u[0])
 
 	//this is in an isogenous curve
 	g2Isogeny(&res)
@@ -379,8 +379,8 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&u[0])
-	Q1 := mapToCurve2(&u[1])
+	Q0 := MapToCurve2(&u[0])
+	Q1 := MapToCurve2(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g2Isogeny(&Q0)

--- a/ecc/bw6-756/hash_to_g2_test.go
+++ b/ecc/bw6-756/hash_to_g2_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !isOnE2Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range hashToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bw6-761/hash_to_g1.go
+++ b/ecc/bw6-761/hash_to_g1.go
@@ -131,9 +131,9 @@ func g1MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve1 implements the SSWU map
+// MapToCurve1 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{12169852093062392636, 3867460573998792965, 2540986171999662608, 3377838107874487171, 6313266756742099767, 5994530928773814047, 5007141583730923456, 2345996307867737670, 7096861766432061441, 10014420324597579745, 8416419844935780388, 63340978449966806}
 	var sswuIsoCurveCoeffB = fp.Element{9514135687797572479, 9972495974968977338, 17954535578332286571, 7437044986470910914, 13903267017721129281, 1871129682978723308, 13401268269932482209, 739043012311877982, 12116264695643437343, 1632209977726909861, 3621981106970059143, 65605772132525947}
@@ -233,7 +233,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SSWU map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	//this is in an isogenous curve
 	g1Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -252,7 +252,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	//this is in an isogenous curve
 	g1Isogeny(&res)
@@ -270,8 +270,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g1Isogeny(&Q0)

--- a/ecc/bw6-761/hash_to_g1_test.go
+++ b/ecc/bw6-761/hash_to_g1_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !isOnE1Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1Isogeny(&q)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/bw6-761/hash_to_g2.go
+++ b/ecc/bw6-761/hash_to_g2.go
@@ -307,9 +307,9 @@ func g2MulByZ(z *fp.Element, x *fp.Element) {
 }
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve2 implements the SSWU map
+// MapToCurve2 implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve2(u *fp.Element) G2Affine {
+func MapToCurve2(u *fp.Element) G2Affine {
 
 	var sswuIsoCurveCoeffA = fp.Element{13704010396169241312, 14330175345318364589, 4449492585807198633, 9884564993510771995, 16507506367033405761, 12171409358426895620, 3759742122315801393, 6972450370136308820, 13649992927502603798, 15742083997009939515, 4062268800652448528, 42571325818609943}
 	var sswuIsoCurveCoeffB = fp.Element{17251063859315847117, 13422534455279952781, 15626212001505409941, 8548929388122544483, 12216093319907597521, 15761783579263790289, 10925761432004348632, 8228665107915194054, 13147767302058909808, 5735540302608306489, 5152863309501448410, 45595036249636616}
@@ -409,7 +409,7 @@ func g2Sgn0(z *fp.Element) uint64 {
 
 // MapToG2 invokes the SSWU map, and guarantees that the result is in g2
 func MapToG2(u fp.Element) G2Affine {
-	res := mapToCurve2(&u)
+	res := MapToCurve2(&u)
 	//this is in an isogenous curve
 	g2Isogeny(&res)
 	res.ClearCofactor(&res)
@@ -428,7 +428,7 @@ func EncodeToG2(msg, dst []byte) (G2Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve2(&u[0])
+	res = MapToCurve2(&u[0])
 
 	//this is in an isogenous curve
 	g2Isogeny(&res)
@@ -446,8 +446,8 @@ func HashToG2(msg, dst []byte) (G2Affine, error) {
 		return G2Affine{}, err
 	}
 
-	Q0 := mapToCurve2(&u[0])
-	Q1 := mapToCurve2(&u[1])
+	Q0 := MapToCurve2(&u[0])
+	Q1 := MapToCurve2(&u[1])
 
 	//TODO (perf): Add in E' first, then apply isogeny
 	g2Isogeny(&Q0)

--- a/ecc/bw6-761/hash_to_g2_test.go
+++ b/ecc/bw6-761/hash_to_g2_test.go
@@ -93,7 +93,7 @@ func TestMapToCurve2(t *testing.T) {
 	properties.Property("[G2] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve2(&a)
+			g := MapToCurve2(&a)
 
 			if !isOnE2Prime(g) {
 				t.Log("Mapping output not on E' curve")
@@ -116,7 +116,7 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range encodeToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
@@ -124,12 +124,12 @@ func TestMapToCurve2(t *testing.T) {
 	for _, c := range hashToG2Vector.cases {
 		var u fp.Element
 		g2CoordSetString(&u, c.u0)
-		q := mapToCurve2(&u)
+		q := MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g2CoordSetString(&u, c.u1)
-		q = mapToCurve2(&u)
+		q = MapToCurve2(&u)
 		g2Isogeny(&q)
 		g2TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}

--- a/ecc/secp256k1/hash_to_g1.go
+++ b/ecc/secp256k1/hash_to_g1.go
@@ -20,10 +20,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/secp256k1/fp"
 )
 
-// mapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
+// MapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
 // No cofactor clearing or isogeny
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#straightline-svdw
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 	var tv1, tv2, tv3, tv4 fp.Element
 	var x1, x2, x3, gx1, gx2, gx, x, y fp.Element
 	var one fp.Element
@@ -112,7 +112,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SVDW map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	return res
 }
 
@@ -128,7 +128,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	return res, nil
 }
@@ -143,8 +143,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	var _Q0, _Q1 G1Jac
 	_Q0.FromAffine(&Q0)

--- a/ecc/secp256k1/hash_to_g1_test.go
+++ b/ecc/secp256k1/hash_to_g1_test.go
@@ -57,7 +57,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !g.IsOnCurve() {
 				t.Log("SVDW output not on curve")
@@ -74,18 +74,18 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
 
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}
 }

--- a/ecc/stark-curve/hash_to_g1.go
+++ b/ecc/stark-curve/hash_to_g1.go
@@ -20,10 +20,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-// mapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
+// MapToCurve1 implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
 // No cofactor clearing or isogeny
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#straightline-svdw
-func mapToCurve1(u *fp.Element) G1Affine {
+func MapToCurve1(u *fp.Element) G1Affine {
 	var tv1, tv2, tv3, tv4 fp.Element
 	var x1, x2, x3, gx1, gx2, gx, x, y fp.Element
 	var one fp.Element
@@ -112,7 +112,7 @@ func g1Sgn0(z *fp.Element) uint64 {
 
 // MapToG1 invokes the SVDW map, and guarantees that the result is in g1
 func MapToG1(u fp.Element) G1Affine {
-	res := mapToCurve1(&u)
+	res := MapToCurve1(&u)
 	return res
 }
 
@@ -128,7 +128,7 @@ func EncodeToG1(msg, dst []byte) (G1Affine, error) {
 		return res, err
 	}
 
-	res = mapToCurve1(&u[0])
+	res = MapToCurve1(&u[0])
 
 	return res, nil
 }
@@ -143,8 +143,8 @@ func HashToG1(msg, dst []byte) (G1Affine, error) {
 		return G1Affine{}, err
 	}
 
-	Q0 := mapToCurve1(&u[0])
-	Q1 := mapToCurve1(&u[1])
+	Q0 := MapToCurve1(&u[0])
+	Q1 := MapToCurve1(&u[1])
 
 	var _Q0, _Q1 G1Jac
 	_Q0.FromAffine(&Q0)

--- a/ecc/stark-curve/hash_to_g1_test.go
+++ b/ecc/stark-curve/hash_to_g1_test.go
@@ -57,7 +57,7 @@ func TestMapToCurve1(t *testing.T) {
 	properties.Property("[G1] mapping output must be on curve", prop.ForAll(
 		func(a fp.Element) bool {
 
-			g := mapToCurve1(&a)
+			g := MapToCurve1(&a)
 
 			if !g.IsOnCurve() {
 				t.Log("SVDW output not on curve")
@@ -74,18 +74,18 @@ func TestMapToCurve1(t *testing.T) {
 	for _, c := range encodeToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
 
 	for _, c := range hashToG1Vector.cases {
 		var u fp.Element
 		g1CoordSetString(&u, c.u0)
-		q := mapToCurve1(&u)
+		q := MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		g1CoordSetString(&u, c.u1)
-		q = mapToCurve1(&u)
+		q = MapToCurve1(&u)
 		g1TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}
 }

--- a/internal/generator/ecc/template/hash_to_curve.go.tmpl
+++ b/internal/generator/ecc/template/hash_to_curve.go.tmpl
@@ -61,7 +61,7 @@ func {{$CurveName}}Sgn0(z *{{$CoordType}}) uint64 {
 
 // MapTo{{$CurveTitle}} invokes the {{.MappingAlgorithm}} map, and guarantees that the result is in {{$CurveName}}
 func MapTo{{$CurveTitle}}(u {{$CoordType}}) {{$AffineType}} {
-    res := mapToCurve{{$CurveIndex}}(&u)
+    res := MapToCurve{{$CurveIndex}}(&u)
     {{- if $isogenyNeeded }}
     //this is in an isogenous curve
         {{$CurveName}}Isogeny(&res)
@@ -85,9 +85,9 @@ func EncodeTo{{$CurveTitle}}(msg, dst []byte) ({{$AffineType}}, error) {
 	}
 
     {{if eq $TowerDegree 1}}
-    res = mapToCurve{{$CurveIndex}}(&u[0])
+    res = MapToCurve{{$CurveIndex}}(&u[0])
     {{else}}
-    res = mapToCurve{{$CurveIndex}}( &{{$CoordType}} {
+    res = MapToCurve{{$CurveIndex}}( &{{$CoordType}} {
         {{range $i := interval 0 $TowerDegree }} {{if eq $TowerDegree 2}}A{{end}}{{$i}}: u[{{$i}}],
     {{end}} })
     {{end}}
@@ -113,13 +113,13 @@ func HashTo{{$CurveTitle}}(msg, dst []byte) ({{$AffineType}}, error) {
 	}
 
 	{{if eq $TowerDegree 1}}
-	Q0 := mapToCurve{{$CurveIndex}}(&u[0])
-	Q1 := mapToCurve{{$CurveIndex}}(&u[1])
+	Q0 := MapToCurve{{$CurveIndex}}(&u[0])
+	Q1 := MapToCurve{{$CurveIndex}}(&u[1])
 	{{else}}
-	Q0 := mapToCurve{{$CurveIndex}}( &{{$CoordType}} {
+	Q0 := MapToCurve{{$CurveIndex}}( &{{$CoordType}} {
 		{{range $i := interval 0 $TowerDegree }} {{if eq $TowerDegree 2}}A{{end}}{{$i}}: u[{{$i}}],
 		{{end}} })
-	Q1 := mapToCurve{{$CurveIndex}}( &{{$CoordType}} {
+	Q1 := MapToCurve{{$CurveIndex}}( &{{$CoordType}} {
         {{range $i := interval 0 $TowerDegree }} {{if eq $TowerDegree 2}}A{{end}}{{$i}}: u[{{$TowerDegree}} + {{$i}}],
         {{end}} })
 	{{end}}

--- a/internal/generator/ecc/template/sswu.go.tmpl
+++ b/internal/generator/ecc/template/sswu.go.tmpl
@@ -291,9 +291,9 @@ func {{$CurveName}}MulByZ(z *{{$CoordType}}, x *{{$CoordType}}) {
 {{ end }}}
 
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-method
-// mapToCurve{{$CurveIndex}} implements the SSWU map
+// MapToCurve{{$CurveIndex}} implements the SSWU map
 // No cofactor clearing or isogeny
-func mapToCurve{{$CurveIndex}}(u *{{$CoordType}}) {{$AffineType}} {
+func MapToCurve{{$CurveIndex}}(u *{{$CoordType}}) {{$AffineType}} {
 
     {{if $isogenyNeeded}}
         var {{$sswuCurveACoeff}} = {{$CoordType}} {{asElement .A}}

--- a/internal/generator/ecc/template/svdw.go.tmpl
+++ b/internal/generator/ecc/template/svdw.go.tmpl
@@ -11,10 +11,10 @@
 {{if $IsG1}}{{$CurveIndex = "1"}}{{$B = "bCurveCoeff"}}{{end}}
 
 
-// mapToCurve{{$CurveIndex}} implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
+// MapToCurve{{$CurveIndex}} implements the Shallue and van de Woestijne method, applicable to any elliptic curve in Weierstrass form
 // No cofactor clearing or isogeny
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#straightline-svdw
-func mapToCurve{{$CurveIndex}}(u *{{$CoordType}}) {{$AffineType}} {
+func MapToCurve{{$CurveIndex}}(u *{{$CoordType}}) {{$AffineType}} {
     var tv1, tv2, tv3, tv4 {{$CoordType}}
     var x1, x2, x3, gx1, gx2, gx, x, y {{$CoordType}}
     var one {{$CoordType}}

--- a/internal/generator/ecc/template/tests/hash_to_curve.go.tmpl
+++ b/internal/generator/ecc/template/tests/hash_to_curve.go.tmpl
@@ -99,7 +99,7 @@ func TestMapToCurve{{$CurveIndex}}(t *testing.T) {
 	properties.Property("[{{$CurveTitle}}] mapping output must be on curve", prop.ForAll(
 		func(a {{$CoordType}}) bool {
 
-			g := mapToCurve{{$CurveIndex}}(&a)
+			g := MapToCurve{{$CurveIndex}}(&a)
 
 			{{if $isogenyNeeded}}
 				if !isOnE{{$CurveIndex}}Prime(g) {
@@ -126,18 +126,18 @@ func TestMapToCurve{{$CurveIndex}}(t *testing.T) {
 	for _, c := range encodeTo{{$CurveTitle}}Vector.cases {
 		var u {{$CoordType}}
 		{{$CurveName}}CoordSetString(&u, c.u)
-		q := mapToCurve{{$CurveIndex}}(&u)
+		q := MapToCurve{{$CurveIndex}}(&u)
 		{{$runIsogeny}}{{$CurveName}}TestMatchPoint(t, "Q", c.msg, c.Q, &q)
 	}
 
 	for _, c := range hashTo{{$CurveTitle}}Vector.cases {
 		var u {{$CoordType}}
 		{{$CurveName}}CoordSetString(&u, c.u0)
-		q := mapToCurve{{$CurveIndex}}(&u)
+		q := MapToCurve{{$CurveIndex}}(&u)
 		{{$runIsogeny}}{{$CurveName}}TestMatchPoint(t, "Q0", c.msg, c.Q0, &q)
 
 		{{$CurveName}}CoordSetString(&u, c.u1)
-		q = mapToCurve{{$CurveIndex}}(&u)
+		q = MapToCurve{{$CurveIndex}}(&u)
 		{{$runIsogeny}}{{$CurveName}}TestMatchPoint(t, "Q1", c.msg, c.Q1, &q)
 	}
 }


### PR DESCRIPTION
This PR allow third party software to rely on the `mapToCurve` provided by gnark-crypto independently from the cofactor clearing.