### PR TITLE
fix: do not read empty slices as nil

### DIFF
--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bls12-378/marshal.go
+++ b/ecc/bls12-378/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -213,7 +213,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bw6-756/marshal.go
+++ b/ecc/bw6-756/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -230,7 +230,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -239,7 +239,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		if err != nil {
 			return
 		}
-		if len(*t) != int(sliceLen) {
+		if len(*t) != int(sliceLen) || *t == nil {
 			*t = make([]G1Affine, sliceLen)
 		}
 		compressed := make([]bool, sliceLen)


### PR DESCRIPTION
This is technically not a major problem, it only causes problems with serialization tests.