### PR TITLE
Refactor: export endomorphisms

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -396,7 +396,7 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 
-	res.phi(p).
+	res.Phi(p).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
@@ -437,7 +437,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -455,7 +455,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-377] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-377] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BLS12-377] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-377] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -380,7 +380,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // ψ(p) = [x₀]P
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
-	tmp.psi(p)
+	tmp.Psi(p)
 	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
@@ -418,7 +418,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Conjugate(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Conjugate(&p.Y).Mul(&p.Y, &endo.v)
@@ -428,7 +428,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -446,7 +446,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -529,7 +529,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	t.Set(&xg).
 		SubAssign(a).
-		psi(&t)
+		Psi(&t)
 
 	res.AddAssign(&t)
 

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-377] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-377] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-377] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-377] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,12 +68,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-377] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BLS12-377] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).Neg(&res1)
+			res1.Psi(&p).Psi(&res1).Neg(&res1)
 			res2.Set(&p)
 			res2.X.MulByElement(&res2.X, &thirdRootOneG1)
 
@@ -358,10 +358,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BLS12-377] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BLS12-377] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -396,7 +396,7 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 
-	res.phi(p).
+	res.Phi(p).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
@@ -437,7 +437,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -455,7 +455,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bls12-378/g1_test.go
+++ b/ecc/bls12-378/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-378] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-378] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BLS12-378] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-378] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -380,7 +380,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // ψ(p) = [x₀]P
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
-	tmp.psi(p)
+	tmp.Psi(p)
 	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
@@ -418,7 +418,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Conjugate(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Conjugate(&p.Y).Mul(&p.Y, &endo.v)
@@ -428,7 +428,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -446,7 +446,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -529,7 +529,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	t.Set(&xg).
 		SubAssign(a).
-		psi(&t)
+		Psi(&t)
 
 	res.AddAssign(&t)
 

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-378] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-378] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-378] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-378] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,12 +68,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-378] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BLS12-378] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).Neg(&res1)
+			res1.Psi(&p).Psi(&res1).Neg(&res1)
 			res2.Set(&p)
 			res2.X.MulByElement(&res2.X, &thirdRootOneG1)
 
@@ -358,10 +358,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BLS12-378] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BLS12-378] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -396,7 +396,7 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 
-	res.phi(p).
+	res.Phi(p).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
 		AddAssign(p)
@@ -437,7 +437,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -455,7 +455,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-381] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-381] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BLS12-381] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-381] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -381,7 +381,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // ψ(p) = [x₀]P
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
-	tmp.psi(p)
+	tmp.Psi(p)
 	res.ScalarMultiplication(p, &xGen).
 		AddAssign(&tmp)
 
@@ -419,7 +419,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Conjugate(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Conjugate(&p.Y).Mul(&p.Y, &endo.v)
@@ -429,7 +429,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -447,7 +447,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -530,7 +530,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	t.Set(&xg).
 		SubAssign(a).
-		psi(&t)
+		Psi(&t)
 
 	res.AddAssign(&t)
 

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS12-381] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS12-381] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-381] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS12-381] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,12 +68,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BLS12-381] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BLS12-381] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).Neg(&res1)
+			res1.Psi(&p).Psi(&res1).Neg(&res1)
 			res2.Set(&p)
 			res2.X.MulByElement(&res2.X, &thirdRootOneG1)
 
@@ -358,10 +358,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BLS12-381] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BLS12-381] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -396,7 +396,7 @@ func (p *G1Jac) IsOnCurve() bool {
 func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
-	res.phi(p).
+	res.Phi(p).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
@@ -439,7 +439,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -457,7 +457,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS24-315] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS24-315] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BLS24-315] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS24-315] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -381,7 +381,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // ψ(p) = [x₀]P
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
-	tmp.psi(p)
+	tmp.Psi(p)
 	res.ScalarMultiplication(p, &xGen).
 		AddAssign(&tmp)
 
@@ -420,7 +420,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Frobenius(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Frobenius(&p.Y).Mul(&p.Y, &endo.v)
@@ -430,7 +430,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -448,7 +448,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -533,25 +533,25 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 		SubAssign(a)
 
 	t.Set(&xxxg).
-		psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Set(&xxg).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	t.Set(&xg).
-		psi(&t).
-		psi(&t).
-		psi(&t).
+		Psi(&t).
+		Psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Double(a).
-		psi(&res).
-		psi(&res).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	p.Set(&res)

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS24-315] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS24-315] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE4(),
 	))
 
-	properties.Property("[BLS24-315] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS24-315] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,12 +68,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE4(),
 	))
 
-	properties.Property("[BLS24-315] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BLS24-315] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).psi(&res1).psi(&res1).Neg(&res1)
+			res1.Psi(&p).Psi(&res1).Psi(&res1).Psi(&res1).Neg(&res1)
 			res2.Set(&p)
 			res2.X.MulByElement(&res2.X, &thirdRootOneG1)
 
@@ -358,10 +358,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BLS24-315] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BLS24-315] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -396,7 +396,7 @@ func (p *G1Jac) IsOnCurve() bool {
 func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
-	res.phi(p).
+	res.Phi(p).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
@@ -439,7 +439,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -457,7 +457,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS24-317] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS24-317] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BLS24-317] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS24-317] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -381,7 +381,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // ψ(p) = [x₀]P
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
-	tmp.psi(p)
+	tmp.Psi(p)
 	res.ScalarMultiplication(p, &xGen).
 		SubAssign(&tmp)
 
@@ -420,7 +420,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Frobenius(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Frobenius(&p.Y).Mul(&p.Y, &endo.v)
@@ -430,7 +430,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -448,7 +448,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -533,25 +533,25 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 		SubAssign(a)
 
 	t.Set(&xxxg).
-		psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Set(&xxg).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	t.Set(&xg).
-		psi(&t).
-		psi(&t).
-		psi(&t).
+		Psi(&t).
+		Psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Double(a).
-		psi(&res).
-		psi(&res).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	p.Set(&res)

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BLS24-317] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BLS24-317] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE4(),
 	))
 
-	properties.Property("[BLS24-317] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BLS24-317] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,12 +68,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE4(),
 	))
 
-	properties.Property("[BLS24-317] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BLS24-317] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E4) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).psi(&res1).psi(&res1).Neg(&res1)
+			res1.Psi(&p).Psi(&res1).Psi(&res1).Psi(&res1).Neg(&res1)
 			res2.Set(&p)
 			res2.X.MulByElement(&res2.X, &thirdRootOneG1)
 
@@ -358,10 +358,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BLS24-317] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BLS24-317] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -427,7 +427,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -445,7 +445,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BN254] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BN254] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BN254] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BN254] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -381,13 +381,13 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var a, b, c, res G2Jac
 	a.ScalarMultiplication(p, &xGen)
-	b.psi(&a)
+	b.Psi(&a)
 	a.AddAssign(p)
-	res.psi(&b)
+	res.Psi(&b)
 	c.Set(&res).
 		AddAssign(&b).
 		AddAssign(&a)
-	res.psi(&res).
+	res.Psi(&res).
 		Double(&res).
 		SubAssign(&c)
 
@@ -425,7 +425,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 }
 
 // ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-func (p *G2Jac) psi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Psi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Conjugate(&p.X).Mul(&p.X, &endo.u)
 	p.Y.Conjugate(&p.Y).Mul(&p.Y, &endo.v)
@@ -435,7 +435,7 @@ func (p *G2Jac) psi(a *G2Jac) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.MulByElement(&p.X, &thirdRootOneG2)
 	return p
@@ -453,7 +453,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -532,12 +532,12 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).
-		psi(&points[1])
+		Psi(&points[1])
 
-	points[2].psi(&points[0]).
-		psi(&points[2])
+	points[2].Psi(&points[0]).
+		Psi(&points[2])
 
-	points[3].psi(a).psi(&points[3]).psi(&points[3])
+	points[3].Psi(a).Psi(&points[3]).Psi(&points[3])
 
 	var res G2Jac
 	res.Set(&g2Infinity)

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BN254] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BN254] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BN254] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BN254] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 
@@ -68,13 +68,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenE2(),
 	))
 
-	properties.Property("[BN254] check that psi^2(P) = -phi(P)", prop.ForAll(
+	properties.Property("[BN254] check that Psi^2(P) = -Phi(P)", prop.ForAll(
 		func(a fptower.E2) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.psi(&p).psi(&res1).Neg(&res1)
-			res2.phi(&p)
+			res1.Psi(&p).Psi(&res1).Neg(&res1)
+			res2.Phi(&p)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
 		},
@@ -357,10 +357,10 @@ func TestG2AffineOps(t *testing.T) {
 		genScalar,
 	))
 
-	properties.Property("[BN254] psi should map points from E' to itself", prop.ForAll(
+	properties.Property("[BN254] Psi should map points from E' to itself", prop.ForAll(
 		func() bool {
 			var a G2Jac
-			a.psi(&g2Gen)
+			a.Psi(&g2Gen)
 			return a.IsOnCurve() && !a.Equal(&g2Gen)
 		},
 	))

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -403,7 +403,7 @@ func (p *G1Jac) IsInSubGroup() bool {
 		ScalarMultiplication(&u4P, &xGen)
 	u5P.ScalarMultiplication(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
-	r.phi(&q).SubAssign(&uP).
+	r.Phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
 		AddAssign(&u5P)
 
@@ -442,7 +442,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -460,7 +460,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -559,7 +559,7 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	tmp.ScalarMultiplication(a, &ht)
 	L1.AddAssign(&tmp)
 
-	p.phi(&L1).AddAssign(&L0)
+	p.Phi(&L1).AddAssign(&L0)
 
 	return p
 

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-633] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-633] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-633] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-633] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -382,7 +382,7 @@ func (p *G2Jac) IsInSubGroup() bool {
 		ScalarMultiplication(&u4P, &xGen)
 	u5P.ScalarMultiplication(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
-	r.phi(&q).SubAssign(&uP).
+	r.Phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
 		AddAssign(&u5P)
 
@@ -421,7 +421,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG2)
 	return p
@@ -439,7 +439,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -540,7 +540,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	tmp.ScalarMultiplication(a, &d3)
 	L1.AddAssign(&tmp)
 
-	p.phi(&L1).AddAssign(&L0)
+	p.Phi(&L1).AddAssign(&L0)
 
 	return p
 

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-633] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-633] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-633] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-633] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -400,17 +400,17 @@ func (p *G1Jac) IsOnCurve() bool {
 // is the infinity.
 func (p *G1Jac) IsInSubGroup() bool {
 
-	var res, phip G1Jac
-	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
-		SubAssign(&phip).
+	var res, Phip G1Jac
+	Phip.Phi(p)
+	res.ScalarMultiplication(&Phip, &xGen).
+		SubAssign(&Phip).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
-		AddAssign(&phip)
+		AddAssign(&Phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	Phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
-	return phip.IsOnCurve() && phip.Z.IsZero()
+	return Phip.IsOnCurve() && Phip.Z.IsZero()
 
 }
 
@@ -446,7 +446,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -464,7 +464,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -559,7 +559,7 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	L1.AddAssign(&tmp).
 		SubAssign(a)
 
-	p.phi(&L1).
+	p.Phi(&L1).
 		AddAssign(&L0)
 
 	return p

--- a/ecc/bw6-756/g1_test.go
+++ b/ecc/bw6-756/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-756] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-756] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-756] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-756] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -379,17 +379,17 @@ func (p *G2Jac) IsOnCurve() bool {
 // is the infinity.
 func (p *G2Jac) IsInSubGroup() bool {
 
-	var res, phip G2Jac
-	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
-		SubAssign(&phip).
+	var res, Phip G2Jac
+	Phip.Phi(p)
+	res.ScalarMultiplication(&Phip, &xGen).
+		SubAssign(&Phip).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
-		AddAssign(&phip)
+		AddAssign(&Phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	Phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
-	return phip.IsOnCurve() && phip.Z.IsZero()
+	return Phip.IsOnCurve() && Phip.Z.IsZero()
 
 }
 
@@ -425,7 +425,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG2)
 	return p
@@ -443,7 +443,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -533,7 +533,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	L1.Set(&u3P).
 		SubAssign(&tmp)
 
-	p.phi(&L0).
+	p.Phi(&L0).
 		AddAssign(&L1)
 
 	return p

--- a/ecc/bw6-756/g2_test.go
+++ b/ecc/bw6-756/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-756] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-756] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-756] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-756] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -400,17 +400,17 @@ func (p *G1Jac) IsOnCurve() bool {
 // is the infinity.
 func (p *G1Jac) IsInSubGroup() bool {
 
-	var res, phip G1Jac
-	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
-		SubAssign(&phip).
+	var res, Phip G1Jac
+	Phip.Phi(p)
+	res.ScalarMultiplication(&Phip, &xGen).
+		SubAssign(&Phip).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
-		AddAssign(&phip)
+		AddAssign(&Phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	Phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
-	return phip.IsOnCurve() && phip.Z.IsZero()
+	return Phip.IsOnCurve() && Phip.Z.IsZero()
 
 }
 
@@ -446,7 +446,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -464,7 +464,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -568,7 +568,7 @@ func (p *G1Jac) ClearCofactor(a *G1Jac) *G1Jac {
 	p2.AddAssign(&tmp)
 	tmp.ScalarMultiplication(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
-	p2.phi(&p2)
+	p2.Phi(&p2)
 
 	p.Set(&p1).AddAssign(&p2)
 

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-761] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-761] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-761] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-761] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -379,17 +379,17 @@ func (p *G2Jac) IsOnCurve() bool {
 // is the infinity.
 func (p *G2Jac) IsInSubGroup() bool {
 
-	var res, phip G2Jac
-	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
-		SubAssign(&phip).
+	var res, Phip G2Jac
+	Phip.Phi(p)
+	res.ScalarMultiplication(&Phip, &xGen).
+		SubAssign(&Phip).
 		ScalarMultiplication(&res, &xGen).
 		ScalarMultiplication(&res, &xGen).
-		AddAssign(&phip)
+		AddAssign(&Phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	Phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
-	return phip.IsOnCurve() && phip.Z.IsZero()
+	return Phip.IsOnCurve() && Phip.Z.IsZero()
 
 }
 
@@ -425,7 +425,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G2Jac) phi(a *G2Jac) *G2Jac {
+func (p *G2Jac) Phi(a *G2Jac) *G2Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG2)
 	return p
@@ -443,7 +443,7 @@ func (p *G2Jac) mulGLV(a *G2Jac, s *big.Int) *G2Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -545,7 +545,7 @@ func (p *G2Jac) ClearCofactor(a *G2Jac) *G2Jac {
 	p2.AddAssign(&tmp)
 	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	p2.phi(&p2).phi(&p2)
+	p2.Phi(&p2).Phi(&p2)
 
 	p.Set(&p1).AddAssign(&p2)
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -40,12 +40,12 @@ func TestG2AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[BW6-761] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[BW6-761] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG2AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[BW6-761] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[BW6-761] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G2Jac
 			g := MapToG2(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -427,7 +427,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *G1Jac) phi(a *G1Jac) *G1Jac {
+func (p *G1Jac) Phi(a *G1Jac) *G1Jac {
 	p.Set(a)
 	p.X.Mul(&p.X, &thirdRootOneG1)
 	return p
@@ -445,7 +445,7 @@ func (p *G1Jac) mulGLV(a *G1Jac, s *big.Int) *G1Jac {
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -40,12 +40,12 @@ func TestG1AffineEndomorphism(t *testing.T) {
 
 	properties := gopter.NewProperties(parameters)
 
-	properties.Property("[SECP256K1] check that phi(P) = lambdaGLV * P", prop.ForAll(
+	properties.Property("[SECP256K1] check that Phi(P) = lambdaGLV * P", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res1, res2 G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			res1.phi(&p)
+			res1.Phi(&p)
 			res2.mulWindowed(&p, &lambdaGLV)
 
 			return p.IsInSubGroup() && res1.Equal(&res2)
@@ -53,13 +53,13 @@ func TestG1AffineEndomorphism(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[SECP256K1] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+	properties.Property("[SECP256K1] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
 		func(a fp.Element) bool {
 			var p, res, tmp G1Jac
 			g := MapToG1(a)
 			p.FromAffine(&g)
-			tmp.phi(&p)
-			res.phi(&tmp).
+			tmp.Phi(&p)
+			res.Phi(&tmp).
 				AddAssign(&tmp).
 				AddAssign(&p)
 

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -440,13 +440,13 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 		func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var a, b, c, res G2Jac
             a.ScalarMultiplication(p, &xGen)
-            b.psi(&a)
+            b.Psi(&a)
             a.AddAssign(p)
-            res.psi(&b)
+            res.Psi(&b)
             c.Set(&res).
                 AddAssign(&b).
                 AddAssign(&a)
-            res.psi(&res).
+            res.Psi(&res).
                 Double(&res).
             SubAssign(&c)
 
@@ -463,17 +463,17 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	// is the infinity.
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
-		var res, phip {{ $TJacobian }}
-		phip.phi(p)
-		res.ScalarMultiplication(&phip, &xGen).
-			SubAssign(&phip).
+		var res, Phip {{ $TJacobian }}
+		Phip.Phi(p)
+		res.ScalarMultiplication(&Phip, &xGen).
+			SubAssign(&Phip).
 			ScalarMultiplication(&res, &xGen).
 			ScalarMultiplication(&res, &xGen).
-			AddAssign(&phip)
+			AddAssign(&Phip)
 
-		phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+		Phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
 
-		return phip.IsOnCurve() && phip.Z.IsZero()
+		return Phip.IsOnCurve() && Phip.Z.IsZero()
     {{ else}}
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
@@ -496,7 +496,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             ScalarMultiplication(&u4P, &xGen)
         u5P.ScalarMultiplication(&u4P, &xGen)
         q.Set(p).SubAssign(&uP)
-        r.phi(&q).SubAssign(&uP).
+        r.Phi(&q).SubAssign(&uP).
             AddAssign(&u4P).
             AddAssign(&u5P)
 
@@ -520,7 +520,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
         func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
             var res {{ $TJacobian }}
-            res.phi(p).
+            res.Phi(p).
                 ScalarMultiplication(&res, &xGen).
                 ScalarMultiplication(&res, &xGen).
                 ScalarMultiplication(&res, &xGen).
@@ -544,7 +544,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
         // ψ(p) = [x₀]P
         func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var res, tmp {{ $TJacobian }}
-            tmp.psi(p)
+            tmp.Psi(p)
             res.ScalarMultiplication(p, &xGen).
             {{ if eq .Name "bls24-315"}}
                 AddAssign(&tmp)
@@ -568,7 +568,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
             var res {{ $TJacobian }}
             {{ if .GLV}}
-            res.phi(p).
+            res.Phi(p).
                 ScalarMultiplication(&res, &xGen).
                 ScalarMultiplication(&res, &xGen).
                 AddAssign(p)
@@ -587,7 +587,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             // ψ(p) = [x₀]P
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
-                tmp.psi(p)
+                tmp.Psi(p)
                 res.ScalarMultiplication(p, &xGen).
                     AddAssign(&tmp)
 
@@ -599,7 +599,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             // ψ(p) = [x₀]P
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
-                tmp.psi(p)
+                tmp.Psi(p)
                 res.ScalarMultiplication(p, &xGen).
                     SubAssign(&tmp)
 
@@ -642,7 +642,7 @@ func (p *{{ $TJacobian }}) mulWindowed(a *{{ $TJacobian }}, s *big.Int) *{{ $TJa
 
 {{ if eq .CoordType "fptower.E2"  }}
 	// ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-	func (p *{{ $TJacobian }}) psi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
+	func (p *{{ $TJacobian }}) Psi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
 		p.Set(a)
 		p.X.Conjugate(&p.X).Mul(&p.X, &endo.u)
 		p.Y.Conjugate(&p.Y).Mul(&p.Y, &endo.v)
@@ -651,7 +651,7 @@ func (p *{{ $TJacobian }}) mulWindowed(a *{{ $TJacobian }}, s *big.Int) *{{ $TJa
 	}
 {{ else if eq .CoordType "fptower.E4"}}
 	// ψ(p) = u o π o u⁻¹ where u:E'→E iso from the twist to E
-	func (p *{{ $TJacobian }}) psi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
+	func (p *{{ $TJacobian }}) Psi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
 		p.Set(a)
 		p.X.Frobenius(&p.X).Mul(&p.X, &endo.u)
 		p.Y.Frobenius(&p.Y).Mul(&p.Y, &endo.v)
@@ -664,7 +664,7 @@ func (p *{{ $TJacobian }}) mulWindowed(a *{{ $TJacobian }}, s *big.Int) *{{ $TJa
 
 // ϕ assigns p to ϕ(a) where ϕ: (x,y) → (w x,y), and returns p
 // where w is a third root of unity in 𝔽p
-func (p *{{ $TJacobian }}) phi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
+func (p *{{ $TJacobian }}) Phi(a *{{ $TJacobian }}) *{{ $TJacobian }} {
 	p.Set(a)
 	{{- if or (eq .CoordType "fptower.E2" ) (eq .CoordType "fptower.E4" )}}
 		p.X.MulByElement(&p.X, &thirdRootOne{{toUpper .PointName}})
@@ -686,7 +686,7 @@ func (p *{{ $TJacobian }}) mulGLV(a *{{ $TJacobian }}, s *big.Int) *{{ $TJacobia
 
 	// table[b3b2b1b0-1] = b3b2 ⋅ ϕ(a) + b1b0*a
 	table[0].Set(a)
-	table[3].phi(a)
+	table[3].Phi(a)
 
 	// split the scalar, modifies ±a, ϕ(a) accordingly
 	k := ecc.SplitScalar(s, &glvBasis)
@@ -810,7 +810,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	p2.AddAssign(&tmp)
 	tmp.ScalarMultiplication(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
-	p2.phi(&p2)
+	p2.Phi(&p2)
 
 	p.Set(&p1).AddAssign(&p2)
 {{ else}}
@@ -848,7 +848,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	tmp.ScalarMultiplication(a, &ht)
 	L1.AddAssign(&tmp)
 
-	p.phi(&L1).AddAssign(&L0)
+	p.Phi(&L1).AddAssign(&L0)
 {{ else}}
     var c1 big.Int
     c1.SetString("516166855112631370346774477030598579858367278343565509012644853411927535599366632765988905418773", 10)
@@ -880,7 +880,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	L1.AddAssign(&tmp).
 		SubAssign(a)
 
-	p.phi(&L1).
+	p.Phi(&L1).
 		AddAssign(&L0)
 {{ else}}
     var c1 big.Int
@@ -903,12 +903,12 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).
-		psi(&points[1])
+		Psi(&points[1])
 
-	points[2].psi(&points[0]).
-		psi(&points[2])
+	points[2].Psi(&points[0]).
+		Psi(&points[2])
 
-	points[3].psi(a).psi(&points[3]).psi(&points[3])
+	points[3].Psi(a).Psi(&points[3]).Psi(&points[3])
 
 	var res {{$TJacobian}}
 	res.Set(&g2Infinity)
@@ -929,7 +929,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 
 	t.Set(&xg).
 		SubAssign(a).
-		psi(&t)
+		Psi(&t)
 
 	res.AddAssign(&t)
 
@@ -954,7 +954,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 
 	t.Set(&xg).
 		SubAssign(a).
-		psi(&t)
+		Psi(&t)
 
 	res.AddAssign(&t)
 
@@ -988,25 +988,25 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 		SubAssign(a)
 
 	t.Set(&xxxg).
-		psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Set(&xxg).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	t.Set(&xg).
-		psi(&t).
-		psi(&t).
-		psi(&t).
+		Psi(&t).
+		Psi(&t).
+		Psi(&t).
 		AddAssign(&res)
 
 	res.Double(a).
-		psi(&res).
-		psi(&res).
-		psi(&res).
-		psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
+		Psi(&res).
 		AddAssign(&t)
 
 	p.Set(&res)
@@ -1045,7 +1045,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	p2.AddAssign(&tmp)
 	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	p2.phi(&p2).phi(&p2)
+	p2.Phi(&p2).Phi(&p2)
 
 	p.Set(&p1).AddAssign(&p2)
 {{else}}
@@ -1086,7 +1086,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	tmp.ScalarMultiplication(a, &d3)
 	L1.AddAssign(&tmp)
 
-	p.phi(&L1).AddAssign(&L0)
+	p.Phi(&L1).AddAssign(&L0)
 {{else}}
     var c2 big.Int
     c2.SetString("516166855112631370346774477030598579858367278343565509012644853411927535599366632765988905418768", 10)
@@ -1115,7 +1115,7 @@ func (p *{{$TJacobian}}) ClearCofactor(a *{{$TJacobian}}) *{{$TJacobian}} {
 	L1.Set(&u3P).
 		SubAssign(&tmp)
 
-	p.phi(&L0).
+	p.Phi(&L0).
 		AddAssign(&L1)
 {{else}}
     var c2 big.Int

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -43,12 +43,12 @@ import (
 
         properties := gopter.NewProperties(parameters)
 
-        properties.Property("[{{ toUpper .Name }}] check that phi(P) = lambdaGLV * P", prop.ForAll(
+        properties.Property("[{{ toUpper .Name }}] check that Phi(P) = lambdaGLV * P", prop.ForAll(
             func(a {{ .CoordType}}) bool {
                 var p, res1, res2 {{ $TJacobian }}
                 g := MapTo{{ toUpper .PointName}}(a)
                 p.FromAffine(&g)
-                res1.phi(&p)
+                res1.Phi(&p)
                 res2.mulWindowed(&p, &lambdaGLV)
 
                 return p.IsInSubGroup() && res1.Equal(&res2)
@@ -56,13 +56,13 @@ import (
             {{$fuzzer}},
         ))
 
-        properties.Property("[{{ toUpper .Name }}] check that phi^2(P) + phi(P) + P = 0", prop.ForAll(
+        properties.Property("[{{ toUpper .Name }}] check that Phi^2(P) + Phi(P) + P = 0", prop.ForAll(
                 func(a {{ .CoordType}}) bool {
                 var p, res, tmp {{ $TJacobian }}
                 g := MapTo{{ toUpper .PointName}}(a)
                 p.FromAffine(&g)
-                tmp.phi(&p)
-                res.phi(&tmp).
+                tmp.Phi(&p)
+                res.Phi(&tmp).
                     AddAssign(&tmp).
                     AddAssign(&p)
 
@@ -73,18 +73,18 @@ import (
 
         {{if eq .PointName "g2" }}
         {{- if and (eq .PointName "g2") (ne .Name "bw6-761") (ne .Name "bw6-633") (ne .Name "bw6-756") }}
-            properties.Property("[{{ toUpper .Name }}] check that psi^2(P) = -phi(P)", prop.ForAll(
+            properties.Property("[{{ toUpper .Name }}] check that Psi^2(P) = -Phi(P)", prop.ForAll(
                 func(a {{ .CoordType}}) bool {
                     var p, res1, res2 {{ $TJacobian }}
                     g := MapTo{{ toUpper .PointName}}(a)
                     p.FromAffine(&g)
                     {{- if or (eq .Name "bls24-315") (eq .Name "bls24-317")}}
-                        res1.psi(&p).psi(&res1).psi(&res1).psi(&res1).Neg(&res1)
+                        res1.Psi(&p).Psi(&res1).Psi(&res1).Psi(&res1).Neg(&res1)
                     {{- else}}
-                        res1.psi(&p).psi(&res1).Neg(&res1)
+                        res1.Psi(&p).Psi(&res1).Neg(&res1)
                     {{- end}}
                     {{- if eq .Name "bn254"}}
-                        res2.phi(&p)
+                        res2.Phi(&p)
                     {{- else}}
                         res2.Set(&p)
                         res2.X.MulByElement(&res2.X, &thirdRootOneG1)
@@ -393,10 +393,10 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 	))
 
 	{{ if or (eq .CoordType "fptower.E2") (eq .CoordType "fptower.E4")}}
-		properties.Property("[{{ toUpper .Name }}] psi should map points from E' to itself", prop.ForAll(
+		properties.Property("[{{ toUpper .Name }}] Psi should map points from E' to itself", prop.ForAll(
 			func() bool {
 				var a {{ $TJacobian }}
-				a.psi(&{{ toLower .PointName }}Gen)
+				a.Psi(&{{ toLower .PointName }}Gen)
 				return a.IsOnCurve() && !a.Equal(&g2Gen)
 			},
 		))


### PR DESCRIPTION
Make `phi()` and `psi()` exportable to use in gnark for hinted `AssertIsOnG1()` and `AssertIsOnG2()`.