### PR TITLE
Refactor: re-introduce points in KZG verification key

### DIFF
--- a/ecc/bls12-377/kzg/kzg.go
+++ b/ecc/bls12-377/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bls12377.G2Affine // [G₂, [α]G₂ ]
+	G1    bls12377.G1Affine
 	Lines [2][2][len(bls12377.LoopCounter) - 1]bls12377.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bls12377.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bls12377.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bls12377.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bls12377.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bls12377.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bls12377.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bls12377.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bls12377.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bls12377.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bls12377.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bls12377.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12377.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12377.PairingCheckFixedQ(
 		[]bls12377.G1Affine{totalG1Aff, negH},
-		[][2][len(bls12377.LoopCounter) - 1]bls12377.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12377.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bls12377.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-377/kzg/marshal.go
+++ b/ecc/bls12-377/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12377.Encoder))
 	enc := bls12377.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,
@@ -609,6 +612,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bls12377.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,

--- a/ecc/bls12-378/kzg/kzg.go
+++ b/ecc/bls12-378/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bls12378.G2Affine // [G₂, [α]G₂ ]
+	G1    bls12378.G1Affine
 	Lines [2][2][len(bls12378.LoopCounter) - 1]bls12378.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bls12378.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bls12378.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bls12378.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bls12378.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bls12378.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bls12378.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bls12378.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bls12378.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bls12378.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bls12378.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bls12378.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12378.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12378.PairingCheckFixedQ(
 		[]bls12378.G1Affine{totalG1Aff, negH},
-		[][2][len(bls12378.LoopCounter) - 1]bls12378.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12378.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bls12378.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-378/kzg/marshal.go
+++ b/ecc/bls12-378/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12378.Encoder))
 	enc := bls12378.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,
@@ -609,6 +612,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bls12378.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,

--- a/ecc/bls12-381/kzg/kzg.go
+++ b/ecc/bls12-381/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bls12381.G2Affine // [G₂, [α]G₂ ]
+	G1    bls12381.G1Affine
 	Lines [2][2][len(bls12381.LoopCounter) - 1]bls12381.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bls12381.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bls12381.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bls12381.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bls12381.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bls12381.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bls12381.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bls12381.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bls12381.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bls12381.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bls12381.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bls12381.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls12381.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls12381.PairingCheckFixedQ(
 		[]bls12381.G1Affine{totalG1Aff, negH},
-		[][2][len(bls12381.LoopCounter) - 1]bls12381.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls12381.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bls12381.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls12-381/kzg/marshal.go
+++ b/ecc/bls12-381/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12381.Encoder))
 	enc := bls12381.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,
@@ -609,6 +612,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bls12381.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][62].R0,
 		&vk.Lines[0][0][62].R1,
 		&vk.Lines[0][0][61].R0,

--- a/ecc/bls24-315/kzg/kzg.go
+++ b/ecc/bls24-315/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bls24315.G2Affine // [G₂, [α]G₂ ]
+	G1    bls24315.G1Affine
 	Lines [2][2][len(bls24315.LoopCounter) - 1]bls24315.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bls24315.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bls24315.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bls24315.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bls24315.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bls24315.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bls24315.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bls24315.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bls24315.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bls24315.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bls24315.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bls24315.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bls24315.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bls24315.PairingCheckFixedQ(
 		[]bls24315.G1Affine{totalG1Aff, negH},
-		[][2][len(bls24315.LoopCounter) - 1]bls24315.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bls24315.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bls24315.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls24-315/kzg/marshal.go
+++ b/ecc/bls24-315/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls24315.Encoder))
 	enc := bls24315.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][31].R0,
 		&vk.Lines[0][0][31].R1,
 		&vk.Lines[0][0][30].R0,
@@ -361,6 +364,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bls24315.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][31].R0,
 		&vk.Lines[0][0][31].R1,
 		&vk.Lines[0][0][30].R0,

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bls24317.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bls24-317/kzg/marshal.go
+++ b/ecc/bls24-317/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls24317.Encoder))
 	enc := bls24317.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][31].R0,
 		&vk.Lines[0][0][31].R1,
 		&vk.Lines[0][0][30].R0,
@@ -361,6 +364,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bls24317.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][31].R0,
 		&vk.Lines[0][0][31].R1,
 		&vk.Lines[0][0][30].R0,

--- a/ecc/bn254/kzg/kzg.go
+++ b/ecc/bn254/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bn254.G2Affine // [G₂, [α]G₂ ]
+	G1    bn254.G1Affine
 	Lines [2][2][len(bn254.LoopCounter)]bn254.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bn254.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bn254.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bn254.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bn254.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bn254.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bn254.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bn254.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bn254.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bn254.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bn254.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bn254.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bn254.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bn254.PairingCheckFixedQ(
 		[]bn254.G1Affine{totalG1Aff, negH},
-		[][2][len(bn254.LoopCounter)]bn254.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bn254.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bn254.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bn254/kzg/marshal.go
+++ b/ecc/bn254/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bn254.Encoder)) (i
 	enc := bn254.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][65].R0,
 		&vk.Lines[0][0][65].R1,
 		&vk.Lines[0][0][64].R0,
@@ -633,6 +636,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bn254.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][65].R0,
 		&vk.Lines[0][0][65].R1,
 		&vk.Lines[0][0][64].R0,

--- a/ecc/bw6-633/kzg/kzg.go
+++ b/ecc/bw6-633/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bw6633.G2Affine // [G₂, [α]G₂ ]
+	G1    bw6633.G1Affine
 	Lines [2][2][len(bw6633.LoopCounter) - 1]bw6633.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bw6633.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bw6633.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bw6633.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bw6633.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bw6633.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bw6633.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bw6633.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bw6633.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bw6633.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bw6633.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bw6633.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6633.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6633.PairingCheckFixedQ(
 		[]bw6633.G1Affine{totalG1Aff, negH},
-		[][2][len(bw6633.LoopCounter) - 1]bw6633.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6633.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bw6633.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-633/kzg/marshal.go
+++ b/ecc/bw6-633/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bw6633.Encoder)) (
 	enc := bw6633.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][157].R0,
 		&vk.Lines[0][0][157].R1,
 		&vk.Lines[0][0][156].R0,
@@ -1369,6 +1372,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bw6633.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][157].R0,
 		&vk.Lines[0][0][157].R1,
 		&vk.Lines[0][0][156].R0,

--- a/ecc/bw6-756/kzg/kzg.go
+++ b/ecc/bw6-756/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bw6756.G2Affine // [G₂, [α]G₂ ]
+	G1    bw6756.G1Affine
 	Lines [2][2][len(bw6756.LoopCounter) - 1]bw6756.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bw6756.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bw6756.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bw6756.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bw6756.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bw6756.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bw6756.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bw6756.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bw6756.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bw6756.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bw6756.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bw6756.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6756.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6756.PairingCheckFixedQ(
 		[]bw6756.G1Affine{totalG1Aff, negH},
-		[][2][len(bw6756.LoopCounter) - 1]bw6756.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6756.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bw6756.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-756/kzg/marshal.go
+++ b/ecc/bw6-756/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bw6756.Encoder)) (
 	enc := bw6756.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][189].R0,
 		&vk.Lines[0][0][189].R1,
 		&vk.Lines[0][0][188].R0,
@@ -1625,6 +1628,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bw6756.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][189].R0,
 		&vk.Lines[0][0][189].R1,
 		&vk.Lines[0][0][188].R0,

--- a/ecc/bw6-761/kzg/kzg.go
+++ b/ecc/bw6-761/kzg/kzg.go
@@ -49,6 +49,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2    [2]bw6761.G2Affine // [G₂, [α]G₂ ]
+	G1    bw6761.G1Affine
 	Lines [2][2][len(bw6761.LoopCounter) - 1]bw6761.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 }
 
@@ -116,17 +118,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 bw6761.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = bw6761.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = bw6761.PrecomputeLines(btG2)
+		srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = bw6761.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = bw6761.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 bw6761.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = bw6761.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = bw6761.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = bw6761.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = bw6761.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -217,7 +221,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff bw6761.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac bw6761.G1Jac
@@ -240,7 +244,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := bw6761.PairingCheckFixedQ(
 		[]bw6761.G1Affine{totalG1Aff, negH},
-		[][2][len(bw6761.LoopCounter) - 1]bw6761.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit bw6761.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -186,7 +186,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit bw6761.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/ecc/bw6-761/kzg/marshal.go
+++ b/ecc/bw6-761/kzg/marshal.go
@@ -55,6 +55,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bw6761.Encoder)) (
 	enc := bw6761.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][188].R0,
 		&vk.Lines[0][0][188].R1,
 		&vk.Lines[0][0][187].R0,
@@ -1617,6 +1620,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := bw6761.NewDecoder(r)
 
 	toDecode := []interface{}{
+		&vk.G2[0],
+		&vk.G2[1],
+		&vk.G1,
 		&vk.Lines[0][0][188].R0,
 		&vk.Lines[0][0][188].R1,
 		&vk.Lines[0][0][187].R0,

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -31,6 +31,8 @@ type ProvingKey struct {
 
 // VerifyingKey used to verify opening proofs
 type VerifyingKey struct {
+	G2 [2]{{ .CurvePackage }}.G2Affine // [G₂, [α]G₂ ]
+	G1 {{ .CurvePackage }}.G1Affine
 {{- if (eq .Name "bn254")}}
 	Lines [2][2][len({{ .CurvePackage }}.LoopCounter)]{{ .CurvePackage }}.LineEvaluationAff // precomputed pairing lines corresponding to G₂, [α]G₂
 {{- else}}
@@ -102,17 +104,19 @@ func NewSRS(size uint64, bAlpha *big.Int) (*SRS, error) {
 				srs.Pk.G1[i] = g[i%4]
 			}
 		})
-		var btG2 {{ .CurvePackage }}.G2Affine
-		btG2.ScalarMultiplication(&gen2Aff, &bt)
-		srs.Vk.Lines[0] = {{ .CurvePackage }}.PrecomputeLines(gen2Aff)
-		srs.Vk.Lines[1] = {{ .CurvePackage }}.PrecomputeLines(btG2)
+        srs.Vk.G1 = gen1Aff
+		srs.Vk.G2[0] = gen2Aff
+		srs.Vk.G2[1].ScalarMultiplication(&srs.Vk.G2[0], &bt)
+		srs.Vk.Lines[0] = {{ .CurvePackage }}.PrecomputeLines(srs.Vk.G2[0])
+		srs.Vk.Lines[1] = {{ .CurvePackage }}.PrecomputeLines(srs.Vk.G2[1])
 		return &srs, nil
 	}
 	srs.Pk.G1[0] = gen1Aff
-	var bAlphaG2 {{ .CurvePackage }}.G2Affine
-	bAlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
-	srs.Vk.Lines[0] = {{ .CurvePackage }}.PrecomputeLines(gen2Aff)
-	srs.Vk.Lines[1] = {{ .CurvePackage }}.PrecomputeLines(bAlphaG2)
+	srs.Vk.G1 = gen1Aff
+	srs.Vk.G2[0] = gen2Aff
+	srs.Vk.G2[1].ScalarMultiplication(&gen2Aff, bAlpha)
+	srs.Vk.Lines[0] = {{ .CurvePackage }}.PrecomputeLines(srs.Vk.G2[0])
+	srs.Vk.Lines[1] = {{ .CurvePackage }}.PrecomputeLines(srs.Vk.G2[1])
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha
@@ -204,7 +208,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	var claimedValueG1Aff {{ .CurvePackage }}.G1Jac
 	var claimedValueBigInt big.Int
 	proof.ClaimedValue.BigInt(&claimedValueBigInt)
-	claimedValueG1Aff.ScalarMultiplicationBase(&claimedValueBigInt)
+	claimedValueG1Aff.ScalarMultiplicationAffine(&vk.G1, &claimedValueBigInt)
 
 	// [f(α) - f(a)]G₁
 	var fminusfaG1Jac {{ .CurvePackage }}.G1Jac
@@ -228,11 +232,7 @@ func Verify(commitment *Digest, proof *OpeningProof, point fr.Element, vk Verify
 	// e([f(α)-f(a)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
 	check, err := {{ .CurvePackage }}.PairingCheckFixedQ(
 		[]{{ .CurvePackage }}.G1Affine{totalG1Aff, negH},
-{{- if (eq .Name "bn254")}}
-		[][2][len({{ .CurvePackage }}.LoopCounter)]{{ .CurvePackage }}.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
-{{- else}}
-		[][2][len({{ .CurvePackage }}.LoopCounter)-1]{{ .CurvePackage }}.LineEvaluationAff{vk.Lines[0], vk.Lines[1]},
-{{- end}}
+		vk.Lines[:],
 	)
 	if err != nil {
 		return err
@@ -464,7 +464,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	var foldedEvalsCommit {{ .CurvePackage }}.G1Affine
 	var foldedEvalsBigInt big.Int
 	foldedEvals.BigInt(&foldedEvalsBigInt)
-	foldedEvalsCommit.ScalarMultiplicationBase(&foldedEvalsBigInt)
+	foldedEvalsCommit.ScalarMultiplication(&vk.G1, &foldedEvalsBigInt)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	foldedDigests.Sub(&foldedDigests, &foldedEvalsCommit)

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -169,7 +169,8 @@ func TestCommit(t *testing.T) {
 	var fxbi big.Int
 	fx.BigInt(&fxbi)
 	var manualCommit {{ .CurvePackage }}.G1Affine
-	manualCommit.ScalarMultiplicationBase(&fxbi)
+	manualCommit.Set(&testSrs.Vk.G1)
+	manualCommit.ScalarMultiplication(&manualCommit, &fxbi)
 
 	// compare both results
 	if !kzgCommit.Equal(&manualCommit) {

--- a/internal/generator/kzg/template/marshal.go.tmpl
+++ b/internal/generator/kzg/template/marshal.go.tmpl
@@ -38,6 +38,9 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*{{.CurvePackage}}.
 	enc := {{ .CurvePackage }}.NewEncoder(w, options...)
 
 	toEncode := []interface{}{
+        &vk.G2[0],
+        &vk.G2[1],
+        &vk.G1,
         {{- if (eq .Name "bw6-756")}}
 		&vk.Lines[0][0][189].R0,
 		&vk.Lines[0][0][189].R1,
@@ -1652,6 +1655,9 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 	dec := {{ .CurvePackage }}.NewDecoder(r)
 
 	toDecode := []interface{}{
+        &vk.G2[0],
+        &vk.G2[1],
+        &vk.G1,
         {{- if (eq .Name "bw6-756")}}
 		&vk.Lines[0][0][189].R0,
 		&vk.Lines[0][0][189].R1,


### PR DESCRIPTION
# Description

Re-introducing points `G1`, `G2` and `[α]G2` in KZG verification key after #466. This is needed in the Solidity Plonk verifier in gnark. My initial thought was to hardcode the values of the points' coordinates in solidity instead of calling the KZG package, but apparently (cc @ThomasPiellard) Linea (and Aztec) use a different `G1` point than `(1,2)` for BN254. We should also then use `ScalarMultiplication(x, G1)` instead of `ScalarMultiplicationBase(x)`. Anyway it should be flexible for users now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue *on gnark side*)

# How has this been tested?

Same current tests.

# How has this been benchmarked?

NA

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

