### PR TITLE
Small optimization over the memory usage of MiMC

### DIFF
--- a/ecc/bls12-377/fr/mimc/mimc.go
+++ b/ecc/bls12-377/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^**17
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bls12-378/fr/mimc/mimc.go
+++ b/ecc/bls12-378/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bls12-381/fr/mimc/mimc.go
+++ b/ecc/bls12-381/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bls24-315/fr/mimc/mimc.go
+++ b/ecc/bls24-315/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bls24-317/fr/mimc/mimc.go
+++ b/ecc/bls24-317/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp1, tmp2 fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^7
-		var tmp1, tmp2 fr.Element
 		tmp1.Add(&m, &d.h).Add(&tmp1, &mimcConstants[i])
 		tmp2.Square(&tmp1)
 		m.Square(&tmp2).

--- a/ecc/bn254/fr/mimc/mimc.go
+++ b/ecc/bn254/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bw6-633/fr/mimc/mimc.go
+++ b/ecc/bw6-633/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bw6-756/fr/mimc/mimc.go
+++ b/ecc/bw6-756/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/ecc/bw6-761/fr/mimc/mimc.go
+++ b/ecc/bw6-761/fr/mimc/mimc.go
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -142,9 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).

--- a/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
@@ -64,7 +64,7 @@ func NewMiMC() hash.Hash {
 
 // Reset resets the Hash to its initial state.
 func (d *digest) Reset() {
-	d.data = nil
+	d.data = d.data[:0]
 	d.h = fr.Element{0, 0, 0, 0}
 }
 
@@ -144,9 +144,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i:=0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^**17
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).
@@ -164,9 +164,9 @@ func (d *digest) encrypt(m fr.Element) fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp1, tmp2 fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^7
-		var tmp1, tmp2 fr.Element
 		tmp1.Add(&m, &d.h).Add(&tmp1, &mimcConstants[i])
 		tmp2.Square(&tmp1)
 		m.Square(&tmp2).
@@ -184,9 +184,9 @@ func (d *digest) encrypt(m fr.Element) fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
+	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
 		// m = (m+k+c)^5
-		var tmp fr.Element
 		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
 		m.Square(&tmp).
 			Square(&m).


### PR DESCRIPTION
## Description

- `Reset` keeps the same buffer
- `tmp` is allocated once above the loop (turns out that the allocation is not optimized)
