### PR TITLE
Generic slice serialization

### DIFF
--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bls12-377 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-377/marshal_test.go
+++ b/ecc/bls12-377/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
@@ -474,4 +475,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bls12-378 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-378/marshal_test.go
+++ b/ecc/bls12-378/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
@@ -474,4 +475,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bls12-381 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-381/marshal_test.go
+++ b/ecc/bls12-381/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
@@ -474,4 +475,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bls24-315 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-315/marshal_test.go
+++ b/ecc/bls24-315/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
@@ -484,4 +485,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bls24-317 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-317/marshal_test.go
+++ b/ecc/bls24-317/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
@@ -484,4 +485,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -195,7 +195,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -18,7 +18,6 @@ package bn254
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"math/big"
 	"math/rand"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -18,6 +18,7 @@ package bn254
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"math/big"
 	"math/rand"
@@ -474,4 +475,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bw6-633 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-633/marshal_test.go
+++ b/ecc/bw6-633/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fp"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
@@ -464,4 +465,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bw6-756 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-756/marshal_test.go
+++ b/ecc/bw6-756/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fp"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
@@ -464,4 +465,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -103,24 +103,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -219,7 +201,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -278,7 +260,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -304,6 +286,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("bw6-761 encoder: unsupported type")
@@ -364,6 +366,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -416,8 +433,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -493,6 +508,11 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -521,8 +541,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -598,6 +616,11 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("<no value> encoder: unsupported type")
@@ -606,25 +629,6 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-761/marshal_test.go
+++ b/ecc/bw6-761/marshal_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fp"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
@@ -464,4 +465,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -108,24 +108,6 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	var read int
 
 	switch t := v.(type) {
-	case *[]uint64:
-		buf64 := buf[:64/8]
-		read, err = io.ReadFull(dec.r, buf64)
-		dec.n += int64(read)
-		if err != nil {
-			return
-		}
-		length := binary.BigEndian.Uint64(buf64)
-		*t = make([]uint64, length)
-		for i := range *t {
-			read, err = io.ReadFull(dec.r, buf64)
-			dec.n += int64(read)
-			if err != nil {
-				return
-			}
-			(*t)[i] = binary.BigEndian.Uint64(buf64)
-		}
-		return
 	case *fr.Element:
 		read, err = io.ReadFull(dec.r, buf[:fr.Bytes])
 		dec.n += int64(read)
@@ -224,7 +206,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool 
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return 
 				}
 				compressed[i] = !r
@@ -283,7 +265,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 				}
 			} else {
 				var r bool
-				if r, err = ((*t)[i].unsafeSetCompressedBytes(buf[:nbBytes])); err != nil {
+				if r, err = (*t)[i].unsafeSetCompressedBytes(buf[:nbBytes]); err != nil {
 					return
 				}
 				compressed[i] = !r
@@ -309,6 +291,26 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Slice {
+			var sliceLen uint32
+			sliceLen, err = dec.readUint32()
+			if err != nil {
+				return
+			}
+			vRef := rv.Elem()
+			if vRef.Len() != int(sliceLen) {
+				newSlice := reflect.MakeSlice(vRef.Type(), int(sliceLen), int(sliceLen))
+				vRef.Set(newSlice)
+			}
+			for i := 0; i < int(sliceLen); i++ {
+				if err = dec.Decode(vRef.Index(i).Addr().Interface()); err != nil {
+					return
+				}
+			}
+			return
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("{{.Name}} encoder: unsupported type")
@@ -374,6 +376,21 @@ func (enc *Encoder) Encode(v interface{}) (err error) {
 	return enc.encode(v)
 }
 
+// encodeSlice takes a slice and encodes first its length, then its elements
+func (enc *Encoder) encodeSlice(vr reflect.Value) error {
+	l := vr.Len()
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(l)); err != nil {
+		return err
+	}
+	enc.n += 32 / 8
+	for i := 0; i < l; i++ {
+		if err := enc.Encode(vr.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // BytesWritten return total bytes written on writer
 func (enc *Encoder) BytesWritten() int64 {
 	return enc.n
@@ -412,25 +429,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 {{template "encode" dict "Raw" ""}}
 {{template "encode" dict "Raw" "Raw"}}
 
-func (enc *Encoder) writeUint64Slice(t []uint64) error {
-	buff := make([]byte, 64/8)
-	binary.BigEndian.PutUint64(buff, uint64(len(t)))
-	written, err := enc.w.Write(buff)
-	enc.n += int64(written)
-	if err != nil {
-		return err
-	}
-	for i := range t {
-		binary.BigEndian.PutUint64(buff, t[i])
-		written, err = enc.w.Write(buff)
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 {{ define "encode"}}
 
 func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
@@ -451,8 +449,6 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 	var written int
 
 	switch t := v.(type) {
-	case []uint64:
-		return enc.writeUint64Slice(t)
 	case *fr.Element:
 		buf := t.Bytes()
 		written, err = enc.w.Write(buf[:])
@@ -528,6 +524,11 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return nil
 	default:
+
+		if rv.Kind() == reflect.Slice {
+			return enc.encodeSlice(rv)
+		}
+
 		n := binary.Size(t)
 		if n == -1 {
 			return errors.New("{{.Name}} encoder: unsupported type")

--- a/internal/generator/ecc/template/tests/marshal.go.tmpl
+++ b/internal/generator/ecc/template/tests/marshal.go.tmpl
@@ -16,6 +16,7 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fp"
@@ -458,4 +459,17 @@ func GenBigInt() gopter.Gen {
 		genResult := gopter.NewGenResult(s, gopter.NoShrinker)
 		return genResult
 	}
+}
+
+func TestSliceSerialization(t *testing.T) {
+	var oBack []uint16
+	o := []uint16{1, 2, 3, 4}
+
+	writer := bytes.NewBuffer(make([]byte, 0, 100))
+	assert.NoError(t, NewEncoder(writer).Encode(o))
+
+	reader := bytes.NewReader(writer.Bytes())
+	assert.NoError(t, NewDecoder(reader).Decode(&oBack))
+
+	assert.Equal(t, o, oBack)
 }


### PR DESCRIPTION
This PR enables the user to serialize (potentially multi-dimensional) slices through the `encoder.Encode` and `decoder.Decode` functions. It is a last resort so will not interfere with custom implementations in performance-critical applications as this implementation uses reflection heavily (per element).