### PR TITLE
feat: add optimal ate pairing variant to bw6-761

### DIFF
--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -40,6 +40,11 @@ type g2JacExtended struct {
 	X, Y, ZZ, ZZZ fp.Element
 }
 
+// g2Proj point in projective coordinates
+type g2Proj struct {
+	x, y, z fp.Element
+}
+
 // -------------------------------------------------------------------------------------------------
 // Affine
 
@@ -879,6 +884,36 @@ func (p *g2JacExtended) doubleMixed(q *G2Affine) *g2JacExtended {
 	p.ZZ.Set(&V)
 	p.ZZZ.Set(&W)
 
+	return p
+}
+
+// -------------------------------------------------------------------------------------------------
+// Homogenous projective
+
+// Set sets p to the provided point
+func (p *g2Proj) Set(a *g2Proj) *g2Proj {
+	p.x, p.y, p.z = a.x, a.y, a.z
+	return p
+}
+
+// Neg computes -G
+func (p *g2Proj) Neg(a *g2Proj) *g2Proj {
+	*p = *a
+	p.y.Neg(&a.y)
+	return p
+}
+
+// FromAffine sets p = Q, p in homogenous projective, Q in affine
+func (p *g2Proj) FromAffine(Q *G2Affine) *g2Proj {
+	if Q.X.IsZero() && Q.Y.IsZero() {
+		p.z.SetZero()
+		p.x.SetOne()
+		p.y.SetOne()
+		return p
+	}
+	p.z.SetOne()
+	p.x.Set(&Q.X)
+	p.y.Set(&Q.Y)
 	return p
 }
 

--- a/ecc/bw6-761/internal/fptower/e6_pairing.go
+++ b/ecc/bw6-761/internal/fptower/e6_pairing.go
@@ -88,6 +88,29 @@ func (z *E6) Expc1(x *E6) *E6 {
 	return z
 }
 
+// MulBy014 multiplication by sparse element (c0,c1,0,0,c4,0)
+func (z *E6) MulBy014(c0, c1, c4 *fp.Element) *E6 {
+
+	var a, b E3
+	var d fp.Element
+
+	a.Set(&z.B0)
+	a.MulBy01(c0, c1)
+
+	b.Set(&z.B1)
+	b.MulBy1(c4)
+	d.Add(c1, c4)
+
+	z.B1.Add(&z.B1, &z.B0)
+	z.B1.MulBy01(c0, &d)
+	z.B1.Sub(&z.B1, &a)
+	z.B1.Sub(&z.B1, &b)
+	z.B0.MulByNonResidue(&b)
+	z.B0.Add(&z.B0, &a)
+
+	return z
+}
+
 // MulBy034 multiplication by sparse element (c0,0,0,c3,c4,0)
 func (z *E6) MulBy034(c0, c3, c4 *fp.Element) *E6 {
 

--- a/ecc/bw6-761/pairing.go
+++ b/ecc/bw6-761/pairing.go
@@ -158,7 +158,7 @@ func FinalExponentiation(z *GT, _z ...*GT) GT {
 
 // MillerLoop Optimal Tate alternative (or twisted ate or Eta revisited)
 // computes the multi-Miller loop
-// ∏ᵢ MillerLoop(Pᵢ, Qᵢ) =
+// ∏ᵢ millerLoop(Pᵢ, Qᵢ) =
 // ∏ᵢ { fᵢ_{x₀+1+λ(x₀³-x₀²-x₀),Pᵢ}(Qᵢ) }
 //
 // Alg.2 in https://eprint.iacr.org/2021/1359.pdf
@@ -220,7 +220,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	var j int8
 
 	if n >= 1 {
-		// i = len(loopCounter0) - 2, separately to avoid an E12 Square
+		// i = len(loopCounter0NAF) - 2, separately to avoid an E12 Square
 		// (Square(res) = 1² = 1)
 		// j = 0
 		// k = 0, separately to avoid MulBy034 (res × ℓ)
@@ -262,12 +262,12 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 	}
 
 	var tmp G1Affine
-	for i := len(loopCounter0) - 3; i >= 1; i-- {
+	for i := len(loopCounter0NAF) - 3; i >= 1; i-- {
 		// (∏ᵢfᵢ)²
 		// mutualize the square among n Miller loops
 		result.Square(&result)
 
-		j = loopCounter1[i]*3 + loopCounter0[i]
+		j = loopCounter1NAF[i]*3 + loopCounter0NAF[i]
 
 		for k := 0; k < n; k++ {
 			// pProj1[1] ← 2pProj1[1] and l0 the tangent ℓ passing 2pProj1[1]
@@ -510,4 +510,209 @@ func (p *g1Proj) lineCompute(evaluations *lineEvaluation, a *G1Affine) {
 	evaluations.r0.Set(&L)
 	evaluations.r1.Neg(&O)
 	evaluations.r2.Set(&J)
+}
+
+// doubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop
+// https://eprint.iacr.org/2013/722.pdf (Section 4.3)
+func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
+
+	// get some Element from our pool
+	var t1, A, B, C, D, E, EE, F, G, H, I, J, K fp.Element
+	A.Mul(&p.x, &p.y)
+	A.Halve()
+	B.Square(&p.y)
+	C.Square(&p.z)
+	D.Double(&C).
+		Add(&D, &C)
+	E.Mul(&D, &bTwistCurveCoeff)
+	F.Double(&E).
+		Add(&F, &E)
+	G.Add(&B, &F)
+	G.Halve()
+	H.Add(&p.y, &p.z).
+		Square(&H)
+	t1.Add(&B, &C)
+	H.Sub(&H, &t1)
+	I.Sub(&E, &B)
+	J.Square(&p.x)
+	EE.Square(&E)
+	K.Double(&EE).
+		Add(&K, &EE)
+
+	// X, Y, Z
+	p.x.Sub(&B, &F).
+		Mul(&p.x, &A)
+	p.y.Square(&G).
+		Sub(&p.y, &K)
+	p.z.Mul(&B, &H)
+
+	// Line evaluation
+	evaluations.r0.Set(&I)
+	evaluations.r1.Double(&J).
+		Add(&evaluations.r1, &J)
+	evaluations.r2.Neg(&H)
+}
+
+// addMixedStep point addition in Mixed Homogenous projective and Affine coordinates
+// https://eprint.iacr.org/2013/722.pdf (Section 4.3)
+func (p *g2Proj) addMixedStep(evaluations *lineEvaluation, a *G2Affine) {
+
+	// get some Element from our pool
+	var Y2Z1, X2Z1, O, L, C, D, E, F, G, H, t0, t1, t2, J fp.Element
+	Y2Z1.Mul(&a.Y, &p.z)
+	O.Sub(&p.y, &Y2Z1)
+	X2Z1.Mul(&a.X, &p.z)
+	L.Sub(&p.x, &X2Z1)
+	C.Square(&O)
+	D.Square(&L)
+	E.Mul(&L, &D)
+	F.Mul(&p.z, &C)
+	G.Mul(&p.x, &D)
+	t0.Double(&G)
+	H.Add(&E, &F).
+		Sub(&H, &t0)
+	t1.Mul(&p.y, &E)
+
+	// X, Y, Z
+	p.x.Mul(&L, &H)
+	p.y.Sub(&G, &H).
+		Mul(&p.y, &O).
+		Sub(&p.y, &t1)
+	p.z.Mul(&E, &p.z)
+
+	t2.Mul(&L, &a.Y)
+	J.Mul(&a.X, &O).
+		Sub(&J, &t2)
+
+	// Line evaluation
+	evaluations.r0.Set(&J)
+	evaluations.r1.Neg(&O)
+	evaluations.r2.Set(&L)
+}
+
+// --- MillerLoop Optimal Ate (for test in gnark.io) ---
+
+// MillerLoopOptAte Optimal Ate
+// f_{u+1,Q}(P) * (f_{u+1})^q_{u^2-2u-1,[u+1]Q}(P) * l^q_{[(u+1)(u^2-2u+1)]Q,-Q}(P)
+// Eq. (4') binary-2NAF in https://hackmd.io/@zkteam/BW6-761-changes
+func MillerLoopOptAte(P []G1Affine, Q []G2Affine) (GT, error) {
+	// check input size match
+	n := len(P)
+	if n == 0 || n != len(Q) {
+		return GT{}, errors.New("invalid inputs sizes")
+	}
+
+	// filter infinity points
+	p := make([]G1Affine, 0, n)
+	q := make([]G2Affine, 0, n)
+
+	for k := 0; k < n; k++ {
+		if P[k].IsInfinity() || Q[k].IsInfinity() {
+			continue
+		}
+		p = append(p, P[k])
+		q = append(q, Q[k])
+	}
+
+	n = len(p)
+
+	var f GT
+	f.SetOne()
+	for k := 0; k < n; k++ {
+		m, err := millerLoopOptAteSingle(p[k], q[k])
+		if err != nil {
+			return GT{}, err
+		}
+		f.Mul(&f, &m)
+	}
+
+	return f, nil
+}
+
+func millerLoopOptAteSingle(p G1Affine, q G2Affine) (GT, error) {
+	// projective points for Q
+	var qProj1, qProj2 g2Proj
+	qProj1.FromAffine(&q)
+	qProj2.FromAffine(&q)
+
+	// f_{u+1,Q}(P)
+	var result1 GT
+	result1.SetOne()
+	var l lineEvaluation
+
+	// i == 62
+	qProj1.doubleStep(&l)
+	// line eval
+	l.r1.Mul(&l.r1, &p.X)
+	l.r2.Mul(&l.r2, &p.Y)
+	result1.MulBy014(&l.r0, &l.r1, &l.r2)
+
+	for i := 61; i >= 0; i-- {
+		result1.Square(&result1)
+
+		qProj1.doubleStep(&l)
+		l.r1.Mul(&l.r1, &p.X)
+		l.r2.Mul(&l.r2, &p.Y)
+		result1.MulBy014(&l.r0, &l.r1, &l.r2)
+
+		if loopCounter0Bin[i] == 0 {
+			continue
+		}
+
+		qProj1.addMixedStep(&l, &q)
+		l.r1.Mul(&l.r1, &p.X)
+		l.r2.Mul(&l.r2, &p.Y)
+		result1.MulBy014(&l.r0, &l.r1, &l.r2)
+	}
+
+	var result1Old, result1Inv GT
+	result1Old.Set(&result1)
+	result1Inv.Conjugate(&result1)
+
+	var uq G2Affine
+	var a fp.Element
+	a.Inverse(&qProj1.z)
+	uq.X.Mul(&qProj1.x, &a)
+	uq.Y.Mul(&qProj1.y, &a)
+
+	// f_{u^2-2u+1,uQ}(P)
+	var result2 GT
+	result2.Set(&result1Old)
+
+	var tmp G2Affine
+	for i := 125; i >= 0; i-- {
+		result2.Square(&result2)
+
+		qProj1.doubleStep(&l)
+		l.r1.Mul(&l.r1, &p.X)
+		l.r2.Mul(&l.r2, &p.Y)
+		result2.MulBy014(&l.r0, &l.r1, &l.r2)
+
+		if loopCounterOptAteNew1NAF[i] == 1 {
+			qProj1.addMixedStep(&l, &uq)
+			l.r1.Mul(&l.r1, &p.X)
+			l.r2.Mul(&l.r2, &p.Y)
+			result2.MulBy014(&l.r0, &l.r1, &l.r2).
+				Mul(&result2, &result1Old)
+		} else if loopCounterOptAteNew1NAF[i] == -1 {
+			tmp.Neg(&uq)
+			qProj1.addMixedStep(&l, &tmp)
+			l.r1.Mul(&l.r1, &p.X)
+			l.r2.Mul(&l.r2, &p.Y)
+			result2.MulBy014(&l.r0, &l.r1, &l.r2).
+				Mul(&result2, &result1Inv)
+		}
+	}
+
+	// l_{(u+1)vQ,-Q}(P)
+	tmp.Neg(&q)
+	qProj1.addMixedStep(&l, &tmp)
+	l.r1.Mul(&l.r1, &p.X)
+	l.r2.Mul(&l.r2, &p.Y)
+	result2.MulBy014(&l.r0, &l.r1, &l.r2)
+
+	result2.Frobenius(&result2).
+		Mul(&result2, &result1)
+
+	return result2, nil
 }

--- a/ecc/bw6-761/pairing_test.go
+++ b/ecc/bw6-761/pairing_test.go
@@ -148,6 +148,41 @@ func TestPairing(t *testing.T) {
 		genR2,
 	))
 
+	properties.Property("[BW6-761] bilinearity (optimal ate)", prop.ForAll(
+		func(a, b fr.Element) bool {
+
+			var res, resa, resb, resab, zero GT
+
+			var ag1 G1Affine
+			var bg2 G2Affine
+
+			var abigint, bbigint, ab big.Int
+
+			a.BigInt(&abigint)
+			b.BigInt(&bbigint)
+			ab.Mul(&abigint, &bbigint)
+
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
+
+			res, _ = MillerLoopOptAte([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
+			res = FinalExponentiation(&res)
+			resa, _ = MillerLoopOptAte([]G1Affine{ag1}, []G2Affine{g2GenAff})
+			resa = FinalExponentiation(&resa)
+			resb, _ = MillerLoopOptAte([]G1Affine{g1GenAff}, []G2Affine{bg2})
+			resb = FinalExponentiation(&resb)
+
+			resab.Exp(res, &ab)
+			resa.Exp(resa, &bbigint)
+			resb.Exp(resb, &abigint)
+
+			return resab.Equal(&resa) && resab.Equal(&resb) && !res.Equal(&zero)
+
+		},
+		genR1,
+		genR2,
+	))
+
 	properties.Property("[BW6-761] PairingCheck", prop.ForAll(
 		func(a, b fr.Element) bool {
 

--- a/internal/generator/config/bw6-761.go
+++ b/internal/generator/config/bw6-761.go
@@ -22,6 +22,7 @@ var BW6_761 = Curve{
 		GLV:              true,
 		CofactorCleaning: true,
 		CRange:           []int{4, 5, 8, 16},
+		Projective:       true,
 	},
 	// 2-isogeny
 	HashE1: &HashSuiteSswu{

--- a/internal/generator/pairing/template/tests/pairing.go.tmpl
+++ b/internal/generator/pairing/template/tests/pairing.go.tmpl
@@ -140,6 +140,42 @@ func TestPairing(t *testing.T) {
 		genR2,
 	))
 
+    {{if eq .Name "bw6-761"}}
+	properties.Property("[{{ toUpper .Name}}] bilinearity (optimal ate)", prop.ForAll(
+		func(a, b fr.Element) bool {
+
+			var res, resa, resb, resab, zero GT
+
+			var ag1 G1Affine
+			var bg2 G2Affine
+
+			var abigint, bbigint, ab big.Int
+
+			a.BigInt(&abigint)
+			b.BigInt(&bbigint)
+			ab.Mul(&abigint, &bbigint)
+
+			ag1.ScalarMultiplication(&g1GenAff, &abigint)
+			bg2.ScalarMultiplication(&g2GenAff, &bbigint)
+
+			res, _ = MillerLoopOptAte([]G1Affine{g1GenAff}, []G2Affine{g2GenAff})
+			res = FinalExponentiation(&res)
+			resa, _ = MillerLoopOptAte([]G1Affine{ag1}, []G2Affine{g2GenAff})
+			resa = FinalExponentiation(&resa)
+			resb, _ = MillerLoopOptAte([]G1Affine{g1GenAff}, []G2Affine{bg2})
+			resb = FinalExponentiation(&resb)
+
+			resab.Exp(res, &ab)
+			resa.Exp(resa, &bbigint)
+			resb.Exp(resb, &abigint)
+
+			return resab.Equal(&resa) && resab.Equal(&resb) && !res.Equal(&zero)
+
+		},
+		genR1,
+		genR2,
+	))
+    {{end}}
 
 	properties.Property("[{{ toUpper .Name}}] PairingCheck", prop.ForAll(
 		func(a, b fr.Element) bool {


### PR DESCRIPTION
# Description

This PR implements an optimal ate variant of the Miller loop for the BW6-761 curve. This corresponds to equation (4') in https://hackmd.io/@gnark/BW6-761-changes. This is needed for testing purposes in https://github.com/Consensys/gnark/pull/846.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Added a test for bilinearity in `pairing_test.go`. 

# How has this been benchmarked?

Benchmarks are not important for this PR as the new method is only used to test the [gnark](gnark.io) circuit implementation. However, this blog post is a good resource for benchamrks https://hackmd.io/@gnark/BW6-761-changes.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

