### PR TITLE
perf: improve fft domain  memory footprint

### DIFF
--- a/ecc/bls12-377/fr/fft/fft.go
+++ b/ecc/bls12-377/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bls12-378/fr/fft/fft.go
+++ b/ecc/bls12-378/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bls12-381/fr/fft/fft.go
+++ b/ecc/bls12-381/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bls24-315/fr/fft/fft.go
+++ b/ecc/bls24-315/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bls24-317/fr/fft/fft.go
+++ b/ecc/bls24-317/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bn254/fr/fft/fft.go
+++ b/ecc/bn254/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bw6-633/fr/fft/fft.go
+++ b/ecc/bw6-633/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bw6-756/fr/fft/fft.go
+++ b/ecc/bw6-756/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/ecc/bw6-761/fr/fft/fft.go
+++ b/ecc/bw6-761/fr/fft/fft.go
@@ -44,18 +44,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -109,21 +113,26 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 

--- a/internal/generator/fft/template/domain.go.tmpl
+++ b/internal/generator/fft/template/domain.go.tmpl
@@ -35,11 +35,9 @@ type Domain struct {
 
 	// CosetTable u*<1,g,..,g^(n-1)>
 	CosetTable         []fr.Element
-	CosetTableReversed []fr.Element // optional, this is computed on demand at the creation of the domain
 
 	// CosetTable[i][j] = domain.Generator(i-th)SqrtInv ^ j
 	CosetTableInv         []fr.Element
-	CosetTableInvReversed []fr.Element // optional, this is computed on demand at the creation of the domain
 }
 
 
@@ -89,9 +87,6 @@ func NewDomain(m uint64, shift ...fr.Element) *Domain {
 	// twiddle factors
 	domain.preComputeTwiddles()
 
-	// store the bit reversed coset tables
-	domain.reverseCosetTables()
-
 	return domain
 }
 
@@ -140,15 +135,6 @@ func Generator(m uint64) (fr.Element, error) {
 	var generator fr.Element
 	generator.Exp(rootOfUnity, big.NewInt(int64(expo))) // order x
 	return generator, nil
-}
-
-func (d *Domain) reverseCosetTables() {
-	d.CosetTableReversed = make([]fr.Element, d.Cardinality)
-	d.CosetTableInvReversed = make([]fr.Element, d.Cardinality)
-	copy(d.CosetTableReversed, d.CosetTable)
-	copy(d.CosetTableInvReversed, d.CosetTableInv)
-	BitReverse(d.CosetTableReversed)
-	BitReverse(d.CosetTableInvReversed)
 }
 
 func (d *Domain) preComputeTwiddles() {
@@ -277,9 +263,6 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	// twiddle factors
 	d.preComputeTwiddles()
 
-	// store the bit reversed coset tables if needed
-	d.reverseCosetTables()
-
 	return dec.BytesRead(), nil
 }
 
@@ -303,8 +286,6 @@ func (d *Domain) AsyncReadFrom(r io.Reader) (int64, error, chan struct{}) {
 		// twiddle factors
 		d.preComputeTwiddles()
 
-		// store the bit reversed coset tables if needed
-		d.reverseCosetTables()
 		close(chDone)
 	}()
 

--- a/internal/generator/fft/template/fft.go.tmpl
+++ b/internal/generator/fft/template/fft.go.tmpl
@@ -26,18 +26,22 @@ func (domain *Domain) FFT(a []fr.Element, decimation Decimation, opts ...Option)
 
 	// if coset != 0, scale by coset table
 	if opt.coset {
-		scale := func(cosetTable []fr.Element) {
+		if decimation == DIT {
+			// scale by coset table (in bit reversed order)
 			parallel.Execute(len(a), func(start, end int) {
+				n := uint64(len(a))
+				nn := uint64(64 - bits.TrailingZeros64(n))
 				for i := start; i < end; i++ {
-					a[i].Mul(&a[i], &cosetTable[i])
+					irev := int(bits.Reverse64(uint64(i)) >> nn)
+					a[i].Mul(&a[i], &domain.CosetTable[irev])
 				}
 			}, opt.nbTasks)
-		}
-		if decimation == DIT {
-			scale(domain.CosetTableReversed)
-
 		} else {
-			scale(domain.CosetTable)
+			parallel.Execute(len(a), func(start, end int) {
+				for i := start; i < end; i++ {
+					a[i].Mul(&a[i], &domain.CosetTable[i])
+				}
+			}, opt.nbTasks)
 		}
 	}
 
@@ -91,21 +95,27 @@ func (domain *Domain) FFTInverse(a []fr.Element, decimation Decimation, opts ...
 		return
 	}
 
-	scale := func(cosetTable []fr.Element) {
+
+	if decimation == DIT {
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
-				a[i].Mul(&a[i], &cosetTable[i]).
+				a[i].Mul(&a[i], &domain.CosetTableInv[i]).
 					Mul(&a[i], &domain.CardinalityInv)
 			}
 		}, opt.nbTasks)
-	}
-	if decimation == DIT {
-		scale(domain.CosetTableInv)
 		return
 	}
 
-	// decimation == DIF
-	scale(domain.CosetTableInvReversed)
+	// decimation == DIF, need to access coset table in bit reversed order.
+	parallel.Execute(len(a), func(start, end int) {
+		n := uint64(len(a))
+		nn := uint64(64 - bits.TrailingZeros64(n))
+		for i := start; i < end; i++ {
+			irev := int(bits.Reverse64(uint64(i)) >> nn)
+			a[i].Mul(&a[i], &domain.CosetTableInv[irev]).
+				Mul(&a[i], &domain.CardinalityInv)
+		}
+	}, opt.nbTasks)
 
 }
 


### PR DESCRIPTION
This PR removes precompute of `CosetTableReversed` and `CosetTableInvReversed` in `fft.Domain`. 
In practice these can be accessed from `CosetTable` and `CosetTableInv` .

New version may result in slightly slower FFT on small domains. 

However, for large domains (think large plonk circuit), precomputing these and storing them in RAM contribute to a high memory load, hence the PR.