### PR TITLE
Enable misspell linter & fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # - errcheck
+    - misspell
 
 run:
   issues-exit-code: 1

--- a/ecc/stark-curve/pedersen-hash/pedersen_hash_test.go
+++ b/ecc/stark-curve/pedersen-hash/pedersen_hash_test.go
@@ -146,12 +146,12 @@ func BenchmarkPedersenArray(b *testing.B) {
 func BenchmarkPedersen(b *testing.B) {
 	e0, err := new(fp.Element).SetString("0x3d937c035c878245caf64531a5756109c53068da139362728feb561405371cb")
 	if err != nil {
-		b.Errorf("Error occured %s", err)
+		b.Errorf("Error occurred %s", err)
 	}
 
 	e1, err := new(fp.Element).SetString("0x208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a")
 	if err != nil {
-		b.Errorf("Error occured %s", err)
+		b.Errorf("Error occurred %s", err)
 	}
 
 	var f fp.Element

--- a/internal/bench/main.go
+++ b/internal/bench/main.go
@@ -18,7 +18,7 @@ type entry struct {
 }
 
 func main() {
-	// quick and dirty helper to benchmark field elements accross branches
+	// quick and dirty helper to benchmark field elements across branches
 
 	var entries []entry
 	err := filepath.WalkDir("../../ecc", func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION
Enable the `misspell` linter which identifies common typos. There were only 3 findings.