### PR TITLE
feat: add AsyncReadFrom to fr.Vector and fft.Domain

### DIFF
--- a/ecc/bls12-377/fp/vector.go
+++ b/ecc/bls12-377/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,71 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[40:48])
+				z[1] = binary.BigEndian.Uint64(b[32:40])
+				z[2] = binary.BigEndian.Uint64(b[24:32])
+				z[3] = binary.BigEndian.Uint64(b[16:24])
+				z[4] = binary.BigEndian.Uint64(b[8:16])
+				z[5] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-377/fp/vector_test.go
+++ b/ecc/bls12-377/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls12-377/fr/vector.go
+++ b/ecc/bls12-377/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-377/fr/vector_test.go
+++ b/ecc/bls12-377/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls12-378/fp/vector.go
+++ b/ecc/bls12-378/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,71 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[40:48])
+				z[1] = binary.BigEndian.Uint64(b[32:40])
+				z[2] = binary.BigEndian.Uint64(b[24:32])
+				z[3] = binary.BigEndian.Uint64(b[16:24])
+				z[4] = binary.BigEndian.Uint64(b[8:16])
+				z[5] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-378/fp/vector_test.go
+++ b/ecc/bls12-378/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls12-378/fr/vector.go
+++ b/ecc/bls12-378/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-378/fr/vector_test.go
+++ b/ecc/bls12-378/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls12-381/fp/vector.go
+++ b/ecc/bls12-381/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,71 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[40:48])
+				z[1] = binary.BigEndian.Uint64(b[32:40])
+				z[2] = binary.BigEndian.Uint64(b[24:32])
+				z[3] = binary.BigEndian.Uint64(b[16:24])
+				z[4] = binary.BigEndian.Uint64(b[8:16])
+				z[5] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-381/fp/vector_test.go
+++ b/ecc/bls12-381/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls12-381/fr/vector.go
+++ b/ecc/bls12-381/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-381/fr/vector_test.go
+++ b/ecc/bls12-381/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls24-315/fp/vector.go
+++ b/ecc/bls24-315/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,70 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[32:40])
+				z[1] = binary.BigEndian.Uint64(b[24:32])
+				z[2] = binary.BigEndian.Uint64(b[16:24])
+				z[3] = binary.BigEndian.Uint64(b[8:16])
+				z[4] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-315/fp/vector_test.go
+++ b/ecc/bls24-315/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls24-315/fr/vector.go
+++ b/ecc/bls24-315/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-315/fr/vector_test.go
+++ b/ecc/bls24-315/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls24-317/fp/vector.go
+++ b/ecc/bls24-317/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,70 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[32:40])
+				z[1] = binary.BigEndian.Uint64(b[24:32])
+				z[2] = binary.BigEndian.Uint64(b[16:24])
+				z[3] = binary.BigEndian.Uint64(b[8:16])
+				z[4] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-317/fp/vector_test.go
+++ b/ecc/bls24-317/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bls24-317/fr/vector.go
+++ b/ecc/bls24-317/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-317/fr/vector_test.go
+++ b/ecc/bls24-317/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bn254/fp/vector.go
+++ b/ecc/bn254/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bn254/fp/vector_test.go
+++ b/ecc/bn254/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bn254/fr/vector.go
+++ b/ecc/bn254/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bn254/fr/vector_test.go
+++ b/ecc/bn254/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-633/fp/vector.go
+++ b/ecc/bw6-633/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,75 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[72:80])
+				z[1] = binary.BigEndian.Uint64(b[64:72])
+				z[2] = binary.BigEndian.Uint64(b[56:64])
+				z[3] = binary.BigEndian.Uint64(b[48:56])
+				z[4] = binary.BigEndian.Uint64(b[40:48])
+				z[5] = binary.BigEndian.Uint64(b[32:40])
+				z[6] = binary.BigEndian.Uint64(b[24:32])
+				z[7] = binary.BigEndian.Uint64(b[16:24])
+				z[8] = binary.BigEndian.Uint64(b[8:16])
+				z[9] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-633/fp/vector_test.go
+++ b/ecc/bw6-633/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-633/fr/vector.go
+++ b/ecc/bw6-633/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,70 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[32:40])
+				z[1] = binary.BigEndian.Uint64(b[24:32])
+				z[2] = binary.BigEndian.Uint64(b[16:24])
+				z[3] = binary.BigEndian.Uint64(b[8:16])
+				z[4] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-633/fr/vector_test.go
+++ b/ecc/bw6-633/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-756/fp/vector.go
+++ b/ecc/bw6-756/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,77 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[88:96])
+				z[1] = binary.BigEndian.Uint64(b[80:88])
+				z[2] = binary.BigEndian.Uint64(b[72:80])
+				z[3] = binary.BigEndian.Uint64(b[64:72])
+				z[4] = binary.BigEndian.Uint64(b[56:64])
+				z[5] = binary.BigEndian.Uint64(b[48:56])
+				z[6] = binary.BigEndian.Uint64(b[40:48])
+				z[7] = binary.BigEndian.Uint64(b[32:40])
+				z[8] = binary.BigEndian.Uint64(b[24:32])
+				z[9] = binary.BigEndian.Uint64(b[16:24])
+				z[10] = binary.BigEndian.Uint64(b[8:16])
+				z[11] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-756/fp/vector_test.go
+++ b/ecc/bw6-756/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-756/fr/vector.go
+++ b/ecc/bw6-756/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,71 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[40:48])
+				z[1] = binary.BigEndian.Uint64(b[32:40])
+				z[2] = binary.BigEndian.Uint64(b[24:32])
+				z[3] = binary.BigEndian.Uint64(b[16:24])
+				z[4] = binary.BigEndian.Uint64(b[8:16])
+				z[5] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-756/fr/vector_test.go
+++ b/ecc/bw6-756/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-761/fp/vector.go
+++ b/ecc/bw6-761/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,77 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[88:96])
+				z[1] = binary.BigEndian.Uint64(b[80:88])
+				z[2] = binary.BigEndian.Uint64(b[72:80])
+				z[3] = binary.BigEndian.Uint64(b[64:72])
+				z[4] = binary.BigEndian.Uint64(b[56:64])
+				z[5] = binary.BigEndian.Uint64(b[48:56])
+				z[6] = binary.BigEndian.Uint64(b[40:48])
+				z[7] = binary.BigEndian.Uint64(b[32:40])
+				z[8] = binary.BigEndian.Uint64(b[24:32])
+				z[9] = binary.BigEndian.Uint64(b[16:24])
+				z[10] = binary.BigEndian.Uint64(b[8:16])
+				z[11] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-761/fp/vector_test.go
+++ b/ecc/bw6-761/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/bw6-761/fr/vector.go
+++ b/ecc/bw6-761/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,71 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[40:48])
+				z[1] = binary.BigEndian.Uint64(b[32:40])
+				z[2] = binary.BigEndian.Uint64(b[24:32])
+				z[3] = binary.BigEndian.Uint64(b[16:24])
+				z[4] = binary.BigEndian.Uint64(b[8:16])
+				z[5] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-761/fr/vector_test.go
+++ b/ecc/bw6-761/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/secp256k1/fp/vector.go
+++ b/ecc/secp256k1/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/secp256k1/fp/vector_test.go
+++ b/ecc/secp256k1/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/secp256k1/fr/vector.go
+++ b/ecc/secp256k1/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/secp256k1/fr/vector_test.go
+++ b/ecc/secp256k1/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/stark-curve/fp/vector.go
+++ b/ecc/stark-curve/fp/vector.go
@@ -19,8 +19,12 @@ package fp
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/stark-curve/fp/vector_test.go
+++ b/ecc/stark-curve/fp/vector_test.go
@@ -17,6 +17,7 @@
 package fp
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/ecc/stark-curve/fr/vector.go
+++ b/ecc/stark-curve/fr/vector.go
@@ -19,8 +19,12 @@ package fr
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,69 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[24:32])
+				z[1] = binary.BigEndian.Uint64(b[16:24])
+				z[2] = binary.BigEndian.Uint64(b[8:16])
+				z[3] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/stark-curve/fr/vector_test.go
+++ b/ecc/stark-curve/fr/vector_test.go
@@ -17,6 +17,7 @@
 package fr
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/field/generator/internal/templates/element/tests_vector.go
+++ b/field/generator/internal/templates/element/tests_vector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sort"
 	"reflect"
+	"bytes"
 )
 
 
@@ -36,12 +37,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2,v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1,v2))
+	assert.True(reflect.DeepEqual(v3,v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -52,12 +57,27 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1,v2))
+	assert.True(reflect.DeepEqual(v3,v2))
+}
+
+
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }
 
 `

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -99,7 +99,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		// process the elements in parallel
 		parallel.Execute(int(sliceLen), func(start, end int) {
 			
-			var z Element
+			var z {{.ElementName}}
 			for i:=start; i < end; i++ {
 				// we have to set vector[i]
 				bstart := i*Bytes

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -6,6 +6,10 @@ import (
 	"encoding/binary"
 	"strings"
 	"bytes"
+	"unsafe"
+	"sync/atomic"
+	"github.com/consensys/gnark-crypto/internal/parallel"
+	"fmt"
 )
 
 // Vector represents a slice of {{.ElementName}}.
@@ -29,11 +33,12 @@ func (vector *Vector) MarshalBinary() (data []byte, err error) {
 	return buf.Bytes(), nil
 }
 
+
 // UnmarshalBinary implements encoding.BinaryUnmarshaler
 func (vector *Vector) UnmarshalBinary(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err := vector.ReadFrom(r)
-    return err 
+	return err
 }
 
 // WriteTo implements io.WriterTo and writes a vector of big endian encoded {{.ElementName}}.
@@ -56,6 +61,73 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		} 
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded {{.ElementName}}.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte 
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+        return int64(read), err, chErr
+    }
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+    n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+			
+			var z Element
+			for i:=start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i*Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				{{- range $i := reverse .NbWordsIndexesFull}}
+					{{- $j := mul $i 8}}
+					{{- $k := sub $.NbWords 1}}
+					{{- $k := sub $k $i}}
+					{{- $jj := add $j 8}}
+					z[{{$k}}] = binary.BigEndian.Uint64(b[{{$j}}:{{$jj}}])
+				{{- end}}
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded {{.ElementName}}.

--- a/field/goldilocks/vector.go
+++ b/field/goldilocks/vector.go
@@ -19,8 +19,12 @@ package goldilocks
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"strings"
+	"sync/atomic"
+	"unsafe"
 )
 
 // Vector represents a slice of Element.
@@ -71,6 +75,66 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+// AsyncReadFrom reads a vector of big endian encoded Element.
+// Length of the vector must be encoded as a uint32 on the first 4 bytes.
+// It consumes the needed bytes from the reader and returns the number of bytes read and an error if any.
+// It also returns a channel that will be closed when the validation is done.
+// The validation consist of checking that the elements are smaller than the modulus, and
+// converting them to montgomery form.
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+	chErr := make(chan error, 1)
+	var buf [Bytes]byte
+	if read, err := io.ReadFull(r, buf[:4]); err != nil {
+		close(chErr)
+		return int64(read), err, chErr
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:4])
+
+	n := int64(4)
+	(*vector) = make(Vector, sliceLen)
+	if sliceLen == 0 {
+		close(chErr)
+		return n, nil, chErr
+	}
+
+	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
+	read, err := io.ReadFull(r, bSlice)
+	n += int64(read)
+	if err != nil {
+		close(chErr)
+		return n, err, chErr
+	}
+
+	go func() {
+		var cptErrors uint64
+		// process the elements in parallel
+		parallel.Execute(int(sliceLen), func(start, end int) {
+
+			var z Element
+			for i := start; i < end; i++ {
+				// we have to set vector[i]
+				bstart := i * Bytes
+				bend := bstart + Bytes
+				b := bSlice[bstart:bend]
+				z[0] = binary.BigEndian.Uint64(b[0:8])
+
+				if !z.smallerThanModulus() {
+					atomic.AddUint64(&cptErrors, 1)
+					return
+				}
+				z.toMont()
+				(*vector)[i] = z
+			}
+		})
+
+		if cptErrors > 0 {
+			chErr <- fmt.Errorf("async read: %d elements failed validation", cptErrors)
+		}
+		close(chErr)
+	}()
+	return n, nil, chErr
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/field/goldilocks/vector_test.go
+++ b/field/goldilocks/vector_test.go
@@ -17,6 +17,7 @@
 package goldilocks
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
@@ -47,12 +48,16 @@ func TestVectorRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
 }
 
 func TestVectorEmptyRoundTrip(t *testing.T) {
@@ -63,10 +68,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	b, err := v1.MarshalBinary()
 	assert.NoError(err)
 
-	var v2 Vector
+	var v2, v3 Vector
 
 	err = v2.UnmarshalBinary(b)
 	assert.NoError(err)
 
+	err = v3.unmarshalBinaryAsync(b)
+	assert.NoError(err)
+
 	assert.True(reflect.DeepEqual(v1, v2))
+	assert.True(reflect.DeepEqual(v3, v2))
+}
+
+func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
+	r := bytes.NewReader(data)
+	_, err, chErr := vector.AsyncReadFrom(r)
+	if err != nil {
+		return err
+	}
+	return <-chErr
 }

--- a/internal/generator/fft/template/domain.go.tmpl
+++ b/internal/generator/fft/template/domain.go.tmpl
@@ -282,3 +282,31 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 
 	return dec.BytesRead(), nil
 }
+
+// AsyncReadFrom attempts to decode a domain from Reader. It returns a channel that will be closed
+// when the precomputation is done.
+func (d *Domain) AsyncReadFrom(r io.Reader) (int64, error, chan struct{}) {
+
+	dec := curve.NewDecoder(r)
+
+	toDecode := []interface{}{&d.Cardinality, &d.CardinalityInv, &d.Generator, &d.GeneratorInv, &d.FrMultiplicativeGen, &d.FrMultiplicativeGenInv}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return dec.BytesRead(), err, nil
+		}
+	}
+
+	chDone := make(chan struct{})
+
+	go func() {
+		// twiddle factors
+		d.preComputeTwiddles()
+
+		// store the bit reversed coset tables if needed
+		d.reverseCosetTables()
+		close(chDone)
+	}()
+
+	return dec.BytesRead(), nil, chDone
+}


### PR DESCRIPTION
in gnark, when reading very large proving keys from disk, it helps perf to do some computation async while the rest of the key is read. 
