### PR TITLE
edwards: improve the performance of Add, MixedAdd and IsOnCurve

### DIFF
--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bls12-378/twistededwards/point_test.go
+++ b/ecc/bls12-378/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-378/twistededwards/point_test.go
+++ b/ecc/bls12-378/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bw6-756/twistededwards/point_test.go
+++ b/ecc/bw6-756/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-756/twistededwards/point_test.go
+++ b/ecc/bw6-756/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -161,8 +161,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -174,7 +173,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -190,8 +189,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -204,7 +202,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -330,14 +328,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -382,15 +379,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -896,6 +896,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -906,6 +910,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -817,3 +817,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -145,8 +145,7 @@ func NewPointAffine(x, y fr.Element) PointAffine {
 
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var lhs, rhs, tmp fr.Element
 
@@ -158,7 +157,7 @@ func (p *PointAffine) IsOnCurve() bool {
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &curveParams.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -174,8 +173,7 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fr.Element
 	pRes := new(PointAffine)
@@ -188,7 +186,7 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &curveParams.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -314,14 +312,13 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 // MixedAdd adds a point in projective to a point in affine coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
 func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var B, C, D, E, F, G, H, I fr.Element
 	B.Square(&p1.Z)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -366,15 +363,14 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 // Add adds points in projective coordinates
 // cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
-
-	ecurve := GetEdwardsCurve()
+	initOnce.Do(initCurveParams)
 
 	var A, B, C, D, E, F, G, H, I fr.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -880,6 +880,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 
+		if !point.IsOnCurve() {
+			b.Fatal("point should must be on curve")
+		}
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = point.IsOnCurve()
@@ -890,6 +894,10 @@ func BenchmarkIsOnCurve(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)
 		point.X.Add(&point.X, &point.X)
+
+		if point.IsOnCurve() {
+			b.Fatal("point should not be on curve")
+		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -801,3 +801,99 @@ func BenchmarkNeg(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMixedAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	var point PointAffine
+	point.ScalarMultiplication(&params.Base, &s)
+
+	b.Run("Projective", func(b *testing.B) {
+		var accum PointProj
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum , &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var accum PointExtended
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.MixedAdd(&accum , &point)
+		}
+	})
+}
+
+func BenchmarkAdd(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+	
+	b.Run("Affine", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		var accum PointAffine
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Projective", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointProj
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+	b.Run("Extended", func(b *testing.B) {
+		var pointAff PointAffine
+		pointAff.ScalarMultiplication(&params.Base, &s)
+		var accum, point PointExtended
+		point.FromAffine(&pointAff)
+		accum.setInfinity()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			accum.Add(&accum, &point)
+		}
+	})
+}
+
+func BenchmarkIsOnCurve(b *testing.B) {
+	params := GetEdwardsCurve()
+	var s big.Int
+	s.SetString("52435875175126190479447705081859658376581184513", 10)
+
+	b.Run("positive", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+
+	b.Run("negative", func(b *testing.B) {
+		var point PointAffine
+		point.ScalarMultiplication(&params.Base, &s)
+		point.X.Add(&point.X, &point.X)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = point.IsOnCurve()
+		}
+	})
+}


### PR DESCRIPTION
# Description

This PR improves the performance if Edwards-related curves in methods: `Add`, `MixedAdd` and `IsOnCuve`. The crux of the problem is two indirect allocations produced by `GetEdwardsCurve(...)` call.

I’m pretty sure that, at least for `MixedAdd`, this is a regression since we didn’t have this allocation some version ago. While fixing it, I noticed this was also happening today for `Add` and `IsOnCuve`, so I’m unsure if those are regressions.

The benchmarks also surface a performance problem I’m not fixing in this PR to avoid convoluting topics. I’ll give a brief explanation in the benchmark section below.

## Type of change

- [x]  Performance improvement

# How has this been tested?

This PR doesn’t change the logic or add new border cases, so existing tests cover correct behavior.

# How has this been benchmarked?

The three mentioned methods (`Add`, `MixedAdd` and `IsOnCurve`) didn’t have benchmarks for Edwards curves, so that’s potentially the reason this was not detected before. I’ve created new benchmarks for each of them to measure the effect of this change.

Running these benchmarks before and after this PR:

```jsx
$ benchstat pre.pprof post.pprof                                                             
name                    old time/op    new time/op    delta
MixedAdd/Projective-16     488ns ± 3%     218ns ± 0%   -55.23%  (p=0.000 n=10+8)
MixedAdd/Extended-16       221ns ± 2%     224ns ± 5%      ~     (p=0.148 n=10+10)
Add/Affine-16             4.86µs ± 1%    4.63µs ± 3%    -4.75%  (p=0.000 n=10+10)
Add/Projective-16          501ns ± 2%     238ns ± 1%   -52.45%  (p=0.000 n=10+8)
Add/Extended-16           3.70µs ± 1%    3.68µs ± 3%      ~     (p=0.255 n=10+10)
IsOnCurve/positive-16      357ns ± 3%     107ns ± 4%   -70.03%  (p=0.000 n=9+10)
IsOnCurve/negative-16      351ns ± 3%     108ns ± 4%   -69.12%  (p=0.000 n=9+10)

name                    old alloc/op   new alloc/op   delta
MixedAdd/Projective-16      128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
MixedAdd/Extended-16       0.00B          0.00B           ~     (all equal)
Add/Affine-16               128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Add/Projective-16           128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Add/Extended-16            0.00B          0.00B           ~     (all equal)
IsOnCurve/positive-16       128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
IsOnCurve/negative-16       128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
MixedAdd/Projective-16      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MixedAdd/Extended-16        0.00           0.00           ~     (all equal)
Add/Affine-16               2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Add/Projective-16           2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Add/Extended-16             0.00           0.00           ~     (all equal)
IsOnCurve/positive-16       2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IsOnCurve/negative-16       2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Note: you can run the “before” by checking out commit `53784cadc54d39c1d1` where I’ve included the benchmarks for `master` without the performance improvements.
Note-2: I'm only showing differences for Bandersnatch; but the same would apply to other edwards.

In summary: 2x speedup in computation, and removing both existing allocations.

Now, notice the `Add/Extended` benchmark. This result is unchanged, which makes sense since it didn’t call `GetEdwardsCurve(...)` in the implementation, but the performance is odd since it should be faster than projective. I know the reason, so I[’d recommend seeing this draft PR](https://github.com/Consensys/gnark-crypto/pull/442) and maybe continuing the discussion there. :)