### PR TITLE
Disable check shadowing in govet linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,3 @@
-linters-settings:
-  govet:
-    check-shadowing: true
-
 linters:
   disable-all: true
   enable:

--- a/ecc/bls12-377/fr/polynomial/pool.go
+++ b/ecc/bls12-377/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bls12-378/fr/polynomial/pool.go
+++ b/ecc/bls12-378/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bls12-381/fr/polynomial/pool.go
+++ b/ecc/bls12-381/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bls24-315/fr/polynomial/pool.go
+++ b/ecc/bls24-315/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bls24-317/fr/polynomial/pool.go
+++ b/ecc/bls24-317/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bn254/fr/polynomial/pool.go
+++ b/ecc/bn254/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bw6-633/fr/polynomial/pool.go
+++ b/ecc/bw6-633/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bw6-756/fr/polynomial/pool.go
+++ b/ecc/bw6-756/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/ecc/bw6-761/fr/polynomial/pool.go
+++ b/ecc/bw6-761/fr/polynomial/pool.go
@@ -187,11 +187,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }

--- a/internal/generator/polynomial/template/pool.go.tmpl
+++ b/internal/generator/polynomial/template/pool.go.tmpl
@@ -194,11 +194,11 @@ func (p *Pool) PrintPoolStats() {
 		InUse += subPool.stats.InUse
 	}
 
-	poolsStats := poolsStats{
+	stats := poolsStats{
 		SubPools: subStats,
 		InUse:    InUse,
 	}
-	serialized, _ := json.MarshalIndent(poolsStats, "", "  ")
+	serialized, _ := json.MarshalIndent(stats, "", "  ")
 	fmt.Println(string(serialized))
 	p.printInUse()
 }


### PR DESCRIPTION
This PR removes the `linter-settings` block which enables `check-shadowing`. Personally, I don't find this check all that useful; it's not necessarily dangerous and making new variables like `err2` and `err3` is pretty ugly IMO.