### PR TITLE
perf: use inverse as a bijection for bw6-761 mimc

### DIFF
--- a/ecc/bw6-761/fr/mimc/mimc.go
+++ b/ecc/bw6-761/fr/mimc/mimc.go
@@ -142,13 +142,9 @@ func (d *digest) checksum() fr.Element {
 func (d *digest) encrypt(m fr.Element) fr.Element {
 	once.Do(initConstants) // init constants
 
-	var tmp fr.Element
 	for i := 0; i < mimcNbRounds; i++ {
-		// m = (m+k+c)^5
-		tmp.Add(&m, &d.h).Add(&tmp, &mimcConstants[i])
-		m.Square(&tmp).
-			Square(&m).
-			Mul(&m, &tmp)
+		// m = 1/(m+k+c)
+		m.Add(&m, &d.h).Add(&m, &mimcConstants[i]).Inverse(&m)
 	}
 	m.Add(&m, &d.h)
 	return m

--- a/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
@@ -177,6 +177,20 @@ func (d *digest) encrypt(m fr.Element) fr.Element {
 	m.Add(&m, &d.h)
 	return m
 }
+{{ else if eq .Name "bw6-761" }}
+// plain execution of a mimc run
+// m: message
+// k: encryption key
+func (d *digest) encrypt(m fr.Element) fr.Element {
+	once.Do(initConstants) // init constants
+
+	for i := 0; i < mimcNbRounds; i++ {
+		// m = 1/(m+k+c)
+		m.Add(&m, &d.h).Add(&m, &mimcConstants[i]).Inverse(&m)
+	}
+	m.Add(&m, &d.h)
+	return m
+}
 {{ else }}
 // plain execution of a mimc run
 // m: message


### PR DESCRIPTION
# Description

Currently BW6-761 MiMC hash uses `pow5` as a bijection. This PR suggests to use the `Inverse` function instead. This reduces the number of constraints needed for the plonk verifier gadget in gnark (see https://github.com/Consensys/gnark/pull/949) but increases the out-circuit execution time.

TODO: 
- [ ] Security analysis of the number of rounds.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?

Same tests as in the master branch.

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

