### PR TITLE
Perf: KZG verification in a single point

### DIFF
--- a/ecc/bls12-377/fr/kzg/kzg.go
+++ b/ecc/bls12-377/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bls12377.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls12377.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bls12377.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bls12377.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bls12377.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bls12377.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12377.PairingCheck(
-		[]bls12377.G1Affine{fminusfaG1Aff, negH},
-		[]bls12377.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bls12377.G1Affine{totalG1Aff, negH},
+		[]bls12377.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bls12-378/fr/kzg/kzg.go
+++ b/ecc/bls12-378/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bls12378.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls12378.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bls12378.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bls12378.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bls12378.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bls12378.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12378.PairingCheck(
-		[]bls12378.G1Affine{fminusfaG1Aff, negH},
-		[]bls12378.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bls12378.G1Affine{totalG1Aff, negH},
+		[]bls12378.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bls12-381/fr/kzg/kzg.go
+++ b/ecc/bls12-381/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bls12381.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls12381.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bls12381.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bls12381.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bls12381.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bls12381.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12381.PairingCheck(
-		[]bls12381.G1Affine{fminusfaG1Aff, negH},
-		[]bls12381.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bls12381.G1Affine{totalG1Aff, negH},
+		[]bls12381.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bls24-317/fr/kzg/kzg.go
+++ b/ecc/bls24-317/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bls24317.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bls24317.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bls24317.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bls24317.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bls24317.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bls24317.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls24317.PairingCheck(
-		[]bls24317.G1Affine{fminusfaG1Aff, negH},
-		[]bls24317.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bls24317.G1Affine{totalG1Aff, negH},
+		[]bls24317.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bn254/fr/kzg/kzg.go
+++ b/ecc/bn254/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bn254.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bn254.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bn254.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bn254.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bn254.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bn254.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bn254.PairingCheck(
-		[]bn254.G1Affine{fminusfaG1Aff, negH},
-		[]bn254.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bn254.G1Affine{totalG1Aff, negH},
+		[]bn254.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bw6-633/fr/kzg/kzg.go
+++ b/ecc/bw6-633/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bw6633.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bw6633.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bw6633.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bw6633.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bw6633.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bw6633.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6633.PairingCheck(
-		[]bw6633.G1Affine{fminusfaG1Aff, negH},
-		[]bw6633.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bw6633.G1Affine{totalG1Aff, negH},
+		[]bw6633.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bw6-756/fr/kzg/kzg.go
+++ b/ecc/bw6-756/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bw6756.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bw6756.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bw6756.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bw6756.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bw6756.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bw6756.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6756.PairingCheck(
-		[]bw6756.G1Affine{fminusfaG1Aff, negH},
-		[]bw6756.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bw6756.G1Affine{totalG1Aff, negH},
+		[]bw6756.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/ecc/bw6-761/fr/kzg/kzg.go
+++ b/ecc/bw6-761/fr/kzg/kzg.go
@@ -195,28 +195,19 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH bw6761.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac bw6761.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 bw6761.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff bw6761.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff bw6761.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
-
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff bw6761.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6761.PairingCheck(
-		[]bw6761.G1Affine{fminusfaG1Aff, negH},
-		[]bw6761.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]bw6761.G1Affine{totalG1Aff, negH},
+		[]bw6761.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -177,28 +177,20 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var negH {{ .CurvePackage }}.G1Affine
 	negH.Neg(&proof.H)
 
-	// [α-a]G₂
-	var alphaMinusaG2Jac, genG2Jac, alphaG2Jac {{ .CurvePackage }}.G2Jac
+	// [f(α) - f(a) + a*H(α)]G₁
+	var totalG1 {{ .CurvePackage }}.G1Jac
 	var pointBigInt big.Int
 	point.BigInt(&pointBigInt)
-	genG2Jac.FromAffine(&vk.G2[0])
-	alphaG2Jac.FromAffine(&vk.G2[1])
-	alphaMinusaG2Jac.ScalarMultiplication(&genG2Jac, &pointBigInt).
-		Neg(&alphaMinusaG2Jac).
-		AddAssign(&alphaG2Jac)
+	totalG1.ScalarMultiplicationAffine(&proof.H, &pointBigInt)
+	totalG1.AddAssign(&fminusfaG1Jac)
+	var totalG1Aff {{ .CurvePackage }}.G1Affine
+	totalG1Aff.FromJacobian(&totalG1)
 
-	// [α-a]G₂
-	var xminusaG2Aff {{ .CurvePackage }}.G2Affine
-	xminusaG2Aff.FromJacobian(&alphaMinusaG2Jac)
 
-	// [f(α) - f(a)]G₁
-	var fminusfaG1Aff {{ .CurvePackage }}.G1Affine
-	fminusfaG1Aff.FromJacobian(&fminusfaG1Jac)
-
-	// e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := {{ .CurvePackage }}.PairingCheck(
-		[]{{ .CurvePackage }}.G1Affine{fminusfaG1Aff, negH},
-		[]{{ .CurvePackage }}.G2Affine{vk.G2[0], xminusaG2Aff},
+		[]{{ .CurvePackage }}.G1Affine{totalG1Aff, negH},
+		[]{{ .CurvePackage }}.G2Affine{vk.G2[0], vk.G2[1]},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR tradeoffs a scalar multiplication in **G2** for a scalar multiplication in **G1** in the case of KZG opening in a single point (`Verify` method). Kudos to @Tabaie for this observation.
```diff
-       // e([f(α) - f(a)]G₁, G₂).e([-H(α)]G₁, [α-a]G₂) ==? 1
+       // e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
```
We actually use KZG opening in multiple points (`BatchVerifyMultiPoints`) for PlonK. So this does not impact the PlonK verification time but only the public `Verify` method, which could be of independent interest. On AWS z1d.large:

```go
benchmark                       old ns/op     new ns/op     delta
BenchmarkKZGVerify-2            708830        653944        -7.74%
BenchmarkKZGBatchVerify10-2     1084355       1035049       -4.55%
```