### PR TITLE
Feat/encode uint64 slices

### DIFF
--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 48
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 48
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 48
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 40
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 40
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -392,8 +392,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -392,25 +392,8 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -619,6 +602,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
+}
+
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
@@ -883,7 +885,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -104,7 +104,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -112,7 +112,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -604,14 +604,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -18,7 +18,6 @@ package bn254
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"math/big"
 	"math/rand"
@@ -475,21 +474,4 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
-}
-
-func TestWriteUint62Array(t *testing.T) {
-	var o, _o []uint64
-	var bb bytes.Buffer
-	enc := NewEncoder(&bb)
-	o = []uint64{1}
-	enc.encode(o)
-	dec := NewDecoder(bytes.NewReader(bb.Bytes()))
-	dec.Decode(&_o)
-	assert.Equal(t, o, _o)
-
-	_o = nil
-	enc.encodeRaw(o)
-	dec = NewDecoder(bytes.NewReader(bb.Bytes()))
-	dec.Decode(&_o)
-	assert.Equal(t, o, _o)
 }

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -18,6 +18,7 @@ package bn254
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"math/big"
 	"math/rand"
@@ -474,4 +475,21 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestWriteUint62Array(t *testing.T) {
+	var o, _o []uint64
+	var bb bytes.Buffer
+	enc := NewEncoder(&bb)
+	o = []uint64{1}
+	enc.encode(o)
+	dec := NewDecoder(bytes.NewReader(bb.Bytes()))
+	dec.Decode(&_o)
+	assert.Equal(t, o, _o)
+
+	_o = nil
+	enc.encodeRaw(o)
+	dec = NewDecoder(bytes.NewReader(bb.Bytes()))
+	dec.Decode(&_o)
+	assert.Equal(t, o, _o)
 }

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 80
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 96
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -103,6 +103,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -398,6 +416,8 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -501,6 +521,8 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -586,6 +608,25 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed
 const SizeOfG1AffineCompressed = 96
 
@@ -598,7 +639,7 @@ func (p *G1Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G1Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err
@@ -854,7 +895,7 @@ func (p *G2Affine) Marshal() []byte {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *G2Affine) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -110,7 +110,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -118,7 +118,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -610,14 +610,14 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -115,7 +115,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		length := binary.LittleEndian.Uint64(buf64)
+		length := binary.BigEndian.Uint64(buf64)
 		*t = make([]uint64, length)
 		for i := range *t {
 			read, err = io.ReadFull(dec.r, buf64)
@@ -123,7 +123,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 			if err != nil {
 				return
 			}
-			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+			(*t)[i] = binary.BigEndian.Uint64(buf64)
 		}
 		return
 	case *fr.Element:
@@ -414,14 +414,14 @@ func isZeroed(firstByte byte, buf []byte) bool {
 
 func (enc *Encoder) writeUint64Slice(t []uint64) error {
 	buff := make([]byte, 64/8)
-	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	binary.BigEndian.PutUint64(buff, uint64(len(t)))
 	written, err := enc.w.Write(buff)
 	enc.n += int64(written)
 	if err != nil {
 		return err
 	}
 	for i := range t {
-		binary.LittleEndian.PutUint64(buff, t[i])
+		binary.BigEndian.PutUint64(buff, t[i])
 		written, err = enc.w.Write(buff)
 		enc.n += int64(written)
 		if err != nil {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -108,6 +108,24 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
+	case *[]uint64:
+		buf64 := buf[:64/8]
+		read, err = io.ReadFull(dec.r, buf64)
+		dec.n += int64(read)
+		if err != nil {
+			return
+		}
+		length := binary.LittleEndian.Uint64(buf64)
+		*t = make([]uint64, length)
+		for i := range *t {
+			read, err = io.ReadFull(dec.r, buf64)
+			dec.n += int64(read)
+			if err != nil {
+				return
+			}
+			(*t)[i] = binary.LittleEndian.Uint64(buf64)
+		}
+		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -394,7 +412,24 @@ func isZeroed(firstByte byte, buf []byte) bool {
 {{template "encode" dict "Raw" ""}}
 {{template "encode" dict "Raw" "Raw"}}
 
-
+func (enc *Encoder) writeUint64Slice(t []uint64) error {
+	buff := make([]byte, 64/8)
+	binary.LittleEndian.PutUint64(buff, uint64(len(t)))
+	written, err := enc.w.Write(buff)
+	enc.n += int64(written)
+	if err != nil {
+		return err
+	}
+	for i := range t {
+		binary.LittleEndian.PutUint64(buff, t[i])
+		written, err = enc.w.Write(buff)
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 {{ define "encode"}}
 
@@ -416,6 +451,8 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
+	case []uint64:
+		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -530,7 +567,7 @@ func (p *{{ $.TAffine }}) Marshal() ([]byte) {
 	return b[:]
 }
 
-// Unmarshal is an allias to SetBytes()
+// Unmarshal is an alias to SetBytes()
 func (p *{{ $.TAffine }}) Unmarshal(buf []byte) error {
 	_, err := p.SetBytes(buf)
 	return err 


### PR DESCRIPTION
In the Plonk verification key, when multi-commits are implemented, we will have to store an array of indexes to commitment constraints. This PR enables that by storing slices of `uint64` in the `len(x), x[0], x[1], ..., x[len(x)-1]` format.