### PR TITLE
Improve performance of point equality checks

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E2
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E2
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E2

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -505,6 +505,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E2
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E2
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E2
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E2
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E2

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -505,6 +505,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E2
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E2
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls12-378/twistededwards/point_test.go
+++ b/ecc/bls12-378/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bls12-381/bandersnatch/point.go
+++ b/ecc/bls12-381/bandersnatch/point.go
@@ -296,10 +296,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls12-381/bandersnatch/point.go
+++ b/ecc/bls12-381/bandersnatch/point.go
@@ -293,7 +293,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E2
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E2
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E2

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -505,6 +505,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E2
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E2
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E4
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E4
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E4

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -505,6 +505,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E4
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E4
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E4
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E4
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E4

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -505,6 +505,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E4
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E4
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -477,6 +477,51 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG1JacEqual(b *testing.B) {
+	var scalar fp.Element
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G1Jac
+	a.ScalarMultiplication(&g1Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fp.Element
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G1Jac
+		aPlus1.AddAssign(&g1Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG1Affine(b *testing.B) {
 
 	var P, R pG1AffineC16

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -177,13 +177,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fptower.E2
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fptower.E2
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -173,9 +173,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fptower.E2

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -504,6 +504,51 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG2JacEqual(b *testing.B) {
+	var scalar fptower.E2
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G2Jac
+	a.ScalarMultiplication(&g2Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fptower.E2
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G2Jac
+		aPlus1.AddAssign(&g2Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG2Affine(b *testing.B) {
 
 	var P, R pG2AffineC16

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -189,9 +189,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -193,13 +193,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -168,9 +168,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -172,13 +172,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -189,9 +189,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -193,13 +193,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -168,9 +168,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -172,13 +172,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bw6-756/twistededwards/point_test.go
+++ b/ecc/bw6-756/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -189,9 +189,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -193,13 +193,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -168,9 +168,14 @@ func (p *G2Jac) Set(a *G2Jac) *G2Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G2Jac) Equal(a *G2Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -172,13 +172,21 @@ func (p *G2Jac) Equal(a *G2Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G2Affine{}
-	_p.FromJacobian(p)
 
-	_a := G2Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -294,7 +294,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -297,10 +297,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -780,7 +780,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -188,13 +188,21 @@ func (p *G1Jac) Equal(a *G1Jac) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := G1Affine{}
-	_p.FromJacobian(p)
 
-	_a := G1Affine{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare fp.Element
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs fp.Element
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -184,9 +184,14 @@ func (p *G1Jac) Set(a *G1Jac) *G1Jac {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *G1Jac) Equal(a *G1Jac) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare fp.Element

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -477,6 +477,51 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 }
 
+func BenchmarkG1JacEqual(b *testing.B) {
+	var scalar fp.Element
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a G1Jac
+	a.ScalarMultiplication(&g1Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared fp.Element
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 G1Jac
+		aPlus1.AddAssign(&g1Gen)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAddG1Affine(b *testing.B) {
 
 	var P, R pG1AffineC15

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -207,9 +207,14 @@ func (p *{{ $TJacobian }}) Set(a *{{ $TJacobian }}) *{{ $TJacobian }} {
 
 // Equal tests if two points (in Jacobian coordinates) are equal
 func (p *{{ $TJacobian }}) Equal(a *{{ $TJacobian }}) bool {
-
-	if p.Z.IsZero() && a.Z.IsZero() {
-		return true
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero() {
+		return a.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if a.Z.IsZero() {
+		return false
 	}
 
 	var pZSquare, aZSquare {{.CoordType}}

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -211,13 +211,21 @@ func (p *{{ $TJacobian }}) Equal(a *{{ $TJacobian }}) bool {
 	if p.Z.IsZero() && a.Z.IsZero() {
 		return true
 	}
-	_p := {{ $TAffine }}{}
-	_p.FromJacobian(p)
 
-	_a := {{ $TAffine }}{}
-	_a.FromJacobian(a)
+	var pZSquare, aZSquare {{.CoordType}}
+	pZSquare.Square(&p.Z)
+	aZSquare.Square(&a.Z)
 
-	return _p.X.Equal(&_a.X) && _p.Y.Equal(&_a.Y)
+	var lhs, rhs {{.CoordType}}
+	lhs.Mul(&p.X, &aZSquare)
+	rhs.Mul(&a.X, &pZSquare)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &aZSquare).Mul(&lhs, &a.Z)
+	rhs.Mul(&a.Y, &pZSquare).Mul(&rhs, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // Neg computes -G

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -584,6 +584,51 @@ func Benchmark{{ $TJacobian }}IsInSubGroup(b *testing.B) {
 
 }
 
+func Benchmark{{ $TJacobian }}Equal(b *testing.B) {
+	var scalar {{ .CoordType}}
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("failed to set scalar: %s", err)
+	}
+
+	var a {{ $TJacobian }}
+	a.ScalarMultiplication(&{{.PointName}}Gen, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		var scalarSquared {{ .CoordType}}
+		scalarSquared.Square(&scalar)
+
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalarSquared)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalarSquared).Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 {{ $TJacobian }}
+		aPlus1.AddAssign(&{{.PointName}}Gen)	
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkBatchAdd{{ $TAffine }}(b *testing.B) {
 
 	var P, R p{{$TAffine}}C{{$c}}

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -281,10 +281,17 @@ func (p *PointProj) Equal(p1 *PointProj) bool {
 	if p.Z.IsZero() || p1.Z.IsZero() {
 		return false
 	}
-	var pAffine, p1Affine PointAffine
-	pAffine.FromProj(p)
-	p1Affine.FromProj(p1)
-	return pAffine.Equal(&p1Affine)
+
+	var lhs, rhs fr.Element
+	lhs.Mul(&p.X, &p1.Z)
+	rhs.Mul(&p1.X, &p.Z)
+	if !lhs.Equal(&rhs) {
+		return false
+	}
+	lhs.Mul(&p.Y, &p1.Z)
+	rhs.Mul(&p1.Y, &p.Z)
+
+	return lhs.Equal(&rhs)
 }
 
 // IsZero returns true if p=0 false otherwise

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -278,7 +278,13 @@ func (p *PointProj) setInfinity() *PointProj {
 // Equal returns true if p=p1 false otherwise
 // If one point is on the affine chart Z=0 it returns false
 func (p *PointProj) Equal(p1 *PointProj) bool {
-	if p.Z.IsZero() || p1.Z.IsZero() {
+	// If one point is infinity, the other must also be infinity.
+	if p.Z.IsZero()  {
+		return p1.Z.IsZero()
+	}
+	// If the other point is infinity, return false since we can't
+	// the following checks would be incorrect.
+	if p1.Z.IsZero() {
 		return false
 	}
 

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -764,7 +764,7 @@ func BenchmarkProjEqual(b *testing.B) {
 
 	b.Run("not equal", func(b *testing.B) {
 		var aPlus1 PointProj
-		aPlus1.Add(&aPlus1, &baseProj)
+		aPlus1.Add(&a, &baseProj)
 
 		// Check the setup.
 		if a.Equal(&aPlus1) {

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -732,6 +732,52 @@ func GenBigInt() gopter.Gen {
 // ------------------------------------------------------------
 // benches
 
+func BenchmarkProjEqual(b *testing.B) {
+	params := GetEdwardsCurve()
+
+	var scalar fr.Element
+	if _, err := scalar.SetRandom(); err != nil {
+		b.Fatalf("error generating random scalar: %v", err)
+	}
+
+	var baseProj PointProj
+	baseProj.FromAffine(&params.Base)
+	var a PointProj
+	a.ScalarMultiplication(&baseProj, big.NewInt(42))
+
+	b.Run("equal", func(b *testing.B) {
+		aZScaled := a
+		aZScaled.X.Mul(&aZScaled.X, &scalar)
+		aZScaled.Y.Mul(&aZScaled.Y, &scalar)
+		aZScaled.Z.Mul(&aZScaled.Z, &scalar)
+
+		// Check the setup.
+		if !a.Equal(&aZScaled) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aZScaled)
+		}
+	})
+
+	b.Run("not equal", func(b *testing.B) {
+		var aPlus1 PointProj
+		aPlus1.Add(&aPlus1, &baseProj)
+
+		// Check the setup.
+		if a.Equal(&aPlus1) {
+			b.Fatalf("invalid test setup")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a.Equal(&aPlus1)
+		}
+	})
+}
+
 func BenchmarkScalarMulExtended(b *testing.B) {
 	params := GetEdwardsCurve()
 	var a PointExtended


### PR DESCRIPTION
# Description

This PR optimizes how point equality checks are done for G1 and twedwards. The previous code transformed points to affine points and then did equality checks requiring two inverses. The new code avoids doing inverses. (I wonder if there was a reason for the current implementation, or if I might need to include something, LMK!).

I also added benchmark codes so we can compare the old and new code.

## Type of change

Please delete options that are not relevant.

- [X] Performance improvement

# How has this been tested?

It runs all existing tests. If this equality check code change breaks the correct logic, it will probably make many tests fail.

# How has this been benchmarked?

I created new benchmarks for equality checks. To test it against `master`, I backported them to the current `master`.

This was run on `AMD Ryzen 7 3800XT 8-Core Processor`.

For succinctness, I'll show the performance difference between BLS12-381 and Bandersnatch curves (but the implementation should fix all the other curves too).

Bandersnatch:
```
name                    old time/op  new time/op  delta
ProjEqual/equal-16      2.45µs ± 2%  0.07µs ± 1%  -97.26%  (p=0.000 n=10+9)
ProjEqual/not_equal-16  2.39µs ± 2%  0.04µs ± 1%  -98.51%  (p=0.000 n=10+9)
```

BLS12-381:
```
name                     old time/op  new time/op  delta
G1JacEqual/equal-16      4.95µs ± 3%  0.23µs ± 1%  -95.44%  (p=0.000 n=10+8)
G1JacEqual/not_equal-16  4.79µs ± 5%  0.11µs ± 1%  -97.61%  (p=0.000 n=9+9)
``` 

In both cases, we can see that `not_equal` bench is faster than `equal` which makes sense since we compare `X` first and `Y` afterwards. In the old code, most of the time is dominated by inverses so `equal` and `not_equal` have similar-ish perf.

