### PR TITLE
Fix `RSis.CopyWithFreshBuffer`

### DIFF
--- a/ecc/bn254/fr/sis/sis.go
+++ b/ecc/bn254/fr/sis/sis.go
@@ -287,6 +287,9 @@ func mulModAcc(res []fr.Element, pLagrangeCosetBitReversed, qLagrangeCosetBitRev
 func (r *RSis) CopyWithFreshBuffer() RSis {
 	res := *r
 	res.buffer = bytes.Buffer{}
+	res.bufM = make(fr.Vector, len(r.bufM))
+	res.bufMValues = bitset.New(r.bufMValues.Len())
+	res.bufRes = make(fr.Vector, len(r.bufRes))
 	return res
 }
 


### PR DESCRIPTION
# Fix `CopyWithFreshBuffer`

`CopyWithFreshBuffer` is a method of `RSis` whose intended role is to enable hashing in parallel by creating short-lived "clones" of the key. The present PR fixes a bug related to this.

## Description of the bug

Prior to this PR, `CopyWithFreshBuffer` would shallow copy the private fields `bufM`, `bufRes` and `bufMValues`. As a result, attempting to use several copies of the same key concurrently results in a race condition (the same buffer being used by all the threads at the same time). 

## The fix

The proposed fix is to also initialize the rest of the buffers
```
	res.bufM = make(fr.Vector, len(r.bufM))
	res.bufMValues = bitset.New(r.bufMValues.Len())
	res.bufRes = make(fr.Vector, len(r.bufRes))
```