### PR TITLE
Feat/fold pedersen

### DIFF
--- a/ecc/bls12-377/fr/pedersen/pedersen.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bls12-377/fr/pedersen/pedersen.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bls12-377/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bls12-377/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bls12-378/fr/pedersen/pedersen.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-378"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bls12-378/fr/pedersen/pedersen.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bls12-378/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bls12-378/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-378"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bls12-381/fr/pedersen/pedersen.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bls12-381/fr/pedersen/pedersen.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bls12-381/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bls12-381/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bls24-315/fr/pedersen/pedersen.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bls24-315/fr/pedersen/pedersen.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bls24-315/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bls24-315/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bls24-317/fr/pedersen/pedersen.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bls24-317/fr/pedersen/pedersen.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bls24-317/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bls24-317/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bn254/fr/pedersen/pedersen.go
+++ b/ecc/bn254/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,22 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+
+		pk[i].basis = bases[i]
 	}
 
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +97,132 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basis)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basis)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +233,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bn254/fr/pedersen/pedersen.go
+++ b/ecc/bn254/fr/pedersen/pedersen.go
@@ -78,10 +78,8 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 		for j := range bases[i] {
 			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
 		}
-
 		pk[i].basis = bases[i]
 	}
-
 	return
 }
 
@@ -177,7 +175,6 @@ func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byt
 			scaledValues[offset].Mul(&values[i][j], &rI)
 			offset++
 		}
-
 		if i+1 < len(pk) {
 			rI.Mul(&rI, &r)
 		}

--- a/ecc/bn254/fr/pedersen/pedersen.go
+++ b/ecc/bn254/fr/pedersen/pedersen.go
@@ -166,13 +166,13 @@ func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byt
 	scaledValues := make([]fr.Element, offset)
 	basis := make([]curve.G1Affine, offset)
 
-	copy(basis, pk[0].basis)
+	copy(basis, pk[0].basisExpSigma)
 	copy(scaledValues, values[0])
 
 	offset = len(values[0])
 	rI := r
 	for i := 1; i < len(pk); i++ {
-		copy(basis[offset:], pk[i].basis)
+		copy(basis[offset:], pk[i].basisExpSigma)
 		for j := range pk[i].basis {
 			scaledValues[offset].Mul(&values[i][j], &rI)
 			offset++

--- a/ecc/bn254/fr/pedersen/pedersen.go
+++ b/ecc/bn254/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bn254/fr/pedersen/pedersen_test.go
+++ b/ecc/bn254/fr/pedersen/pedersen_test.go
@@ -73,7 +73,6 @@ func testCommit(t *testing.T, values ...interface{}) {
 		err             error
 		commitment, pok curve.G1Affine
 	)
-
 	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)

--- a/ecc/bn254/fr/pedersen/pedersen_test.go
+++ b/ecc/bn254/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bw6-633/fr/pedersen/pedersen.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bw6-633/fr/pedersen/pedersen.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bw6-633/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bw6-633/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bw6-756/fr/pedersen/pedersen.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bw6-756/fr/pedersen/pedersen.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-756"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bw6-756/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bw6-756/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-756"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/ecc/bw6-761/fr/pedersen/pedersen.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen.go
@@ -18,10 +18,12 @@ package pedersen
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
 	"math/big"
 )
@@ -51,7 +53,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 	}
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
 	if vk.g, err = randomOnG2(); err != nil {
 		return
@@ -70,19 +72,20 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
 	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-	pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-	for i := range basis {
-		pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+	pk = make([]ProvingKey, len(bases))
+	for i := range bases {
+		pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+		for j := range bases[i] {
+			pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+		}
+		pk[i].basis = bases[i]
 	}
-
-	pk.basis = basis
 	return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
 	if len(values) != len(pk.basis) {
-		err = fmt.Errorf("unexpected number of values")
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
@@ -92,12 +95,131 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, kn
 		NbTasks: 1, // TODO Experiment
 	}
 
-	if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+	_, err = pok.MultiExp(pk.basisExpSigma, values, config)
+	return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+	if len(values) != len(pk.basis) {
+		err = fmt.Errorf("must have as many values as basis elements")
 		return
 	}
 
-	_, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(pk.basis, values, config)
 
+	return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+	if len(pk) != len(values) {
+		err = fmt.Errorf("must have as many value vectors as bases")
+		return
+	}
+
+	if len(pk) == 1 { // no need to fold
+		return pk[0].ProveKnowledge(values[0])
+	}
+
+	offset := 0
+	for i := range pk {
+		if len(values[i]) != len(pk[i].basis) {
+			err = fmt.Errorf("must have as many values as basis elements")
+			return
+		}
+		offset += len(values[i])
+	}
+
+	var r fr.Element
+	if r, err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+
+	// prepare one amalgamated MSM
+	scaledValues := make([]fr.Element, offset)
+	basis := make([]curve.G1Affine, offset)
+
+	copy(basis, pk[0].basisExpSigma)
+	copy(scaledValues, values[0])
+
+	offset = len(values[0])
+	rI := r
+	for i := 1; i < len(pk); i++ {
+		copy(basis[offset:], pk[i].basisExpSigma)
+		for j := range pk[i].basis {
+			scaledValues[offset].Mul(&values[i][j], &rI)
+			offset++
+		}
+		if i+1 < len(pk) {
+			rI.Mul(&rI, &r)
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+
+	_, err = pok.MultiExp(basis, scaledValues, config)
+	return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
 	return
 }
 
@@ -108,14 +230,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-	if err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
 		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
 	}
-	if product.IsOne() {
-		return nil
-	}
-	return fmt.Errorf("proof rejected")
+	return nil
 }
 
 // Marshal

--- a/ecc/bw6-761/fr/pedersen/pedersen.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen.go
@@ -116,25 +116,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
 	return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-	// incorporate user-provided seeds into the transcript
-	t := fiatshamir.NewTranscript(sha256.New(), "r")
-	for i := range fiatshamirSeeds {
-		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-			return
-		}
-	}
-
-	// obtain the challenge
-	var rBytes []byte
-
-	if rBytes, err = t.ComputeChallenge("r"); err != nil {
-		return
-	}
-	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-	return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
 	if len(pk) != len(values) {
@@ -236,6 +217,25 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("proof rejected")
 	}
 	return nil
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+	// incorporate user-provided seeds into the transcript
+	t := fiatshamir.NewTranscript(sha256.New(), "r")
+	for i := range fiatshamirSeeds {
+		if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+			return
+		}
+	}
+
+	// obtain the challenge
+	var rBytes []byte
+
+	if rBytes, err = t.ComputeChallenge("r"); err != nil {
+		return
+	}
+	r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+	return
 }
 
 // Marshal

--- a/ecc/bw6-761/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen_test.go
@@ -106,6 +106,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {

--- a/ecc/bw6-761/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen_test.go
@@ -17,6 +17,7 @@
 package pedersen
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -67,20 +68,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err             error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/internal/generator/pedersen/template/pedersen.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.go.tmpl
@@ -98,25 +98,6 @@ func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, er
     return
 }
 
-func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
-    // incorporate user-provided seeds into the transcript
-    t := fiatshamir.NewTranscript(sha256.New(), "r")
-    for i := range fiatshamirSeeds {
-        if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
-            return
-        }
-    }
-
-    // obtain the challenge
-    var rBytes []byte
-
-    if rBytes, err = t.ComputeChallenge("r"); err != nil {
-        return
-    }
-    r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
-    return
-}
-
 // BatchProve generates a single proof of knowledge for multiple commitments for faster verification
 func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
     if len(pk) != len(values) {
@@ -220,6 +201,24 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 	return nil
 }
 
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+    // incorporate user-provided seeds into the transcript
+    t := fiatshamir.NewTranscript(sha256.New(), "r")
+    for i := range fiatshamirSeeds {
+        if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+            return
+        }
+    }
+
+    // obtain the challenge
+    var rBytes []byte
+
+    if rBytes, err = t.ComputeChallenge("r"); err != nil {
+        return
+    }
+    r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+    return
+}
 
 // Marshal
 

--- a/internal/generator/pedersen/template/pedersen.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.go.tmpl
@@ -1,9 +1,11 @@
 import (
     "crypto/rand"
+	"crypto/sha256"
     "fmt"
     "github.com/consensys/gnark-crypto/ecc"
     curve "github.com/consensys/gnark-crypto/ecc/{{.Name}}"
     "github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	"io"
     "math/big"
 )
@@ -33,7 +35,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
     }
 }
 
-func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
+func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
     if vk.g, err = randomOnG2(); err != nil {
         return
@@ -52,35 +54,155 @@ func Setup(basis []curve.G1Affine) (pk ProvingKey, vk VerifyingKey, err error) {
     sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
     vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
 
-    pk.basisExpSigma = make([]curve.G1Affine, len(basis))
-    for i := range basis {
-        pk.basisExpSigma[i].ScalarMultiplication(&basis[i], sigma)
+    pk = make([]ProvingKey, len(bases))
+    for i := range bases {
+        pk[i].basisExpSigma = make([]curve.G1Affine, len(bases[i]))
+        for j := range bases[i] {
+            pk[i].basisExpSigma[j].ScalarMultiplication(&bases[i][j], sigma)
+        }
+        pk[i].basis = bases[i]
     }
-
-    pk.basis = basis
     return
 }
 
-func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, knowledgeProof curve.G1Affine, err error) {
-
+func (pk *ProvingKey) ProveKnowledge(values []fr.Element) (pok curve.G1Affine, err error) {
     if len(values) != len(pk.basis) {
-        err = fmt.Errorf("unexpected number of values")
+        err = fmt.Errorf("must have as many values as basis elements")
         return
     }
 
     // TODO @gbotrel this will spawn more than one task, see
-    // https://github.com/ConsenSys/gnark-crypto/issues/269 
+    // https://github.com/ConsenSys/gnark-crypto/issues/269
     config := ecc.MultiExpConfig{
-        NbTasks:     1, // TODO Experiment
+        NbTasks: 1, // TODO Experiment
     }
 
-    if _, err = commitment.MultiExp(pk.basis, values, config); err != nil {
+    _, err = pok.MultiExp(pk.basisExpSigma, values, config)
+    return
+}
+
+func (pk *ProvingKey) Commit(values []fr.Element) (commitment curve.G1Affine, err error) {
+
+    if len(values) != len(pk.basis) {
+        err = fmt.Errorf("must have as many values as basis elements")
         return
     }
 
-    _, err = knowledgeProof.MultiExp(pk.basisExpSigma, values, config)
+    // TODO @gbotrel this will spawn more than one task, see
+    // https://github.com/ConsenSys/gnark-crypto/issues/269
+    config := ecc.MultiExpConfig{
+        NbTasks: 1,
+    }
+    _, err = commitment.MultiExp(pk.basis, values, config)
 
     return
+}
+
+func getChallenge(fiatshamirSeeds [][]byte) (r fr.Element, err error) {
+    // incorporate user-provided seeds into the transcript
+    t := fiatshamir.NewTranscript(sha256.New(), "r")
+    for i := range fiatshamirSeeds {
+        if err = t.Bind("r", fiatshamirSeeds[i]); err != nil {
+            return
+        }
+    }
+
+    // obtain the challenge
+    var rBytes []byte
+
+    if rBytes, err = t.ComputeChallenge("r"); err != nil {
+        return
+    }
+    r.SetBytes(rBytes) // TODO @Tabaie Plonk challenge generation done the same way; replace both with hash to fr?
+    return
+}
+
+// BatchProve generates a single proof of knowledge for multiple commitments for faster verification
+func BatchProve(pk []ProvingKey, values [][]fr.Element, fiatshamirSeeds ...[]byte) (pok curve.G1Affine, err error) {
+    if len(pk) != len(values) {
+        err = fmt.Errorf("must have as many value vectors as bases")
+        return
+    }
+
+    if len(pk) == 1 { // no need to fold
+        return pk[0].ProveKnowledge(values[0])
+    }
+
+    offset := 0
+    for i := range pk {
+        if len(values[i]) != len(pk[i].basis) {
+            err = fmt.Errorf("must have as many values as basis elements")
+            return
+        }
+        offset += len(values[i])
+    }
+
+    var r fr.Element
+    if r, err = getChallenge(fiatshamirSeeds); err != nil {
+        return
+    }
+
+    // prepare one amalgamated MSM
+    scaledValues := make([]fr.Element, offset)
+    basis := make([]curve.G1Affine, offset)
+
+    copy(basis, pk[0].basisExpSigma)
+    copy(scaledValues, values[0])
+
+    offset = len(values[0])
+    rI := r
+    for i := 1; i < len(pk); i++ {
+        copy(basis[offset:], pk[i].basisExpSigma)
+        for j := range pk[i].basis {
+            scaledValues[offset].Mul(&values[i][j], &rI)
+            offset++
+    }
+        if i+1 < len(pk) {
+            rI.Mul(&rI, &r)
+        }
+    }
+
+    // TODO @gbotrel this will spawn more than one task, see
+    // https://github.com/ConsenSys/gnark-crypto/issues/269
+    config := ecc.MultiExpConfig{
+        NbTasks: 1,
+    }
+
+    _, err = pok.MultiExp(basis, scaledValues, config)
+    return
+}
+
+// FoldCommitments amalgamates
+func FoldCommitments(commitments []curve.G1Affine, fiatshamirSeeds ...[]byte) (commitment curve.G1Affine, err error) {
+
+	if len(commitments) == 1 { // no need to fold
+		commitment = commitments[0]
+		return
+	}
+
+	r := make([]fr.Element, len(commitments))
+	r[0].SetOne()
+	if r[1], err = getChallenge(fiatshamirSeeds); err != nil {
+		return
+	}
+	for i := 2; i < len(commitments); i++ {
+		r[i].Mul(&r[i-1], &r[1])
+	}
+
+	for i := range commitments { // TODO @Tabaie Remove if MSM does subgroup check for you
+		if !commitments[i].IsInSubGroup() {
+			err = fmt.Errorf("subgroup check failed")
+			return
+		}
+	}
+
+	// TODO @gbotrel this will spawn more than one task, see
+	// https://github.com/ConsenSys/gnark-crypto/issues/269
+	config := ecc.MultiExpConfig{
+		NbTasks: 1,
+	}
+	_, err = commitment.MultiExp(commitments, r, config)
+	return
 }
 
 // Verify checks if the proof of knowledge is valid
@@ -90,14 +212,12 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
         return fmt.Errorf("subgroup check failed")
     }
 
-    product, err := curve.Pair([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg})
-    if err != nil {
-        return err
-    }
-    if product.IsOne() {
-        return nil
-    }
-    return fmt.Errorf("proof rejected")
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+		return err
+	} else if !isOne {
+		return fmt.Errorf("proof rejected")
+	}
+	return nil
 }
 
 

--- a/internal/generator/pedersen/template/pedersen.test.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.test.go.tmpl
@@ -1,4 +1,5 @@
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/{{.Name}}"
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
 	"github.com/consensys/gnark-crypto/utils"
@@ -49,20 +50,77 @@ func testCommit(t *testing.T, values ...interface{}) {
 	basis := randomG1Slice(t, len(values))
 
 	var (
-		pk              ProvingKey
+		pk              []ProvingKey
 		vk              VerifyingKey
 		err 			error
 		commitment, pok curve.G1Affine
 	)
+	valuesFr := interfaceSliceToFrSlice(t, values...)
 
 	pk, vk, err = Setup(basis)
 	assert.NoError(t, err)
-	commitment, pok, err = pk.Commit(interfaceSliceToFrSlice(t, values...))
+	commitment, err = pk[0].Commit(valuesFr)
+	assert.NoError(t, err)
+	pok, err = pk[0].ProveKnowledge(valuesFr)
 	assert.NoError(t, err)
 	assert.NoError(t, vk.Verify(commitment, pok))
 
 	pok.Neg(&pok)
 	assert.NotNil(t, vk.Verify(commitment, pok))
+}
+
+func TestFoldProofs(t *testing.T) {
+
+	values := [][]fr.Element{
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+	}
+
+	bases := make([][]curve.G1Affine, len(values))
+	for i := range bases {
+		bases[i] = randomG1Slice(t, len(values[i]))
+	}
+
+	pk, vk, err := Setup(bases...)
+	assert.NoError(t, err)
+
+	commitments := make([]curve.G1Affine, len(values))
+	for i := range values {
+		commitments[i], err = pk[i].Commit(values[i])
+	}
+
+	t.Run("folding with zeros", func(t *testing.T) {
+		pokFolded, err := BatchProve(pk[:2], [][]fr.Element{
+			values[0],
+			make([]fr.Element, len(values[1])),
+		}, []byte("test"))
+		assert.NoError(t, err)
+		var pok curve.G1Affine
+		pok, err = pk[0].ProveKnowledge(values[0])
+		assert.NoError(t, err)
+		assert.Equal(t, pok, pokFolded)
+	})
+
+	run := func(values [][]fr.Element) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			var foldedCommitment curve.G1Affine
+			pok, err := BatchProve(pk[:len(values)], values, []byte("test"))
+			assert.NoError(t, err)
+
+			foldedCommitment, err = FoldCommitments(commitments[:len(values)], []byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, vk.Verify(foldedCommitment, pok))
+
+			pok.Neg(&pok)
+			assert.NotNil(t, vk.Verify(foldedCommitment, pok))
+		}
+	}
+
+	for i := range values {
+		t.Run(fmt.Sprintf("folding %d", i+1), run(values[:i+1]))
+	}
 }
 
 func TestCommitToOne(t *testing.T) {

--- a/internal/generator/pedersen/template/pedersen.test.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.test.go.tmpl
@@ -88,6 +88,7 @@ func TestFoldProofs(t *testing.T) {
 	commitments := make([]curve.G1Affine, len(values))
 	for i := range values {
 		commitments[i], err = pk[i].Commit(values[i])
+		assert.NoError(t, err)
 	}
 
 	t.Run("folding with zeros", func(t *testing.T) {


### PR DESCRIPTION
In anticipation of multicommits for Groth16, this PR provides the possibility to verify proofs of knowledge for Pedersen commitments more efficiently (by reducing the number of MSMs, generating the proof might be a bit faster as well)

Similarly to KZG, a value $r$ is obtained from a single-challenge Fiat-Shamir object using byte arrays provided by the user (the reason for custom byte arrays explained later.) Then instead of shipping $\set{(C_i, \pi_i)\}_i$ where $C_i$ are commitments and $\pi_i$ the corresponding proofs of knowledge, the prover sends $(\set{C_i}_i, \pi \coloneqq \sum_i r^i\pi_i)$.
The verifier in turn computes $C \coloneqq \sum_i r^iC_i$ and instead of checking $e(C_i,g)=e(\pi_i,g^{1/\sigma})$ multiple times, checks once that $e(C,g)=e(\pi,g^{1/\sigma})$.

From the user's perspective, the breaking change is that the function $pk.Commit$ does not yield a proof of knowledge anymore. A later call to $pk.ProveKnoweldge$ or $BatchProve$ will be necessary.

**Remark:** Normally in Fiat-Shamir one would expect hashing all the commitments that are to be verified, perhaps along with a nonce coming from the user. However, if we allow the user to take control of this, in the Groth16+Commitments verifier we could hash the representations of the commitment values in Fr, rather than the larger group elements. An alternative could be for the `Fold` functions to hash the compressed representations of the commitment values directly. Would welcome your input on this design choice.