### PR TITLE
clean: remove useless snippet in mulWindowed

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -442,11 +442,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -417,11 +417,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -442,11 +442,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -417,11 +417,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -442,11 +442,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -418,11 +418,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -444,11 +444,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -419,11 +419,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -444,11 +444,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -419,11 +419,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -432,11 +432,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -424,11 +424,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -447,11 +447,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -419,11 +419,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -451,11 +451,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -423,11 +423,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -451,11 +451,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -423,11 +423,7 @@ func (p *G2Jac) mulWindowed(a *G2Jac, s *big.Int) *G2Jac {
 	var ops [3]G2Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g2Infinity)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -432,11 +432,7 @@ func (p *G1Jac) mulWindowed(a *G1Jac, s *big.Int) *G1Jac {
 	var ops [3]G1Jac
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&g1Infinity)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -23,14 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/parallel"
 	"math/big"
 	"runtime"
-	"sync"
 )
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
 
 // G1Affine point in affine coordinates
 type G1Affine struct {

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -8,9 +8,6 @@
 import (
 	"math/big"
 	"runtime"
-	{{- if eq .PointName "g1"}}
-	"sync"
-	{{- end }}
 
 	{{- if .GLV}}
 	"github.com/consensys/gnark-crypto/ecc"
@@ -24,13 +21,6 @@ import (
 	{{- end}}
 )
 
-{{- if eq .PointName "g1"}}
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
-{{- end}}
 
 // {{ $TAffine }} point in affine coordinates
 type {{ $TAffine }} struct {

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -651,11 +651,7 @@ func (p *{{ $TJacobian }}) mulWindowed(a *{{ $TJacobian }}, s *big.Int) *{{ $TJa
 	var ops [3]{{ $TJacobian }}
 
 	ops[0].Set(a)
-	e := s
 	if s.Sign() == -1 {
-		e = bigIntPool.Get().(*big.Int)
-		defer bigIntPool.Put(e)
-		e.Neg(s)
 		ops[0].Neg(&ops[0])
 	}
 	res.Set(&{{ toLower .PointName}}Infinity)


### PR DESCRIPTION
# Description

Minor clean up, pr #451 introduced a snippet that is not used (see https://github.com/Consensys/gnark-crypto/pull/451/files#r1347690325 ) .

