### PR TITLE
multiexp: avoid direct coordinate access to check for zero points

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -634,6 +634,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -572,6 +572,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-377/multiexp_affine.go
+++ b/ecc/bls12-377/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls12-377/multiexp_jacobian.go
+++ b/ecc/bls12-377/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -127,7 +127,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -634,6 +634,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -572,6 +572,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-378/multiexp_affine.go
+++ b/ecc/bls12-378/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls12-378/multiexp_jacobian.go
+++ b/ecc/bls12-378/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -129,7 +129,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -634,6 +634,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -573,6 +573,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls12-381/multiexp_affine.go
+++ b/ecc/bls12-381/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls12-381/multiexp_jacobian.go
+++ b/ecc/bls12-381/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -127,7 +127,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -636,6 +636,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -588,6 +588,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls24-315/multiexp_affine.go
+++ b/ecc/bls24-315/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls24-315/multiexp_jacobian.go
+++ b/ecc/bls24-315/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -127,7 +127,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -636,6 +636,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -588,6 +588,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bls24-317/multiexp_affine.go
+++ b/ecc/bls24-317/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bls24-317/multiexp_jacobian.go
+++ b/ecc/bls24-317/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -127,7 +127,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -605,6 +605,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -577,6 +577,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bn254/multiexp_affine.go
+++ b/ecc/bn254/multiexp_affine.go
@@ -220,7 +220,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -536,7 +536,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bn254/multiexp_jacobian.go
+++ b/ecc/bn254/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -129,7 +129,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -664,6 +664,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -574,6 +574,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-633/multiexp_affine.go
+++ b/ecc/bw6-633/multiexp_affine.go
@@ -219,7 +219,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -475,7 +475,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-633/multiexp_jacobian.go
+++ b/ecc/bw6-633/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -111,7 +111,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -664,6 +664,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -567,6 +567,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-756/multiexp_affine.go
+++ b/ecc/bw6-756/multiexp_affine.go
@@ -219,7 +219,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -475,7 +475,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-756/multiexp_jacobian.go
+++ b/ecc/bw6-756/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -111,7 +111,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -675,6 +675,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -581,6 +581,10 @@ func (p *g2JacExtended) setInfinity() *g2JacExtended {
 	return p
 }
 
+func (p *g2JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G2Affine) fromJacExtended(Q *g2JacExtended) *G2Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/bw6-761/multiexp_affine.go
+++ b/ecc/bw6-761/multiexp_affine.go
@@ -219,7 +219,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)
@@ -475,7 +475,7 @@ func processChunkG2BatchAffine[BJE ibg2JacExtended, B ibG2Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/bw6-761/multiexp_jacobian.go
+++ b/ecc/bw6-761/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)
@@ -113,7 +113,7 @@ func processChunkG2Jacobian[B ibg2JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -605,6 +605,10 @@ func (p *g1JacExtended) setInfinity() *g1JacExtended {
 	return p
 }
 
+func (p *g1JacExtended) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *G1Affine) fromJacExtended(Q *g1JacExtended) *G1Affine {
 	if Q.ZZ.IsZero() {

--- a/ecc/secp256k1/multiexp_affine.go
+++ b/ecc/secp256k1/multiexp_affine.go
@@ -219,7 +219,7 @@ func processChunkG1BatchAffine[BJE ibg1JacExtended, B ibG1Affine, BS bitSet, TP 
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/ecc/secp256k1/multiexp_jacobian.go
+++ b/ecc/secp256k1/multiexp_jacobian.go
@@ -50,7 +50,7 @@ func processChunkG1Jacobian[B ibg1JacExtended](chunk uint64,
 	runningSum.setInfinity()
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
-		if !buckets[k].ZZ.IsZero() {
+		if !buckets[k].IsZero() {
 			runningSum.add(&buckets[k])
 		}
 		total.add(&runningSum)

--- a/internal/generator/ecc/template/multiexp_affine.go.tmpl
+++ b/internal/generator/ecc/template/multiexp_affine.go.tmpl
@@ -224,7 +224,7 @@ func processChunk{{ $.UPointName }}BatchAffine[BJE ib{{ $.TJacobianExtended }},B
 	total.setInfinity()
 	for k := len(buckets) - 1; k >= 0; k-- {
 		runningSum.addMixed(&buckets[k])
-		if !bucketsJE[k].ZZ.IsZero() {
+		if !bucketsJE[k].IsZero() {
 			runningSum.add(&bucketsJE[k])
 		}
 		total.add(&runningSum)

--- a/internal/generator/ecc/template/multiexp_jacobian.go.tmpl
+++ b/internal/generator/ecc/template/multiexp_jacobian.go.tmpl
@@ -54,7 +54,7 @@ func processChunk{{ $.UPointName }}Jacobian[B ib{{ $.TJacobianExtended }}](chunk
    runningSum.setInfinity()
    total.setInfinity()
    for k := len(buckets) - 1; k >= 0; k-- {
-	   if !buckets[k].ZZ.IsZero() {
+	   if !buckets[k].IsZero() {
 		   runningSum.add(&buckets[k])
 	   }
 	   total.add(&runningSum)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -1234,6 +1234,10 @@ func (p *{{ $TJacobianExtended }}) setInfinity() *{{ $TJacobianExtended }} {
 	return p
 }
 
+func (p *{{ $TJacobianExtended }}) IsZero() bool {
+	return p.ZZ.IsZero()
+}
+
 // fromJacExtended sets Q in affine coordinates
 func (p *{{ $TAffine }})  fromJacExtended (Q *{{ $TJacobianExtended }}) *{{ $TAffine }} {
 	if Q.ZZ.IsZero() {


### PR DESCRIPTION
This PR introduces a new `IsZero() bool` method for G1/G2 `JacExtended` points to check if they're the zero element.

In the multiexp algorithm, this is required when aggregating Pippenger buckets while doing the running sum. Apart from multiexp, it can be helpful for clients in general. I can imagine some tension around `IsZero()` vs `IsInfinity()` in the naming, but I leaned towards `IsZero()` since feels more general (since points at infinity aren't always the zero points in all curves).

Considering the new method is very simple, the compiler inlines it, so it shouldn't have any performance hit. 

--- 

The context for this PR is about something other than _implementation purity_. I was trying to adapt the multiexp algorithm to a tw. Edwards curve (i.e: Bandersnatch), where I have to "adapt" these Jacobian points to, e.g., Projective points. So I created point adapters that would override method calls to the other underlying point. But, these direct coordinate accesses made this impossible. 

To be clear, adapting multiexp to an underlying tw. Edwards curve is probably not optimal for performance since there're some affine batch addition tricks applied here that only make sense for short Wiestrass curves. But, since our MSMs were somewhat short, I just wanted to experiment with "how bad" (or good!) using an "untouched" MSM implementation could work for us.

It would be very nice to have some MSM algorithm optimized for tw. Edwards! And in particular, for short MSMs (in our case, we're doing MSM on a basis length of 256). That's another argument to expect the current multiexp not to be ideal since it's more optimized for big MSMs (e.g., SNARKs). I don't know if that's on the roadmap, but it would be great :)

None of what I mentioned in this section is an argument for merging or justifying this PR, but to explain where this came from.
