### PR TITLE
feat: fix v computation in ECDSA signature

### DIFF
--- a/ecc/bn254/ecdsa/ecdsa.go
+++ b/ecc/bn254/ecdsa/ecdsa.go
@@ -140,20 +140,14 @@ func RecoverP(v uint, r *big.Int) (*bn254.G1Affine, error) {
 	if y.ModSqrt(y, fp.Modulus()) == nil {
 		return nil, errors.New("no square root")
 	}
-	// y2 is -y
-	y2 := new(big.Int).Sub(fp.Modulus(), y)
-	// if yChoice == 0, return min(y, y2), else max(y, y2)
-	if (y.Cmp(y2) < 0) == (yChoice == 0) {
-		return &bn254.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y),
-		}, nil
-	} else {
-		return &bn254.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y2),
-		}, nil
+	// check that y has same oddity as defined by v
+	if y.Bit(0) != yChoice {
+		y = y.Sub(fp.Modulus(), y)
 	}
+	return &bn254.G1Affine{
+		X: *new(fp.Element).SetBigInt(x),
+		Y: *new(fp.Element).SetBigInt(y),
+	}, nil
 }
 
 type zr struct{}
@@ -241,8 +235,6 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 //
 // SEC 1, Version 2.0, Section 4.1.3
 func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
-	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
-	halfp.Div(halfp, big.NewInt(2))
 	r, s = new(big.Int), new(big.Int)
 
 	scalar, kInv := new(big.Int), new(big.Int)
@@ -265,10 +257,8 @@ func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v ui
 			P.X.BigInt(r)
 			// set how many times we overflow the scalar field
 			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
-			// set if y is small or big
-			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
-				v |= 1
-			}
+			// set if y is even or odd
+			v |= P.Y.BigInt(new(big.Int)).Bit(0)
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {

--- a/ecc/bn254/ecdsa/marshal.go
+++ b/ecc/bn254/ecdsa/marshal.go
@@ -18,6 +18,7 @@ package ecdsa
 
 import (
 	"crypto/subtle"
+	"errors"
 	"io"
 	"math/big"
 
@@ -61,6 +62,12 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 // methods sets the current public key to the recovered value. Otherwise returns
 // error and leaves current public key unchanged.
 func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	if s.Cmp(fr.Modulus()) >= 0 {
+		return errors.New("s is larger than modulus")
+	}
+	if s.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("s is negative")
+	}
 	P, err := RecoverP(v, r)
 	if err != nil {
 		return err

--- a/ecc/secp256k1/ecdsa/ecdsa.go
+++ b/ecc/secp256k1/ecdsa/ecdsa.go
@@ -140,20 +140,14 @@ func RecoverP(v uint, r *big.Int) (*secp256k1.G1Affine, error) {
 	if y.ModSqrt(y, fp.Modulus()) == nil {
 		return nil, errors.New("no square root")
 	}
-	// y2 is -y
-	y2 := new(big.Int).Sub(fp.Modulus(), y)
-	// if yChoice == 0, return min(y, y2), else max(y, y2)
-	if (y.Cmp(y2) < 0) == (yChoice == 0) {
-		return &secp256k1.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y),
-		}, nil
-	} else {
-		return &secp256k1.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y2),
-		}, nil
+	// check that y has same oddity as defined by v
+	if y.Bit(0) != yChoice {
+		y = y.Sub(fp.Modulus(), y)
 	}
+	return &secp256k1.G1Affine{
+		X: *new(fp.Element).SetBigInt(x),
+		Y: *new(fp.Element).SetBigInt(y),
+	}, nil
 }
 
 type zr struct{}
@@ -241,8 +235,6 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 //
 // SEC 1, Version 2.0, Section 4.1.3
 func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
-	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
-	halfp.Div(halfp, big.NewInt(2))
 	r, s = new(big.Int), new(big.Int)
 
 	scalar, kInv := new(big.Int), new(big.Int)
@@ -265,10 +257,8 @@ func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v ui
 			P.X.BigInt(r)
 			// set how many times we overflow the scalar field
 			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
-			// set if y is small or big
-			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
-				v |= 1
-			}
+			// set if y is even or odd
+			v |= P.Y.BigInt(new(big.Int)).Bit(0)
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {

--- a/ecc/secp256k1/ecdsa/marshal.go
+++ b/ecc/secp256k1/ecdsa/marshal.go
@@ -18,6 +18,7 @@ package ecdsa
 
 import (
 	"crypto/subtle"
+	"errors"
 	"io"
 	"math/big"
 
@@ -61,6 +62,12 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 // methods sets the current public key to the recovered value. Otherwise returns
 // error and leaves current public key unchanged.
 func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	if s.Cmp(fr.Modulus()) >= 0 {
+		return errors.New("s is larger than modulus")
+	}
+	if s.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("s is negative")
+	}
 	P, err := RecoverP(v, r)
 	if err != nil {
 		return err

--- a/ecc/stark-curve/ecdsa/ecdsa.go
+++ b/ecc/stark-curve/ecdsa/ecdsa.go
@@ -140,20 +140,14 @@ func RecoverP(v uint, r *big.Int) (*starkcurve.G1Affine, error) {
 	if y.ModSqrt(y, fp.Modulus()) == nil {
 		return nil, errors.New("no square root")
 	}
-	// y2 is -y
-	y2 := new(big.Int).Sub(fp.Modulus(), y)
-	// if yChoice == 0, return min(y, y2), else max(y, y2)
-	if (y.Cmp(y2) < 0) == (yChoice == 0) {
-		return &starkcurve.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y),
-		}, nil
-	} else {
-		return &starkcurve.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y2),
-		}, nil
+	// check that y has same oddity as defined by v
+	if y.Bit(0) != yChoice {
+		y = y.Sub(fp.Modulus(), y)
 	}
+	return &starkcurve.G1Affine{
+		X: *new(fp.Element).SetBigInt(x),
+		Y: *new(fp.Element).SetBigInt(y),
+	}, nil
 }
 
 type zr struct{}
@@ -241,8 +235,6 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 //
 // SEC 1, Version 2.0, Section 4.1.3
 func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
-	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
-	halfp.Div(halfp, big.NewInt(2))
 	r, s = new(big.Int), new(big.Int)
 
 	scalar, kInv := new(big.Int), new(big.Int)
@@ -265,10 +257,8 @@ func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v ui
 			P.X.BigInt(r)
 			// set how many times we overflow the scalar field
 			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
-			// set if y is small or big
-			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
-				v |= 1
-			}
+			// set if y is even or odd
+			v |= P.Y.BigInt(new(big.Int)).Bit(0)
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {

--- a/ecc/stark-curve/ecdsa/marshal.go
+++ b/ecc/stark-curve/ecdsa/marshal.go
@@ -18,6 +18,7 @@ package ecdsa
 
 import (
 	"crypto/subtle"
+	"errors"
 	"io"
 	"math/big"
 
@@ -61,6 +62,12 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 // methods sets the current public key to the recovered value. Otherwise returns
 // error and leaves current public key unchanged.
 func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	if s.Cmp(fr.Modulus()) >= 0 {
+		return errors.New("s is larger than modulus")
+	}
+	if s.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("s is negative")
+	}
 	P, err := RecoverP(v, r)
 	if err != nil {
 		return err

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -239,8 +239,6 @@ func (privKey *PrivateKey) Public() signature.PublicKey {
 //
 // SEC 1, Version 2.0, Section 4.1.3
 func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v uint, r, s *big.Int, err error) {
-	halfp := new(big.Int).Sub(fp.Modulus(), big.NewInt(1))
-	halfp.Div(halfp, big.NewInt(2))
 	r, s = new(big.Int), new(big.Int)
 
 	scalar, kInv := new(big.Int), new(big.Int)
@@ -263,10 +261,8 @@ func (privKey *PrivateKey) SignForRecover(message []byte, hFunc hash.Hash) (v ui
 			P.X.BigInt(r)
 			// set how many times we overflow the scalar field
 			v |= (uint(new(big.Int).Div(r, order).Uint64())) << 1
-			// set if y is small or big
-			if P.Y.BigInt(new(big.Int)).Cmp(halfp) >= 0 {
-				v |= 1
-			}
+			// set if y is even or odd
+			v |= P.Y.BigInt(new(big.Int)).Bit(0)
 
 			r.Mod(r, order)
 			if r.Sign() != 0 {

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -136,20 +136,14 @@ func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
 	if y.ModSqrt(y, fp.Modulus()) == nil {
 		return nil, errors.New("no square root")
 	}
-	// y2 is -y
-	y2 := new(big.Int).Sub(fp.Modulus(), y)
-	// if yChoice == 0, return min(y, y2), else max(y, y2)
-	if (y.Cmp(y2) < 0) == (yChoice == 0) {
-		return &{{ .CurvePackage }}.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y),
-		}, nil
-	} else {
-		return &{{ .CurvePackage }}.G1Affine{
-			X: *new(fp.Element).SetBigInt(x),
-			Y: *new(fp.Element).SetBigInt(y2),
-		}, nil
+	// check that y has same oddity as defined by v
+	if y.Bit(0) != yChoice {
+		y = y.Sub(fp.Modulus(), y)
 	}
+	return &{{ .CurvePackage }}.G1Affine{
+		X: *new(fp.Element).SetBigInt(x),
+		Y: *new(fp.Element).SetBigInt(y),
+	}, nil
 }
 {{- end}}
 

--- a/internal/generator/ecdsa/template/marshal.go.tmpl
+++ b/internal/generator/ecdsa/template/marshal.go.tmpl
@@ -2,6 +2,7 @@ import (
 	"crypto/subtle"
 	"io"
 	{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
+	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
@@ -50,6 +51,12 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 // methods sets the current public key to the recovered value. Otherwise returns
 // error and leaves current public key unchanged.
 func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
+	if s.Cmp(fr.Modulus()) >= 0 {
+		return errors.New("s is larger than modulus")
+	}
+	if s.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("s is negative")
+	}
 	P, err := RecoverP(v, r)
 	if err != nil {
 		return err


### PR DESCRIPTION
I referred to other implementations to understand how v is computed when creating an ECDSA signature. I had assumed that v gives if `y` coordinate of the ephemeral point is small or large (e.h. bigger than half the order). But due to different encoding order, it was actually the oddity of `y`.

This is confirmed also in [Ethereum Yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf) (Appendix F) and makes also a lot more sense.