### PR TITLE
perf/limb-decompose-bytes

### DIFF
--- a/ecc/bn254/fr/sis/sis.go
+++ b/ecc/bn254/fr/sis/sis.go
@@ -366,6 +366,7 @@ func limbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound, degree int, mValue
 	// each of these block (<< 64bits) are interpreted as a coefficient
 	mPos := 0
 	for fieldStart := 0; fieldStart < nbBits; {
+		word := uint64(0)
 		for bitInField := 0; bitInField < fr.Bytes*8; {
 
 			j := bitInField % logTwoBound
@@ -373,16 +374,17 @@ func limbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound, degree int, mValue
 			// r.LogTwoBound < 64; we just use the first word of our element here,
 			// and set the bits from LSB to MSB.
 			at := fieldStart + fr.Bytes*8 - bitInField - 1
-
-			m[mPos][0] |= uint64(bitAt(at) << j)
+			word |= uint64(bitAt(at) << j)
 			bitInField++
 
 			// Check if mPos is zero and mark as non-zero in the bitset if not
 			if j == logTwoBound-1 || bitInField == fr.Bytes*8 {
-				if m[mPos][0] != 0 && mValues != nil {
+				m[mPos][0] = word
+				if word != 0 && mValues != nil {
 					mValues.Set(uint(mPos / degree))
 				}
 				mPos++
+				word = 0
 			}
 		}
 		fieldStart += fr.Bytes * 8

--- a/ecc/bn254/fr/sis/sis.go
+++ b/ecc/bn254/fr/sis/sis.go
@@ -378,11 +378,10 @@ func limbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound, degree int, mValue
 			bitInField++
 
 			// Check if mPos is zero and mark as non-zero in the bitset if not
-			if m[mPos][0] != 0 && mValues != nil {
-				mValues.Set(uint(mPos / degree))
-			}
-
 			if j == logTwoBound-1 || bitInField == fr.Bytes*8 {
+				if m[mPos][0] != 0 && mValues != nil {
+					mValues.Set(uint(mPos / degree))
+				}
 				mPos++
 			}
 		}

--- a/ecc/bn254/fr/sis/sis.go
+++ b/ecc/bn254/fr/sis/sis.go
@@ -357,9 +357,8 @@ func limbDecomposeBytes(buf []byte, m fr.Vector, logTwoBound, degree int, mValue
 		if k >= len(buf) {
 			return 0
 		}
-		b := buf[k]
-		j := i % 8
-		return b >> (7 - j) & 1
+		//i & 7 == i % 8
+		return buf[k] >> (7 - i&7) & 1
 	}
 
 	// we process the input buffer by blocks of r.LogTwoBound bits


### PR DESCRIPTION
# Motivation

This PR aims to improve the performance of `limbDecomposeBytes()` by applying a couple of tweaks without changing the logic of the function.

Improvement:
- changed if-statements to reduce the total number of conditions to be checked
- added a temporary variable `word` that holds the value of `m[Pos][0]` inside the loop to reduce relatively expensive memory access to m[][]
- optimized `bitAt()` function

Note) I switched off the newly added `limbDecomposeBytes64()` for the benchmark.

# Testing

**Test environment:**

AWS Instance: hpc6a.48xlarge
Number of vCPUs: 96
Memory: 384 GiB
OS: Ubuntu 22.04.2 LTS (GNU/Linux 5.19.0-1025-aws x86_64)

Test sizes for single_round bench:
```
	var (
		size      int = 1 << 27
		smallSize int = 1 << 23
		splitSize int = 1 << 12
	)
```

**Test:**

Go to `~/zkevm-monorepo/prover/example/single_round`

Run `sudo go test -timeout 60m -benchmem -run=^$ -tags amd64 -bench ^BenchmarkSingleRound$ github.com/consensys/accelerated-crypto-monorepo/example/single_round`

# Performance

Note) Please note that the performance results depend on the size of the benchmark. Especially, note that the size of the current benchmark SIS is relatively small (comparison 3).

## comparison 1
Total execution time of the benchmark single_round

before this PR: 885.935s
after this PR: 592.166s

This PR reduced the total execution time of the benchmark by 33.16% with the test sizes. 

## comparison 2

The runtime of limbDecomposeBytes() during the benchmark extracted from pprof top:

before this PR:
**0.43hrs  3.58% 80.27%    0.73hrs  6.05%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes**
**0.18hrs  1.51% 88.90%    0.18hrs  1.51%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes.func1 (inline)**

after this PR:
**0.20hrs  4.22% 68.66%    0.34hrs  7.09%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes**
**0.12hrs  2.48% 78.09%    0.12hrs  2.48%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes.func1 (inline)**


## comparison 3

result from benchmark SIS:

before this PR: 90.124s
after this PR: 86.21075s

This PR improved the performance by 4.34%. 


# Appendix

pprof top 20 before this PR:

``` 
File: single_round.test
Type: cpu
Time: Jul 7, 2023 at 3:35pm (UTC)
Duration: 863.64s, Total samples = 12.01hrs (5007.74%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 20
Showing nodes accounting for 11.31hrs, 94.15% of 12.01hrs total
Dropped 842 nodes (cum <= 0.06hrs)
Showing top 20 nodes out of 79
flat  flat%   sum%        cum   cum%
7.27hrs 60.49% 60.49%    7.82hrs 65.11%  github.com/consensys/gnark-crypto/ecc/bn254/fr/fft.difFFT
1.21hrs 10.09% 70.57%    1.22hrs 10.13%  github.com/consensys/gnark-crypto/ecc/bn254/fr.mul
0.74hrs  6.12% 76.70%    0.74hrs  6.16%  github.com/consensys/gnark-crypto/ecc/bn254/fr.(*Element).SetZero (inline)
**0.43hrs  3.58% 80.27%    0.73hrs  6.05%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes**
0.34hrs  2.85% 83.13%    0.34hrs  2.85%  runtime.memclrNoHeapPointers
0.31hrs  2.57% 85.69%    0.31hrs  2.58%  runtime.writeHeapBits.flush
0.20hrs  1.70% 87.40%    0.94hrs  7.86%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.(*RSis).cleanupBuffers
**0.18hrs  1.51% 88.90%    0.18hrs  1.51%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes.func1 (inline)**
0.17hrs  1.40% 90.30%    0.17hrs  1.40%  github.com/consensys/gnark-crypto/ecc/bn254/fr.Butterfly
0.11hrs  0.94% 91.24%    0.11hrs  0.95%  github.com/bits-and-blooms/bitset.(*BitSet).Set
0.10hrs  0.84% 92.08%    0.10hrs  0.84%  runtime.memmove
0.08hrs  0.65% 92.73%    0.08hrs  0.65%  github.com/consensys/accelerated-crypto-monorepo/maths/common/smartvectors.(*Regular).Get
0.03hrs  0.25% 92.98%    0.27hrs  2.22%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.mulModAcc
0.03hrs  0.23% 93.21%    1.06hrs  8.86%  runtime.mallocgc
0.03hrs  0.23% 93.44%    0.32hrs  2.66%  runtime.(*mcache).refill
0.02hrs  0.17% 93.61%    0.25hrs  2.10%  github.com/consensys/accelerated-crypto-monorepo/maths/fft.ditFFT
0.02hrs  0.17% 93.78%    1.23hrs 10.26%  github.com/consensys/gnark-crypto/ecc/bn254/fr.(*Element).Mul (inline)
0.02hrs  0.15% 93.93%    0.08hrs  0.69%  runtime.(*sweepLocked).sweep
0.02hrs  0.13% 94.05%    0.10hrs  0.86%  runtime.(*mheap).allocSpan
0.01hrs 0.097% 94.15%    0.06hrs  0.51%  runtime.(*mheap).initSpan


```



pprof top 20 after this PR:
```
Type: cpu
Time: Jul 7, 2023 at 3:52pm (UTC)
Duration: 570.51s, Total samples = 4.76hrs (3005.84%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 20
Showing nodes accounting for 4.12hrs, 86.55% of 4.76hrs total
Dropped 822 nodes (cum <= 0.02hrs)
Showing top 20 nodes out of 118
flat  flat%   sum%        cum   cum%
1.37hrs 28.84% 28.84%    1.38hrs 28.87%  github.com/consensys/gnark-crypto/ecc/bn254/fr.mul
0.71hrs 14.96% 43.80%    0.72hrs 15.07%  github.com/consensys/gnark-crypto/ecc/bn254/fr.(*Element).SetZero (inline)
0.34hrs  7.16% 50.96%    1.06hrs 22.23%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.(*RSis).cleanupBuffers
0.33hrs  6.96% 57.92%    0.33hrs  6.96%  runtime.memclrNoHeapPointers
0.31hrs  6.52% 64.44%    0.31hrs  6.54%  runtime.writeHeapBits.flush
**0.20hrs  4.22% 68.66%    0.34hrs  7.09%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes**
0.18hrs  3.69% 72.34%    0.18hrs  3.69%  github.com/consensys/gnark-crypto/ecc/bn254/fr.Butterfly
0.16hrs  3.27% 75.61%    0.16hrs  3.28%  github.com/consensys/accelerated-crypto-monorepo/maths/common/smartvectors.(*Regular).Get
**0.12hrs  2.48% 78.09%    0.12hrs  2.48%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.limbDecomposeBytes.func1 (inline)**
0.10hrs  2.07% 80.16%    0.10hrs  2.07%  runtime.memmove
0.06hrs  1.26% 81.43%    0.06hrs  1.26%  runtime.futex
0.04hrs  0.75% 82.17%    0.62hrs 13.09%  github.com/consensys/gnark-crypto/ecc/bn254/fr/fft.difFFT
0.03hrs  0.72% 82.89%    0.05hrs  1.12%  github.com/consensys/gnark-crypto/ecc/bn254/fr.(*Element).Add
0.03hrs  0.71% 83.60%    0.34hrs  7.11%  github.com/consensys/gnark-crypto/ecc/bn254/fr/sis.mulModAcc
0.03hrs  0.65% 84.25%    1.08hrs 22.61%  runtime.mallocgc
0.03hrs  0.61% 84.86%    0.34hrs  7.17%  runtime.(*mcache).refill
0.02hrs  0.47% 85.33%    1.39hrs 29.24%  github.com/consensys/gnark-crypto/ecc/bn254/fr.(*Element).Mul (inline)
0.02hrs  0.43% 85.76%    0.25hrs  5.31%  github.com/consensys/accelerated-crypto-monorepo/maths/fft.ditFFT
0.02hrs   0.4% 86.16%    0.06hrs  1.28%  runtime.gcDrain
0.02hrs  0.39% 86.55%    0.09hrs  1.96%  runtime.(*sweepLocked).sweep

```