### PR TITLE
edwards: optimize point negation

### DIFF
--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls12-378/twistededwards/point_test.go
+++ b/ecc/bls12-378/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bls12-381/bandersnatch/point.go
+++ b/ecc/bls12-381/bandersnatch/point.go
@@ -181,8 +181,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -312,8 +312,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -445,9 +446,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bw6-756/twistededwards/point_test.go
+++ b/ecc/bw6-756/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -182,8 +182,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -313,8 +313,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -470,9 +471,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -779,3 +779,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -166,8 +166,8 @@ func (p *PointAffine) IsOnCurve() bool {
 
 // Neg sets p to -p1 and returns it
 func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
 	return p
 }
 
@@ -297,8 +297,9 @@ func (p *PointProj) IsZero() bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointProj) Neg(p1 *PointProj) *PointProj {
-	p.Set(p1)
-	p.X.Neg(&p.X)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
 	return p
 }
 
@@ -458,9 +459,10 @@ func (p *PointExtended) Equal(p1 *PointExtended) bool {
 // Neg negates point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointExtended) Neg(p1 *PointExtended) *PointExtended {
-	p.Set(p1)
-	p.X.Neg(&p.X)
-	p.T.Neg(&p.T)
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.Z = p1.Z
+	p.T.Neg(&p1.T)
 	return p
 }
 

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -763,3 +763,41 @@ func BenchmarkScalarMulProjective(b *testing.B) {
 		doubleAndAdd.ScalarMultiplication(&a, &s)
 	}
 }
+
+func BenchmarkNeg(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var baseProj PointProj
+		baseProj.FromAffine(&params.Base)
+		var point PointProj
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var baseProj PointExtended
+		baseProj.FromAffine(&params.Base)
+		var point PointExtended
+		point.ScalarMultiplication(&baseProj, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			point.Neg(&point)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds benchmarks for `Neg(...)` of points in Edwards variants, and an optimization to avoid redundant assignment in point coordinates.

If we run the new benchmarks available in the second commit of this branch against the same ones after the optimization here's what we get:
```
name               old time/op  new time/op  delta
pkg:github.com/consensys/gnark-crypto/ecc/bls12-377/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.60ns ± 2%  2.23ns ± 2%  -51.59%  (p=0.008 n=5+5)
Neg/Projective-16  5.28ns ± 3%  2.24ns ± 1%  -57.60%  (p=0.008 n=5+5)
Neg/Extended-16    7.73ns ± 1%  5.02ns ± 6%  -35.04%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bls12-378/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.77ns ± 5%  2.23ns ± 2%  -53.33%  (p=0.008 n=5+5)
Neg/Projective-16  5.29ns ± 4%  2.25ns ± 2%  -57.55%  (p=0.008 n=5+5)
Neg/Extended-16    7.68ns ± 2%  4.88ns ± 1%  -36.51%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bls12-381/bandersnatch goos:linux goarch:amd64
Neg/Affine-16      4.58ns ± 1%  2.22ns ± 1%  -51.60%  (p=0.008 n=5+5)
Neg/Projective-16  5.19ns ± 2%  2.30ns ± 4%  -55.64%  (p=0.016 n=4+5)
Neg/Extended-16    8.02ns ± 7%  5.01ns ± 2%  -37.48%  (p=0.016 n=5+4)
pkg:github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.92ns ±13%  2.24ns ± 1%  -54.54%  (p=0.008 n=5+5)
Neg/Projective-16  5.61ns ± 9%  2.25ns ± 2%  -59.90%  (p=0.008 n=5+5)
Neg/Extended-16    8.04ns ± 5%  5.08ns ± 2%  -36.78%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bls24-315/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.90ns ± 9%  2.25ns ± 1%  -54.10%  (p=0.008 n=5+5)
Neg/Projective-16  5.22ns ± 2%  2.27ns ± 2%  -56.61%  (p=0.008 n=5+5)
Neg/Extended-16    7.80ns ± 5%  4.90ns ± 3%  -37.12%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bls24-317/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.71ns ± 3%  2.29ns ± 4%  -51.37%  (p=0.008 n=5+5)
Neg/Projective-16  5.32ns ± 3%  2.27ns ± 2%  -57.32%  (p=0.008 n=5+5)
Neg/Extended-16    7.75ns ± 4%  5.01ns ± 1%  -35.39%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bn254/twistededwards goos:linux goarch:amd64
Neg/Affine-16      4.61ns ± 1%  2.30ns ± 9%  -50.13%  (p=0.008 n=5+5)
Neg/Projective-16  5.22ns ± 1%  2.25ns ± 2%  -56.86%  (p=0.016 n=4+5)
Neg/Extended-16    7.64ns ± 4%  4.87ns ± 3%  -36.27%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bw6-633/twistededwards goos:linux goarch:amd64
Neg/Affine-16      5.22ns ± 5%  2.56ns ± 5%  -50.99%  (p=0.008 n=5+5)
Neg/Projective-16  6.48ns ± 7%  2.59ns ± 4%  -60.04%  (p=0.008 n=5+5)
Neg/Extended-16    8.96ns ± 1%  6.60ns ± 3%  -26.32%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bw6-756/twistededwards goos:linux goarch:amd64
Neg/Affine-16      6.85ns ± 4%  2.73ns ± 1%  -60.17%  (p=0.008 n=5+5)
Neg/Projective-16  7.25ns ± 9%  2.77ns ± 6%  -61.82%  (p=0.008 n=5+5)
Neg/Extended-16    10.4ns ± 1%   7.2ns ± 1%  -31.14%  (p=0.008 n=5+5)
pkg:github.com/consensys/gnark-crypto/ecc/bw6-761/twistededwards goos:linux goarch:amd64
Neg/Affine-16      6.04ns ± 2%  2.82ns ± 7%  -53.36%  (p=0.016 n=4+5)
Neg/Projective-16  7.11ns ± 4%  2.86ns ± 3%  -59.79%  (p=0.008 n=5+5)
Neg/Extended-16    10.3ns ± 2%   7.4ns ± 6%  -28.31%  (p=0.008 n=5+5)
```

The TL;DR is quite simple: a `.Set(...)` call will copy coordinates that need to be negated afterward, so that's unnecessary work.

I double-checked, and this optimization looks to be already present for the base curves, so it was only missing for edwards variants.