### PR TITLE
msm: semaphore to limit CPUs + better split strategy (up to 25% perf boost on 96cores)

### DIFF
--- a/ecc/bls12-377/multiexp.go
+++ b/ecc/bls12-377/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -474,6 +477,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bls12-377/multiexp.go
+++ b/ecc/bls12-377/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -373,7 +373,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bls12-377/multiexp.go
+++ b/ecc/bls12-377/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -298,6 +335,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -332,7 +370,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -362,29 +400,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -406,6 +466,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -418,8 +488,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -429,7 +503,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -437,7 +511,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -582,6 +656,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bls12-377/multiexp_affine.go
+++ b/ecc/bls12-377/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-377/multiexp_jacobian.go
+++ b/ecc/bls12-377/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -97,7 +109,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -131,6 +149,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-377/multiexp_test.go
+++ b/ecc/bls12-377/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bls12-378/multiexp.go
+++ b/ecc/bls12-378/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -300,6 +337,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -334,7 +372,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -364,29 +402,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -408,6 +468,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -420,8 +490,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -431,7 +505,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -439,7 +513,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -586,6 +660,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bls12-378/multiexp.go
+++ b/ecc/bls12-378/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -476,6 +479,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bls12-378/multiexp.go
+++ b/ecc/bls12-378/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -375,7 +375,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bls12-378/multiexp_affine.go
+++ b/ecc/bls12-378/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-378/multiexp_jacobian.go
+++ b/ecc/bls12-378/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -99,7 +111,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -133,6 +151,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-378/multiexp_test.go
+++ b/ecc/bls12-378/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bls12-381/multiexp.go
+++ b/ecc/bls12-381/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -474,6 +477,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bls12-381/multiexp.go
+++ b/ecc/bls12-381/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -373,7 +373,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bls12-381/multiexp.go
+++ b/ecc/bls12-381/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -298,6 +335,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -332,7 +370,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -362,29 +400,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -406,6 +466,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -418,8 +488,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -429,7 +503,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -437,7 +511,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -582,6 +656,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bls12-381/multiexp_affine.go
+++ b/ecc/bls12-381/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-381/multiexp_jacobian.go
+++ b/ecc/bls12-381/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -97,7 +109,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -131,6 +149,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls12-381/multiexp_test.go
+++ b/ecc/bls12-381/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bls24-315/multiexp.go
+++ b/ecc/bls24-315/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -474,6 +477,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bls24-315/multiexp.go
+++ b/ecc/bls24-315/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -373,7 +373,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bls24-315/multiexp.go
+++ b/ecc/bls24-315/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -298,6 +335,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -332,7 +370,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -362,29 +400,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -406,6 +466,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -418,8 +488,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -429,7 +503,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -437,7 +511,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -582,6 +656,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bls24-315/multiexp_affine.go
+++ b/ecc/bls24-315/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls24-315/multiexp_jacobian.go
+++ b/ecc/bls24-315/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -97,7 +109,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -131,6 +149,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls24-315/multiexp_test.go
+++ b/ecc/bls24-315/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bls24-317/multiexp.go
+++ b/ecc/bls24-317/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -474,6 +477,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bls24-317/multiexp.go
+++ b/ecc/bls24-317/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -373,7 +373,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bls24-317/multiexp.go
+++ b/ecc/bls24-317/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -298,6 +335,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -332,7 +370,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -362,29 +400,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -406,6 +466,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -418,8 +488,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -429,7 +503,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -437,7 +511,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -582,6 +656,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bls24-317/multiexp_affine.go
+++ b/ecc/bls24-317/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls24-317/multiexp_jacobian.go
+++ b/ecc/bls24-317/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -97,7 +109,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -131,6 +149,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bls24-317/multiexp_test.go
+++ b/ecc/bls24-317/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bn254/multiexp.go
+++ b/ecc/bn254/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -300,6 +337,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -334,7 +372,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -364,29 +402,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -408,6 +468,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -420,8 +490,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -431,7 +505,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -439,7 +513,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -586,6 +660,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bn254/multiexp.go
+++ b/ecc/bn254/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -476,6 +479,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bn254/multiexp.go
+++ b/ecc/bn254/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -375,7 +375,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bn254/multiexp_affine.go
+++ b/ecc/bn254/multiexp_affine.go
@@ -37,7 +37,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -226,6 +232,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 
 }
@@ -353,7 +365,13 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -540,6 +558,12 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bn254/multiexp_jacobian.go
+++ b/ecc/bn254/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total
@@ -99,7 +111,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -133,6 +151,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bn254/multiexp_test.go
+++ b/ecc/bn254/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bw6-633/multiexp.go
+++ b/ecc/bw6-633/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -322,7 +322,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bw6-633/multiexp.go
+++ b/ecc/bw6-633/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -423,6 +426,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bw6-633/multiexp.go
+++ b/ecc/bw6-633/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 4:
@@ -247,6 +284,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -281,7 +319,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -311,29 +349,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -355,6 +415,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -367,8 +437,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -378,7 +452,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -386,7 +460,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 4:
@@ -480,6 +554,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bw6-633/multiexp_jacobian.go
+++ b/ecc/bw6-633/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -56,6 +62,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 }
 
@@ -81,7 +93,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -115,6 +133,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bw6-633/multiexp_test.go
+++ b/ecc/bw6-633/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bw6-756/multiexp.go
+++ b/ecc/bw6-756/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -247,6 +284,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -281,7 +319,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -311,29 +349,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -355,6 +415,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -367,8 +437,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -378,7 +452,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -386,7 +460,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 3:
@@ -480,6 +554,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bw6-756/multiexp.go
+++ b/ecc/bw6-756/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -322,7 +322,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bw6-756/multiexp.go
+++ b/ecc/bw6-756/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -423,6 +426,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bw6-756/multiexp_jacobian.go
+++ b/ecc/bw6-756/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -56,6 +62,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 }
 
@@ -81,7 +93,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -115,6 +133,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bw6-756/multiexp_test.go
+++ b/ecc/bw6-756/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/bw6-761/multiexp.go
+++ b/ecc/bw6-761/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -324,7 +324,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/bw6-761/multiexp.go
+++ b/ecc/bw6-761/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -249,6 +286,7 @@ func (p *G2Affine) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G2Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -283,7 +321,7 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -313,29 +351,51 @@ func (p *G2Jac) MultiExp(points []G2Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G2Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G2Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG2(p, C, points, scalars, config)
 
 	return p, nil
@@ -357,6 +417,16 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g2JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -369,8 +439,12 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g2JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -380,7 +454,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG2Affine(p, int(c), chChunks[:])
@@ -388,7 +462,7 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 
 // getChunkProcessorG2 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16) {
+func getChunkProcessorG2(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g2JacExtended, c uint64, points []G2Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -484,6 +558,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/bw6-761/multiexp.go
+++ b/ecc/bw6-761/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
@@ -425,6 +428,9 @@ func _innerMsmG2(p *G2Jac, c uint64, points []G2Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/bw6-761/multiexp_jacobian.go
+++ b/ecc/bw6-761/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -56,6 +62,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 		total.add(&runningSum)
 	}
 
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
+	}
+
 	chRes <- total
 }
 
@@ -83,7 +95,13 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	chRes chan<- g2JacExtended,
 	c uint64,
 	points []G2Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -117,6 +135,12 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/bw6-761/multiexp_test.go
+++ b/ecc/bw6-761/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(16), chChunks[:])
@@ -718,7 +718,7 @@ func _innerMsmG2Reference(p *G2Jac, points []G2Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG2Jacobian[bucketg2JacExtendedC16]
-		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 16, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG2Affine(p, int(16), chChunks[:])

--- a/ecc/secp256k1/multiexp.go
+++ b/ecc/secp256k1/multiexp.go
@@ -76,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/ecc/secp256k1/multiexp.go
+++ b/ecc/secp256k1/multiexp.go
@@ -180,6 +180,9 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		for i := 0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/ecc/secp256k1/multiexp.go
+++ b/ecc/secp256k1/multiexp.go
@@ -41,6 +41,7 @@ func (p *G1Affine) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.MultiExpConfig) (*G1Jac, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -75,7 +76,7 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -105,29 +106,51 @@ func (p *G1Jac) MultiExp(points []G1Affine, scalars []fr.Element, config ecc.Mul
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints / 2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit * 2
-		if (nbTasksPostSplit <= config.NbTasks/2) || (nbTasksPostSplit-config.NbTasks/2) <= (config.NbTasks-nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p G1Jac
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm;
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int { return (nbPoints + int((1 << c))) }
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+
+	cPostSplit := bestC(nbPoints / 2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit*2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p G1Jac
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsmG1(p, C, points, scalars, config)
 
 	return p, nil
@@ -149,6 +172,16 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 		chChunks[i] = make(chan g1JacExtended, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks*2) // *2 because if chunk is overweight we split it in two
+		for i := 0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -161,8 +194,12 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan g1JacExtended, 2)
 			split := n / 2
-			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j), chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j), chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -172,7 +209,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunkG1Affine(p, int(c), chChunks[:])
@@ -180,7 +217,7 @@ func _innerMsmG1(p *G1Jac, c uint64, points []G1Affine, scalars []fr.Element, co
 
 // getChunkProcessorG1 decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16) {
+func getChunkProcessorG1(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- g1JacExtended, c uint64, points []G1Affine, digits []uint16, sem chan struct{}) {
 	switch c {
 
 	case 2:
@@ -318,6 +355,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64, nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 

--- a/ecc/secp256k1/multiexp_affine.go
+++ b/ecc/secp256k1/multiexp_affine.go
@@ -36,7 +36,13 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -223,6 +229,12 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/secp256k1/multiexp_jacobian.go
+++ b/ecc/secp256k1/multiexp_jacobian.go
@@ -20,7 +20,13 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	chRes chan<- g1JacExtended,
 	c uint64,
 	points []G1Affine,
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	var buckets B
 	for i := 0; i < len(buckets); i++ {
@@ -54,6 +60,12 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
+	}
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/ecc/secp256k1/multiexp_test.go
+++ b/ecc/secp256k1/multiexp_test.go
@@ -306,7 +306,7 @@ func _innerMsmG1Reference(p *G1Jac, points []G1Affine, scalars []fr.Element, con
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunkG1Jacobian[bucketg1JacExtendedC15]
-		go processChunk(uint64(j), chChunks[j], 15, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], 15, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunkG1Affine(p, int(15), chChunks[:])

--- a/internal/generator/ecc/template/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/multiexp.go.tmpl
@@ -386,6 +386,9 @@ func _innerMsm{{ $.UPointName }}(p *{{ $.TJacobian }}, c uint64, points []{{ $.T
 		for i:=0; i < config.NbTasks; i++ {
 			sem <- struct{}{}
 		}
+		defer func() {
+			close(sem)
+		}()
 	}
 
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.

--- a/internal/generator/ecc/template/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/multiexp.go.tmpl
@@ -69,6 +69,11 @@ type chunkStat struct {
 // negative digits can be processed in a later step as adding -G into the bucket instead of G
 // (computing -G is cheap, and this saves us half of the buckets in the MultiExp or BatchScalarMultiplication)
 func partitionScalars(scalars []fr.Element, c uint64,  nbTasks int) ([]uint16, []chunkStat) {
+	// no benefit here to have more tasks than CPUs
+	if nbTasks > runtime.NumCPU() {
+		nbTasks = runtime.NumCPU()
+	}
+
 	// number of c-bit radixes in a scalar
 	nbChunks := computeNbChunks(c)
 
@@ -240,6 +245,7 @@ func (p *{{ $.TAffine }}) MultiExp(points []{{ $.TAffine }}, scalars []fr.Elemen
 //
 // This call return an error if len(scalars) != len(points) or if provided config is invalid.
 func (p *{{ $.TJacobian }}) MultiExp(points []{{ $.TAffine }}, scalars []fr.Element, config ecc.MultiExpConfig) (*{{ $.TJacobian }}, error) {
+	// TODO @gbotrel replace the ecc.MultiExpConfig by a Option pattern for maintainability.
 	// note:
 	// each of the msmCX method is the same, except for the c constant it declares
 	// duplicating (through template generation) these methods allows to declare the buckets on the stack
@@ -274,7 +280,7 @@ func (p *{{ $.TJacobian }}) MultiExp(points []{{ $.TAffine }}, scalars []fr.Elem
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU()
+		config.NbTasks = runtime.NumCPU() * 3
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}
@@ -306,29 +312,51 @@ func (p *{{ $.TJacobian }}) MultiExp(points []{{ $.TAffine }}, scalars []fr.Elem
 	C := bestC(nbPoints)
 	nbChunks := int(computeNbChunks(C))
 
-	// if we don't utilise all the tasks (CPU in the default case) that we could, let's see if it's worth it to split
-	if config.NbTasks > 1 && nbChunks < config.NbTasks {
-		// before splitting, let's see if we end up with more tasks than thread;
-		cSplit := bestC(nbPoints/2)
-		nbChunksPostSplit := int(computeNbChunks(cSplit))
-		nbTasksPostSplit := nbChunksPostSplit*2
-		if (nbTasksPostSplit <= config.NbTasks /2 ) || ( nbTasksPostSplit - config.NbTasks/2 ) <= ( config.NbTasks - nbChunks) {
-			// if postSplit we still have less tasks than available CPU
-			// or if we have more tasks BUT the difference of CPU usage is in our favor, we split.
-			config.NbTasks /= 2
-			var _p {{ $.TJacobian }}
-			chDone := make(chan struct{}, 1)
-			go func() {
-				_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
-				close(chDone)
-			}()
-			p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
-			<-chDone
-			p.AddAssign(&_p)
-			return p, nil
+	// should we recursively split the msm in half? (see below)
+	// we want to minimize the execution time of the algorithm; 
+	// splitting the msm will **add** operations, but if it allows to use more CPU, it might be worth it.
+
+	// costFunction returns a metric that represent the "wall time" of the algorithm
+	costFunction := func(nbTasks, nbCpus, costPerTask int) int {
+		// cost for the reduction of all tasks (msmReduceChunk)
+		totalCost := nbTasks
+
+		// cost for the computation of each task (msmProcessChunk)
+		for nbTasks >= nbCpus {
+			nbTasks -= nbCpus
+			totalCost += costPerTask
 		}
+		if nbTasks > 0 {
+			totalCost += costPerTask
+		}
+		return totalCost
 	}
 
+	// costPerTask is the approximate number of group ops per task
+	costPerTask := func(c uint64, nbPoints int) int {return (nbPoints + int((1 << c)))}
+
+	costPreSplit := costFunction(nbChunks, config.NbTasks, costPerTask(C, nbPoints))
+	
+	cPostSplit := bestC(nbPoints/2)
+	nbChunksPostSplit := int(computeNbChunks(cPostSplit))
+	costPostSplit := costFunction(nbChunksPostSplit * 2, config.NbTasks, costPerTask(cPostSplit, nbPoints/2))
+
+	// if the cost of the split msm is lower than the cost of the non split msm, we split
+	if costPostSplit < costPreSplit {
+		config.NbTasks = int(math.Ceil(float64(config.NbTasks) / 2.0))
+		var _p {{ $.TJacobian }}
+		chDone := make(chan struct{}, 1)
+		go func() {
+			_p.MultiExp(points[:nbPoints/2], scalars[:nbPoints/2], config)
+			close(chDone)
+		}()
+		p.MultiExp(points[nbPoints/2:], scalars[nbPoints/2:], config)
+		<-chDone
+		p.AddAssign(&_p)
+		return p, nil
+	}
+
+	// if we don't split, we use the best C we found
 	_innerMsm{{ $.UPointName }}(p, C, points, scalars, config)
 
 	return p, nil
@@ -350,6 +378,16 @@ func _innerMsm{{ $.UPointName }}(p *{{ $.TJacobian }}, c uint64, points []{{ $.T
 		chChunks[i] = make(chan {{ $.TJacobianExtended }}, 1)
 	}
 
+	// we use a semaphore to limit the number of go routines running concurrently
+	// (only if nbTasks < nbCPU)
+	var sem chan struct{}
+	if config.NbTasks < runtime.NumCPU() {
+		sem = make(chan struct{}, config.NbTasks * 2) // *2 because if chunk is overweight we split it in two
+		for i:=0; i < config.NbTasks; i++ {
+			sem <- struct{}{}
+		}
+	}
+
 	// the last chunk may be processed with a different method than the rest, as it could be smaller.
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
@@ -362,8 +400,12 @@ func _innerMsm{{ $.UPointName }}(p *{{ $.TJacobian }}, c uint64, points []{{ $.T
 			// else what would happen is this go routine would finish much later than the others.
 			chSplit := make(chan {{ $.TJacobianExtended }}, 2)
 			split := n / 2
-			go processChunk(uint64(j),chSplit, c, points[:split], digits[j*n:(j*n)+split])
-			go processChunk(uint64(j),chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n])
+
+			if sem != nil {
+				sem <- struct{}{} // add another token to the semaphore, since we split in two.
+			}
+			go processChunk(uint64(j),chSplit, c, points[:split], digits[j*n:(j*n)+split], sem)
+			go processChunk(uint64(j),chSplit, c, points[split:], digits[(j*n)+split:(j+1)*n], sem)
 			go func(chunkID int) {
 				s1 := <-chSplit
 				s2 := <-chSplit
@@ -373,7 +415,7 @@ func _innerMsm{{ $.UPointName }}(p *{{ $.TJacobian }}, c uint64, points []{{ $.T
 			}(j)
 			continue
 		}
-		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], c, points, digits[j*n:(j+1)*n], sem)
 	}
 
 	return msmReduceChunk{{ $.TAffine }}(p, int(c), chChunks[:])
@@ -382,7 +424,7 @@ func _innerMsm{{ $.UPointName }}(p *{{ $.TJacobian }}, c uint64, points []{{ $.T
 
 // getChunkProcessor{{ $.UPointName }} decides, depending on c window size and statistics for the chunk
 // to return the best algorithm to process the chunk.
-func getChunkProcessor{{ $.UPointName }}(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- {{ $.TJacobianExtended }}, c uint64, points []{{ $.TAffine }}, digits []uint16) {
+func getChunkProcessor{{ $.UPointName }}(c uint64, stat chunkStat) func(chunkID uint64, chRes chan<- {{ $.TJacobianExtended }}, c uint64, points []{{ $.TAffine }}, digits []uint16, sem chan struct{}) {
 	switch c {
 		{{- range $c :=  $.LastCRange}}
 		case {{$c}}:

--- a/internal/generator/ecc/template/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/multiexp.go.tmpl
@@ -280,7 +280,7 @@ func (p *{{ $.TJacobian }}) MultiExp(points []{{ $.TAffine }}, scalars []fr.Elem
 
 	// if nbTasks is not set, use all available CPUs
 	if config.NbTasks <= 0 {
-		config.NbTasks = runtime.NumCPU() * 3
+		config.NbTasks = runtime.NumCPU() * 2
 	} else if config.NbTasks > 1024 {
 		return nil, errors.New("invalid config: config.NbTasks > 1024")
 	}

--- a/internal/generator/ecc/template/multiexp_affine.go.tmpl
+++ b/internal/generator/ecc/template/multiexp_affine.go.tmpl
@@ -38,7 +38,13 @@ func processChunk{{ $.UPointName }}BatchAffine[BJE ib{{ $.TJacobianExtended }},B
 	 chRes chan<- {{ $.TJacobianExtended }},
 	 c uint64,
 	 points []{{ $.TAffine }},
-	 digits []uint16) {
+	 digits []uint16,
+	 sem chan struct{}) {
+
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
 	// the batch affine addition needs independent points; in other words, for a window of batchSize
 	// we want to hit independent bucketIDs when processing the digit. if there is a conflict (we're trying
@@ -228,6 +234,13 @@ func processChunk{{ $.UPointName }}BatchAffine[BJE ib{{ $.TJacobianExtended }},B
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
+	}
+
+
+	if sem != nil {
+		// release a token to the semaphore
+		// before sending to chRes
+		sem <- struct{}{}
 	}
 
 	chRes <- total

--- a/internal/generator/ecc/template/multiexp_jacobian.go.tmpl
+++ b/internal/generator/ecc/template/multiexp_jacobian.go.tmpl
@@ -21,9 +21,13 @@ func processChunk{{ $.UPointName }}Jacobian[B ib{{ $.TJacobianExtended }}](chunk
 	chRes chan<- {{ $.TJacobianExtended }},
 	c uint64,
 	points []{{ $.TAffine }},
-	digits []uint16) {
+	digits []uint16,
+	sem chan struct{}) {
 
-
+	if sem != nil {
+		// if we are limited, wait for a token in the semaphore
+		<-sem
+	}
 
    var buckets B
    for i := 0 ; i < len(buckets); i++ {
@@ -59,6 +63,12 @@ func processChunk{{ $.UPointName }}Jacobian[B ib{{ $.TJacobianExtended }}](chunk
 	   }
 	   total.add(&runningSum)
    }
+
+   if sem != nil {
+	// release a token to the semaphore
+	// before sending to chRes
+	sem <- struct{}{}
+}
 
    chRes <- total
 }

--- a/internal/generator/ecc/template/tests/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/tests/multiexp.go.tmpl
@@ -333,7 +333,7 @@ func _innerMsm{{ $.UPointName }}Reference(p *{{ $.TJacobian }}, points []{{ $.TA
 	n := len(points)
 	for j := int(nbChunks - 1); j >= 0; j-- {
 		processChunk := processChunk{{ $.UPointName }}Jacobian[bucket{{ $.TJacobianExtended }}C{{$.cmax}}]
-		go processChunk(uint64(j), chChunks[j], {{$.cmax}}, points, digits[j*n:(j+1)*n])
+		go processChunk(uint64(j), chChunks[j], {{$.cmax}}, points, digits[j*n:(j+1)*n], nil)
 	}
 
 	return msmReduceChunk{{ $.TAffine }}(p, int({{$.cmax}}), chChunks[:])


### PR DESCRIPTION
This PR fixes #269  by introducing a semaphore when the MSM has a `NbTasks` parameter smaller than available CPUs.

Additionally, it revisits the heuristic to decide if it's worth it to split a msm into 2 (parallelization) and this result in some noticeable gains on our reference machine (aws hpc w/ 96 cores);

```
BenchmarkMultiExpG1/32_points-96                       327401         321755         -1.72%
BenchmarkMultiExpG1/32_points-smallvalues-96           311009         314889         +1.25%
BenchmarkMultiExpG1/32_points-redundancy-96            304380         309269         +1.61%
BenchmarkMultiExpG1/64_points-96                       386807         399116         +3.18%
BenchmarkMultiExpG1/64_points-smallvalues-96           382944         405201         +5.81%
BenchmarkMultiExpG1/64_points-redundancy-96            353195         350016         -0.90%
BenchmarkMultiExpG1/128_points-96                      508717         485115         -4.64%
BenchmarkMultiExpG1/128_points-smallvalues-96          500944         488468         -2.49%
BenchmarkMultiExpG1/128_points-redundancy-96           444654         454710         +2.26%
BenchmarkMultiExpG1/256_points-96                      631444         592283         -6.20%
BenchmarkMultiExpG1/256_points-smallvalues-96          575041         575244         +0.04%
BenchmarkMultiExpG1/256_points-redundancy-96           521282         534379         +2.51%
BenchmarkMultiExpG1/512_points-96                      752645         738090         -1.93%
BenchmarkMultiExpG1/512_points-smallvalues-96          788867         727497         -7.78%
BenchmarkMultiExpG1/512_points-redundancy-96           708452         679447         -4.09%
BenchmarkMultiExpG1/1024_points-96                     982689         944976         -3.84%
BenchmarkMultiExpG1/1024_points-smallvalues-96         990555         924593         -6.66%
BenchmarkMultiExpG1/1024_points-redundancy-96          923502         875818         -5.16%
BenchmarkMultiExpG1/2048_points-96                     1449082        1294379        -10.68%
BenchmarkMultiExpG1/2048_points-smallvalues-96         1414236        1229068        -13.09%
BenchmarkMultiExpG1/2048_points-redundancy-96          1295271        1175792        -9.22%
BenchmarkMultiExpG1/4096_points-96                     2085203        1781633        -14.56%
BenchmarkMultiExpG1/4096_points-smallvalues-96         2157690        1865174        -13.56%
BenchmarkMultiExpG1/4096_points-redundancy-96          2092848        1736579        -17.02%
BenchmarkMultiExpG1/8192_points-96                     3025724        2480464        -18.02%
BenchmarkMultiExpG1/8192_points-smallvalues-96         2892254        2425291        -16.15%
BenchmarkMultiExpG1/8192_points-redundancy-96          2783529        2320568        -16.63%
BenchmarkMultiExpG1/16384_points-96                    4510822        3794422        -15.88%
BenchmarkMultiExpG1/16384_points-smallvalues-96        4611577        4137253        -10.29%
BenchmarkMultiExpG1/16384_points-redundancy-96         4917603        3740932        -23.93%
BenchmarkMultiExpG1/32768_points-96                    7498927        6453743        -13.94%
BenchmarkMultiExpG1/32768_points-smallvalues-96        7904327        7382794        -6.60%
BenchmarkMultiExpG1/32768_points-redundancy-96         9362676        6137316        -34.45%
BenchmarkMultiExpG1/65536_points-96                    13543243       10923930       -19.34%
BenchmarkMultiExpG1/65536_points-smallvalues-96        13774630       11240420       -18.40%
BenchmarkMultiExpG1/65536_points-redundancy-96         15251163       11893144       -22.02%
BenchmarkMultiExpG1/131072_points-96                   24667428       18600625       -24.59%
BenchmarkMultiExpG1/131072_points-smallvalues-96       16858509       19325035       +14.63%
BenchmarkMultiExpG1/131072_points-redundancy-96        17304408       21860954       +26.33%
BenchmarkMultiExpG1/262144_points-96                   31878446       27247364       -14.53%
BenchmarkMultiExpG1/262144_points-smallvalues-96       31506573       29903329       -5.09%
BenchmarkMultiExpG1/262144_points-redundancy-96        33713084       32366152       -4.00%
BenchmarkMultiExpG1/524288_points-96                   58810510       52820165       -10.19%
BenchmarkMultiExpG1/524288_points-smallvalues-96       64905743       56003531       -13.72%
BenchmarkMultiExpG1/524288_points-redundancy-96        84538547       63161207       -25.29%
BenchmarkMultiExpG1/1048576_points-96                  113699503      102988409      -9.42%
BenchmarkMultiExpG1/1048576_points-smallvalues-96      127858512      108100661      -15.45%
BenchmarkMultiExpG1/1048576_points-redundancy-96       133258407      123546612      -7.29%
BenchmarkMultiExpG1/2097152_points-96                  223833891      216214307      -3.40%
BenchmarkMultiExpG1/2097152_points-smallvalues-96      237968346      228441042      -4.00%
BenchmarkMultiExpG1/2097152_points-redundancy-96       249153114      259179318      +4.02%
BenchmarkMultiExpG1/4194304_points-96                  398882329      338510504      -15.14%
BenchmarkMultiExpG1/4194304_points-smallvalues-96      428621784      362486074      -15.43%
BenchmarkMultiExpG1/4194304_points-redundancy-96       462562064      406775819      -12.06%
BenchmarkMultiExpG1/8388608_points-96                  739058637      662146690      -10.41%
BenchmarkMultiExpG1/8388608_points-smallvalues-96      806492486      699046536      -13.32%
BenchmarkMultiExpG1/8388608_points-redundancy-96       898269025      708105713      -21.17%
BenchmarkMultiExpG1/16777216_points-96                 1488257482     1191146328     -19.96%
BenchmarkMultiExpG1/16777216_points-smallvalues-96     1492737756     1252325303     -16.11%
BenchmarkMultiExpG1/16777216_points-redundancy-96      1746767789     1322819146     -24.27%
BenchmarkMultiExpG2/32_points-96                       638585         638668         +0.01%
BenchmarkMultiExpG2/32_points-smallvalues-96           634666         634983         +0.05%
BenchmarkMultiExpG2/32_points-redundancy-96            592647         600617         +1.34%
BenchmarkMultiExpG2/64_points-96                       761122         757613         -0.46%
BenchmarkMultiExpG2/64_points-smallvalues-96           749023         750656         +0.22%
BenchmarkMultiExpG2/64_points-redundancy-96            695057         707707         +1.82%
BenchmarkMultiExpG2/128_points-96                      906985         913358         +0.70%
BenchmarkMultiExpG2/128_points-smallvalues-96          899359         894607         -0.53%
BenchmarkMultiExpG2/128_points-redundancy-96           887100         835173         -5.85%
BenchmarkMultiExpG2/256_points-96                      1133083        1079976        -4.69%
BenchmarkMultiExpG2/256_points-smallvalues-96          1121605        1075911        -4.07%
BenchmarkMultiExpG2/256_points-redundancy-96           1095646        1000072        -8.72%
BenchmarkMultiExpG2/512_points-96                      1411844        1361207        -3.59%
BenchmarkMultiExpG2/512_points-smallvalues-96          1386061        1384758        -0.09%
BenchmarkMultiExpG2/512_points-redundancy-96           1335372        1281565        -4.03%
BenchmarkMultiExpG2/1024_points-96                     2084482        1962867        -5.83%
BenchmarkMultiExpG2/1024_points-smallvalues-96         1996537        1907398        -4.46%
BenchmarkMultiExpG2/1024_points-redundancy-96          1895181        1695670        -10.53%
BenchmarkMultiExpG2/2048_points-96                     2683672        2354556        -12.26%
BenchmarkMultiExpG2/2048_points-smallvalues-96         2670599        2480385        -7.12%
BenchmarkMultiExpG2/2048_points-redundancy-96          2661723        2295406        -13.76%
BenchmarkMultiExpG2/4096_points-96                     3997941        3751463        -6.17%
BenchmarkMultiExpG2/4096_points-smallvalues-96         3998818        3702869        -7.40%
BenchmarkMultiExpG2/4096_points-redundancy-96          3936731        3591620        -8.77%
BenchmarkMultiExpG2/8192_points-96                     6397008        5934513        -7.23%
BenchmarkMultiExpG2/8192_points-smallvalues-96         6306886        5723582        -9.25%
BenchmarkMultiExpG2/8192_points-redundancy-96          6006736        5713436        -4.88%
BenchmarkMultiExpG2/16384_points-96                    10376980       9306092        -10.32%
BenchmarkMultiExpG2/16384_points-smallvalues-96        10379099       9642047        -7.10%
BenchmarkMultiExpG2/16384_points-redundancy-96         11196384       8781211        -21.57%
BenchmarkMultiExpG2/32768_points-96                    17250773       16208197       -6.04%
BenchmarkMultiExpG2/32768_points-smallvalues-96        18644895       16881485       -9.46%
BenchmarkMultiExpG2/32768_points-redundancy-96         21795695       15883130       -27.13%
BenchmarkMultiExpG2/65536_points-96                    26781600       24341193       -9.11%
BenchmarkMultiExpG2/65536_points-smallvalues-96        32814865       25981450       -20.82%
BenchmarkMultiExpG2/65536_points-redundancy-96         32165668       30469548       -5.27%
BenchmarkMultiExpG2/131072_points-96                   39070259       40439373       +3.50%
BenchmarkMultiExpG2/131072_points-smallvalues-96       40481212       40295419       -0.46%
BenchmarkMultiExpG2/131072_points-redundancy-96        47162983       52780730       +11.91%
BenchmarkMultiExpG2/262144_points-96                   76631778       68889621       -10.10%
BenchmarkMultiExpG2/262144_points-smallvalues-96       76471465       72575848       -5.09%
BenchmarkMultiExpG2/262144_points-redundancy-96        89791042       91834827       +2.28%
BenchmarkMultiExpG2/524288_points-96                   137436942      129320175      -5.91%
BenchmarkMultiExpG2/524288_points-smallvalues-96       155879149      147114332      -5.62%
BenchmarkMultiExpG2/524288_points-redundancy-96        246710904      180653627      -26.78%
BenchmarkMultiExpG2/1048576_points-96                  344298791      275237375      -20.06%
BenchmarkMultiExpG2/1048576_points-smallvalues-96      350704216      303612692      -13.43%
BenchmarkMultiExpG2/1048576_points-redundancy-96       352475308      362878166      +2.95%
BenchmarkMultiExpG2/2097152_points-96                  644483916      573325482      -11.04%
BenchmarkMultiExpG2/2097152_points-smallvalues-96      618112810      619546779      +0.23%
BenchmarkMultiExpG2/2097152_points-redundancy-96       663478718      666394920      +0.44%
BenchmarkMultiExpG2/4194304_points-96                  1032104377     837934765      -18.81%
BenchmarkMultiExpG2/4194304_points-smallvalues-96      1119005923     885782366      -20.84%
BenchmarkMultiExpG2/4194304_points-redundancy-96       1254040458     1003086447     -20.01%
BenchmarkMultiExpG2/8388608_points-96                  1994499528     1791175296     -10.19%
BenchmarkMultiExpG2/8388608_points-smallvalues-96      2108917042     1725956851     -18.16%
BenchmarkMultiExpG2/8388608_points-redundancy-96       2405604610     1858394300     -22.75%
BenchmarkMultiExpG2/16777216_points-96                 3805535019     3099428789     -18.55%
BenchmarkMultiExpG2/16777216_points-smallvalues-96     4068009844     3128809045     -23.09%
BenchmarkMultiExpG2/16777216_points-redundancy-96      4727332985     3492094011     -26.13%
```