### PR TITLE
Do not XOR with zero

### DIFF
--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -232,7 +232,7 @@ func (z *Element) IsZero() bool {
 
 // IsOne returns z == 1
 func (z *Element) IsOne() bool {
-	return (z[3] ^ 0 | z[2] ^ 0 | z[1] ^ 0 | z[0] ^ 4294968273) == 0
+	return (z[3] | z[2] | z[1] | z[0] ^ 4294968273) == 0
 }
 
 // IsUint64 reports whether z can be represented as an uint64.

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -232,7 +232,7 @@ func (z *Element) IsZero() bool {
 
 // IsOne returns z == 1
 func (z *Element) IsOne() bool {
-	return (z[3] ^ 0 | z[2] ^ 1 | z[1] ^ 4994812053365940164 | z[0] ^ 4624529908474429119) == 0
+	return (z[3] | z[2] ^ 1 | z[1] ^ 4994812053365940164 | z[0] ^ 4624529908474429119) == 0
 }
 
 // IsUint64 reports whether z can be represented as an uint64.

--- a/field/generator/internal/templates/element/base.go
+++ b/field/generator/internal/templates/element/base.go
@@ -218,7 +218,7 @@ func (z *{{.ElementName}}) IsOne() bool {
 	{{- if eq .NbWords 1}}
 	return z[0] == {{index $.One 0}}
 	{{- else}}
-	return ( {{- range $i := reverse .NbWordsIndexesNoZero }} z[{{$i}}] ^ {{index $.One $i}} | {{- end}} z[0] ^ {{index $.One 0}} ) == 0
+	return ( {{- range $i := reverse .NbWordsIndexesNoZero -}}{{if ne (index $.One $i) 0}}z[{{$i}}] ^ {{index $.One $i}} | {{else}}z[{{$i}}] | {{end}}{{- end}}z[0] ^ {{index $.One 0}} ) == 0
 	{{- end}}
 }
 


### PR DESCRIPTION
The staticcheck linter pointed out some unnecessary XORs with zero:
```
ecc/secp256k1/fr/element.go:235:10: SA4016: z[3] ^ 0 always equals z[3] (staticcheck)
        return (z[3] ^ 0 | z[2] ^ 1 | z[1] ^ 4994812053365940164 | z[0] ^ 4624529908474429119) == 0

ecc/secp256k1/fp/element.go:235:10: SA4016: z[3] ^ 0 | z[2] ^ 0 | z[1] ^ 0 always equals z[3] ^ 0 | z[2] ^ 0 | z[1] (staticcheck)
        return (z[3] ^ 0 | z[2] ^ 0 | z[1] ^ 0 | z[0] ^ 4294968273) == 0
```

This PR removes those.