### PR TITLE
Update the limb decomposition of the SIS

### DIFF
--- a/ecc/bn254/fr/sis/sis.go
+++ b/ecc/bn254/fr/sis/sis.go
@@ -91,7 +91,16 @@ func NewRSis(seed int64, logTwoDegree, logTwoBound, maxNbElementsToHash int) (*R
 	// capacity == [degree * n * logTwoBound] / 8
 	// n == (capacity*8)/(degree*logTwoBound)
 
-	n := capacity * 8 / logTwoBound // number of coefficients
+	// First n <- #limbs to represent a single field element
+	n := (fr.Bytes * 8) / logTwoBound
+	if n*logTwoBound < fr.Bytes*8 {
+		n++
+	}
+
+	// Then multiply by the number of field elements
+	n *= maxNbElementsToHash
+
+	// And divide (+ ceil) to get the number of polynomials
 	if n%degree == 0 {
 		n /= degree
 	} else {
@@ -160,53 +169,11 @@ func (r *RSis) Sum(b []byte) []byte {
 	}
 
 	// clear the buffers of the instance.
-	defer func() {
-		r.bufMValues.ClearAll()
-		for i := 0; i < len(r.bufM); i++ {
-			r.bufM[i].SetZero()
-		}
-		for i := 0; i < len(r.bufRes); i++ {
-			r.bufRes[i].SetZero()
-		}
-	}()
+	defer r.cleanupBuffers()
 
-	// bitwise decomposition of the buffer, in order to build m (the vector to hash)
-	// as a list of polynomials, whose coefficients are less than r.B bits long.
-	// Say buf=[0xbe,0x0f]. As a stream of bits it is interpreted like this:
-	// 10111110 00001111. BitAt(0)=1 (=leftmost bit), bitAt(1)=0 (=second leftmost bit), etc.
-	nbBits := len(buf) * 8
-	bitAt := func(i int) uint8 {
-		k := i / 8
-		if k >= len(buf) {
-			return 0
-		}
-		b := buf[k]
-		j := i % 8
-		return b >> (7 - j) & 1
-	}
-
-	// now we can construct m. The input to hash consists of the polynomials
-	// m[k*r.Degree:(k+1)*r.Degree]
 	m := r.bufM
-
-	// mark blocks m[i*r.Degree : (i+1)*r.Degree] != [0...0]
 	mValues := r.bufMValues
-
-	// we process the input buffer by blocks of r.LogTwoBound bits
-	// each of these block (<< 64bits) are interpreted as a coefficient
-	mPos := 0
-	for i := 0; i < nbBits; mPos++ {
-		for j := 0; j < r.LogTwoBound; j++ {
-			// r.LogTwoBound < 64; we just use the first word of our element here,
-			// and set the bits from LSB to MSB.
-			m[mPos][0] |= uint64(bitAt(i) << j)
-			i++
-		}
-		if m[mPos][0] == 0 {
-			continue
-		}
-		mValues.Set(uint(mPos / r.Degree))
-	}
+	limbDecomposeBytes(buf, m, r.LogTwoBound, r.Degree, mValues)
 
 	// we can hash now.
 	res := r.bufRes
@@ -321,4 +288,84 @@ func (r *RSis) CopyWithFreshBuffer() RSis {
 	res := *r
 	res.buffer = bytes.Buffer{}
 	return res
+}
+
+// Cleanup the buffers of the RSis instance
+func (r *RSis) cleanupBuffers() {
+	r.bufMValues.ClearAll()
+	for i := 0; i < len(r.bufM); i++ {
+		r.bufM[i].SetZero()
+	}
+	for i := 0; i < len(r.bufRes); i++ {
+		r.bufRes[i].SetZero()
+	}
+}
+
+// Split an slice of bytes representing an array of serialized field element in
+// big-endian form into an array of limbs representing the same field elements
+// in little-endian form. Namely, if our field is reprented with 64 bits and we
+// have the following field element 0x0123456789abcdef (0 being the most significant
+// character and and f being the least significant one) and our log norm bound is
+// 16 (so 1 hex character = 1 limb). The function assigns the values of m to [f, e,
+// d, c, b, a, ..., 3, 2, 1, 0]. m should be preallocated and zeroized. Additionally,
+// we have the guarantee that 2 bits contributing to different field elements cannot
+// be part of the same limb.
+func LimbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound int) {
+	limbDecomposeBytes(buf, m, logTwoBound, 0, nil)
+}
+
+// Split an slice of bytes representing an array of serialized field element in
+// big-endian form into an array of limbs representing the same field elements
+// in little-endian form. Namely, if our field is reprented with 64 bits and we
+// have the following field element 0x0123456789abcdef (0 being the most significant
+// character and and f being the least significant one) and our log norm bound is
+// 16 (so 1 hex character = 1 limb). The function assigns the values of m to [f, e,
+// d, c, b, a, ..., 3, 2, 1, 0]. m should be preallocated and zeroized. mValues is
+// an optional bitSet. If provided, it must be empty. The function will set bit "i"
+// to indicate the that i-th SIS input polynomial should be non-zero. Recall, that a
+// SIS polynomial corresponds to a chunk of limbs of size `degree`. Additionally,
+// we have the guarantee that 2 bits contributing to different field elements cannot
+// be part of the same limb.
+func limbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound, degree int, mValues *bitset.BitSet) {
+
+	// bitwise decomposition of the buffer, in order to build m (the vector to hash)
+	// as a list of polynomials, whose coefficients are less than r.B bits long.
+	// Say buf=[0xbe,0x0f]. As a stream of bits it is interpreted like this:
+	// 10111110 00001111. BitAt(0)=1 (=leftmost bit), bitAt(1)=0 (=second leftmost bit), etc.
+	nbBits := len(buf) * 8
+	bitAt := func(i int) uint8 {
+		k := i / 8
+		if k >= len(buf) {
+			return 0
+		}
+		b := buf[k]
+		j := i % 8
+		return b >> (7 - j) & 1
+	}
+
+	// we process the input buffer by blocks of r.LogTwoBound bits
+	// each of these block (<< 64bits) are interpreted as a coefficient
+	mPos := 0
+	for fieldStart := 0; fieldStart < nbBits; {
+		for bitInField := 0; bitInField < fr.Bytes*8; {
+
+			j := bitInField % logTwoBound
+
+			// r.LogTwoBound < 64; we just use the first word of our element here,
+			// and set the bits from LSB to MSB.
+			at := fieldStart + fr.Bytes*8 - bitInField - 1
+			m[mPos][0] |= uint64(bitAt(at) << j)
+			bitInField++
+
+			// Check if mPos is zero and mark as non-zero in the bitset if not
+			if m[mPos][0] > 0 && mValues != nil {
+				mValues.Set(uint(mPos / degree))
+			}
+
+			if j == logTwoBound-1 || bitInField == fr.Bytes*8 {
+				mPos++
+			}
+		}
+		fieldStart += fr.Bytes * 8
+	}
 }

--- a/ecc/bn254/fr/sis/sis_test.go
+++ b/ecc/bn254/fr/sis/sis_test.go
@@ -69,7 +69,7 @@ func TestReference(t *testing.T) {
 	err = json.Unmarshal(data, &testCases)
 	assert.NoError(err, "reading test cases failed")
 
-	for _, testCase := range testCases.Entries {
+	for testCaseID, testCase := range testCases.Entries {
 		// create the SIS instance
 		sis, err := NewRSis(testCase.Params.Seed, testCase.Params.LogTwoDegree, testCase.Params.LogTwoBound, testCase.Params.MaxNbElementsToHash)
 		assert.NoError(err)
@@ -88,7 +88,11 @@ func TestReference(t *testing.T) {
 					assert.True(e.IsZero(), "mismatch between reference test and computed value")
 				}
 			} else {
-				assert.EqualValues(testCase.Expected[i], got, "mismatch between reference test and computed value")
+				assert.EqualValues(
+					testCase.Expected[i], got,
+					"mismatch between reference test and computed value (testcase %v - input n° %v)",
+					testCaseID, i,
+				)
 			}
 
 			// ensure max nb elements to hash has no incidence on result.
@@ -153,6 +157,67 @@ func TestMulMod(t *testing.T) {
 		}
 	}
 
+}
+
+// Test the fact that the limb decomposition allows obtaining the original
+// field element by evaluating the polynomial whose the coeffiients are the
+// limbs.
+func TestLimbDecomposition(t *testing.T) {
+	sis, _ := NewRSis(0, 4, 4, 3)
+
+	testcases := []fr.Vector{
+		{fr.One()},
+		{fr.NewElement(2)},
+		{fr.NewElement(1 << 32), fr.NewElement(2), fr.NewElement(1)},
+	}
+
+	for _, testcase := range testcases {
+
+		// clean the sis hasher
+		sis.bufMValues.ClearAll()
+		for i := 0; i < len(sis.bufM); i++ {
+			sis.bufM[i].SetZero()
+		}
+		for i := 0; i < len(sis.bufRes); i++ {
+			sis.bufRes[i].SetZero()
+		}
+
+		buf := bytes.Buffer{}
+		for _, x := range testcase {
+			xBytes := x.Bytes()
+			buf.Write(xBytes[:])
+		}
+		limbDecomposeBytes(buf.Bytes(), sis.bufM, sis.LogTwoBound, sis.Degree, sis.bufMValues)
+
+		// Just to test, this does not return panic
+		dummyBuffer := make(fr.Vector, 192)
+		LimbDecomposeBytes(buf.Bytes(), dummyBuffer, sis.LogTwoBound)
+
+		// b is a field element representing the max norm bound
+		// used for limb splitting the input field elements.
+		b := fr.NewElement(1 << sis.LogTwoBound)
+		numLimbsPerField := fr.Bytes * 8 / sis.LogTwoBound
+
+		// Compute r (corresponds to the Montgommery constant)
+		var r fr.Element
+		r.SetString("6350874878119819312338956282401532410528162663560392320966563075034087161851")
+
+		// Attempt to recompose the entry #i in the test-case
+		for i := range testcase {
+			// allegedly corresponds to the limbs of the entry i
+			subRes := sis.bufM[i*numLimbsPerField : (i+1)*numLimbsPerField]
+
+			// performs a Horner evaluation of subres by b
+			var y fr.Element
+			for j := numLimbsPerField - 1; j >= 0; j-- {
+				y.Mul(&y, &b)
+				y.Add(&y, &subRes[j])
+			}
+
+			y.Mul(&y, &r)
+			require.Equal(t, testcase[i].String(), y.String(), "the subRes was %v", subRes)
+		}
+	}
 }
 
 func makeKeyDeterminitic(t *testing.T, sis *RSis, _seed int64) {

--- a/ecc/bn254/fr/sis/sis_test.go
+++ b/ecc/bn254/fr/sis/sis_test.go
@@ -163,6 +163,12 @@ func TestMulMod(t *testing.T) {
 // field element by evaluating the polynomial whose the coeffiients are the
 // limbs.
 func TestLimbDecomposition(t *testing.T) {
+
+	// Skipping the test for 32 bits
+	if bits.UintSize == 32 {
+		t.Skip("skipping this test in 32bit.")
+	}
+
 	sis, _ := NewRSis(0, 4, 4, 3)
 
 	testcases := []fr.Vector{


### PR DESCRIPTION
# Update the limb decomposition process in ring-SIS

This PR updates the way we decompose a list of field elements into limbs.

## Prior state and motivation

The field elements were concatenated into bytes buffer in big-endian form and this bytes buffer was then split into limbs of short norm. The issue with this approach is that some limbs may contain bits from different field elements of the input slice. 

These are blockers for the self-recursion. Indeed, for self-recursion we critically rely on the fact that we can recompute the original field element from its limbs as a polynomial evaluation.

## Description of the new method

We split a slice of bytes representing an array of serialized field element in big-endian form into an array of limbs representing the same field elements in little-endian form. For instance, say our field is represented with 64 bits and we have the following field element `x = 0x0123456789abcdef` (0 being the most significant character and f being the least significant one) and our log norm bound is 16 (so 1 hex character = 1 limb). The function assigns the values of m to `[f, e,
d, c, b, a, ..., 3, 2, 1, 0]`.  Additionally, we have the guarantee that 2 bits contributing to different field elements cannot be part of the same limb.

Thanks to that, we have that `x = \sum_i limbs[i] * 16^i`

## Impacts on the code

All changes are concentrated in the package `ecc/bn254/fr/sis/`:
* Add a private method `cleanUp` to reinitialize the buffers of the ring-SIS instance
* Add a public function `LimbDecomposeBytes` exposed to the user, which gives the same limb decomposition as the one that is used by the `Sum` function
* We add a private function `limbDecomposeBytes` that is used by both `Sum` and `LimbDecomposeBytes`
* Update the sage script to account for this new behavior

## Testing

Adds a test `TestLimbDecomposition`
* Test the property that we can recover a field element from its limb decomposition
* The test is broken (and disabled) for 32 bits

## Performances impact

These changes add 1µs per field. This has little impact on the performances of "low-degree" instances, although their implementation is suboptimal from a performance perspective. However, the effect is significant on the "large-degree instances".

### Benchmarks  on an EC2-HPC6a
```
pkg: github.com/consensys/gnark-crypto/ecc/bn254/fr/sis
cpu: AMD EPYC 7R13 Processor
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=2/log2-degree=3-96         	     102	  11634465 ns/op	     11364 ns/field	     14986 ns/field(theory)	 1313186 B/op	   32785 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=2/log2-degree=3-96         	      49	  23181387 ns/op	     11322 ns/field	     14986 ns/field(theory)	 2625938 B/op	   65553 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=2/log2-degree=3-96         	      25	  46756417 ns/op	     11418 ns/field	     14986 ns/field(theory)	 5255187 B/op	  131089 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=2/log2-degree=3-96         	      12	  92725842 ns/op	     11321 ns/field	     14986 ns/field(theory)	10531030 B/op	  262156 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=2/log2-degree=3-96        	       6	 189031106 ns/op	     11541 ns/field	     14986 ns/field(theory)	21147776 B/op	  524299 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=2/log2-degree=3-96        	       3	 364529072 ns/op	     11128 ns/field	     14986 ns/field(theory)	42643096 B/op	 1048578 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=2/log2-degree=3-96        	       2	 741948000 ns/op	     11324 ns/field	     14986 ns/field(theory)	85983824 B/op	 2097147 allocs/op
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=4/log2-degree=4-96         	     162	   7254340 ns/op	      7086 ns/field	      9144 ns/field(theory)	  331444 B/op	    8210 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=4/log2-degree=4-96         	      80	  14293500 ns/op	      6980 ns/field	      9144 ns/field(theory)	  660358 B/op	   16402 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=4/log2-degree=4-96         	      40	  28912099 ns/op	      7060 ns/field	      9144 ns/field(theory)	 1320632 B/op	   32786 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=4/log2-degree=4-96         	      20	  57487656 ns/op	      7020 ns/field	      9144 ns/field(theory)	 2651012 B/op	   65554 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=4/log2-degree=4-96        	       9	 115669204 ns/op	      7063 ns/field	      9144 ns/field(theory)	 5362742 B/op	  131091 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=4/log2-degree=4-96        	       5	 227501583 ns/op	      6945 ns/field	      9144 ns/field(theory)	10908539 B/op	  262165 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=4/log2-degree=4-96        	       3	 463685164 ns/op	      7077 ns/field	      9144 ns/field(theory)	22372962 B/op	  524311 allocs/op
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=6/log2-degree=5-96         	     202	   5752091 ns/op	      5618 ns/field	      7196 ns/field(theory)	  116836 B/op	    2771 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=6/log2-degree=5-96         	      99	  11346857 ns/op	      5542 ns/field	      7196 ns/field(theory)	  227915 B/op	    5523 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=6/log2-degree=5-96         	      50	  22559259 ns/op	      5509 ns/field	      7196 ns/field(theory)	  451993 B/op	   11027 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=6/log2-degree=5-96         	      26	  45360163 ns/op	      5538 ns/field	      7196 ns/field(theory)	  907234 B/op	   22035 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=6/log2-degree=5-96        	      12	  92162865 ns/op	      5627 ns/field	      7196 ns/field(theory)	 1855088 B/op	   44052 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=6/log2-degree=5-96        	       6	 184241799 ns/op	      5624 ns/field	      7196 ns/field(theory)	 3878506 B/op	   88085 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=6/log2-degree=5-96        	       3	 360950622 ns/op	      5510 ns/field	      7196 ns/field(theory)	 8449634 B/op	  176152 allocs/op
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=10/log2-degree=6-96        	     273	   4321890 ns/op	      4221 ns/field	      4978 ns/field(theory)	   46095 B/op	     852 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=10/log2-degree=6-96        	     138	   8654232 ns/op	      4227 ns/field	      4978 ns/field(theory)	   80085 B/op	    1684 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=10/log2-degree=6-96        	      67	  17325751 ns/op	      4231 ns/field	      4978 ns/field(theory)	  149607 B/op	    3348 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=10/log2-degree=6-96        	      33	  34580995 ns/op	      4222 ns/field	      4978 ns/field(theory)	  294701 B/op	    6676 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=10/log2-degree=6-96       	      16	  68147857 ns/op	      4161 ns/field	      4978 ns/field(theory)	  610588 B/op	   13332 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=10/log2-degree=6-96       	       8	 140118855 ns/op	      4277 ns/field	      4978 ns/field(theory)	 1339672 B/op	   26645 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=10/log2-degree=6-96       	       4	 278617983 ns/op	      4253 ns/field	      4978 ns/field(theory)	 3191056 B/op	   53272 allocs/op
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=16/log2-degree=7-96        	     336	   3434020 ns/op	      3354 ns/field	      3524 ns/field(theory)	   35298 B/op	     277 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=16/log2-degree=7-96        	     172	   6905153 ns/op	      3372 ns/field	      3524 ns/field(theory)	   46105 B/op	     533 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=16/log2-degree=7-96        	      81	  13457584 ns/op	      3286 ns/field	      3524 ns/field(theory)	   69059 B/op	    1045 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=16/log2-degree=7-96        	      40	  26960261 ns/op	      3291 ns/field	      3524 ns/field(theory)	  119889 B/op	    2069 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=16/log2-degree=7-96       	      20	  54644984 ns/op	      3336 ns/field	      3524 ns/field(theory)	  241129 B/op	    4117 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=16/log2-degree=7-96       	       9	 111824736 ns/op	      3413 ns/field	      3524 ns/field(theory)	  585554 B/op	    8214 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=16/log2-degree=7-96       	       5	 217212744 ns/op	      3315 ns/field	      3524 ns/field(theory)	 1519073 B/op	   16408 allocs/op
BenchmarkSIS/ring-sis/inputs=1024/log2-bound=32/log2-degree=8-96        	     436	   2685187 ns/op	      2623 ns/field	      1968 ns/field(theory)	   52154 B/op	      87 allocs/op
BenchmarkSIS/ring-sis/inputs=2048/log2-bound=32/log2-degree=8-96        	     230	   5220743 ns/op	      2549 ns/field	      1968 ns/field(theory)	   55133 B/op	     151 allocs/op
BenchmarkSIS/ring-sis/inputs=4096/log2-bound=32/log2-degree=8-96        	     100	  10524313 ns/op	      2570 ns/field	      1968 ns/field(theory)	   62304 B/op	     279 allocs/op
BenchmarkSIS/ring-sis/inputs=8192/log2-bound=32/log2-degree=8-96        	      56	  20986863 ns/op	      2562 ns/field	      1968 ns/field(theory)	   79285 B/op	     535 allocs/op
BenchmarkSIS/ring-sis/inputs=16384/log2-bound=32/log2-degree=8-96       	      27	  41182502 ns/op	      2514 ns/field	      1968 ns/field(theory)	  129238 B/op	    1047 allocs/op
BenchmarkSIS/ring-sis/inputs=32768/log2-bound=32/log2-degree=8-96       	      13	  83982155 ns/op	      2564 ns/field	      1968 ns/field(theory)	  292678 B/op	    2072 allocs/op
BenchmarkSIS/ring-sis/inputs=65536/log2-bound=32/log2-degree=8-96       	       6	 168201920 ns/op	      2567 ns/field	      1968 ns/field(theory)	  912325 B/op	    4121 allocs/op
PASS

```