### PR TITLE
perf: optimize curve membership test

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -407,8 +407,7 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=1 (nothing to do)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E2
+	var left, right, tmp, ZZ fptower.E2
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -407,8 +407,7 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=1 (nothing to do)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E2
+	var left, right, tmp, ZZ fptower.E2
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=4
 	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E2
+	var left, right, tmp, ZZ fptower.E2
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -407,8 +407,7 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=1 (nothing to do)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E4
+	var left, right, tmp, ZZ fptower.E4
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=4
 	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E4
+	var left, right, tmp, ZZ fptower.E4
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=3
 	fp.MulBy3(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	fp.MulBy3(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fptower.E2
+	var left, right, tmp, ZZ fptower.E2
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.MulBybTwistCurveCoeff(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=4
 	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Double(&tmp).Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -398,8 +398,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bTwistCurveCoeff=8
 	tmp.Double(&tmp).Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-633/pairing.go
+++ b/ecc/bw6-633/pairing.go
@@ -320,7 +320,7 @@ func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 	C.Square(&p.z)
 	D.Double(&C).
 		Add(&D, &C)
-	E.Mul(&D, &bTwistCurveCoeff)
+	E.Double(&D).Double(&E).Double(&E)
 	F.Double(&E).
 		Add(&F, &E)
 	G.Add(&B, &F)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -407,8 +407,7 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=1 (nothing to do)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -398,8 +398,7 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -406,8 +406,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bCurveCoeff=-1
 	tmp.Neg(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Neg(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -398,8 +398,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
+	// Mul tmp by bTwistCurveCoeff=4
 	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -399,8 +399,8 @@ func (p *G2Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bTwistCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Double(&tmp).Double(&tmp)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -394,13 +394,12 @@ func (p *G2Jac) FromAffine(Q *G2Affine) *G2Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G2Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bTwistCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/bw6-761/pairing.go
+++ b/ecc/bw6-761/pairing.go
@@ -284,7 +284,7 @@ func (p *g2Proj) doubleStep(evaluations *lineEvaluation) {
 	C.Square(&p.z)
 	D.Double(&C).
 		Add(&D, &C)
-	E.Mul(&D, &bTwistCurveCoeff)
+	E.Double(&D).Double(&E)
 	F.Double(&E).
 		Add(&F, &E)
 	G.Add(&B, &F)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -402,13 +402,12 @@ func (p *G1Jac) FromAffine(Q *G1Affine) *G1Jac {
 
 // IsOnCurve returns true if p in on the curve
 func (p *G1Jac) IsOnCurve() bool {
-	var left, right, tmp fp.Element
+	var left, right, tmp, ZZ fp.Element
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+	tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -407,8 +407,8 @@ func (p *G1Jac) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
 	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
-		Mul(&tmp, &bCurveCoeff)
+		Mul(&tmp, &ZZ)
+	tmp.Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)
 }

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -406,8 +406,7 @@ func (p *G1Jac) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-	tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+	tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 	tmp.Mul(&tmp, &bCurveCoeff)
 	right.Add(&right, &tmp)
 	return left.Equal(&right)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -434,13 +434,12 @@ func (p *{{ $TJacobian }}) FromAffine(Q *{{ $TAffine }}) *{{ $TJacobian }} {
 
 // IsOnCurve returns true if p in on the curve
 func (p *{{ $TJacobian }}) IsOnCurve() bool {
-	var left, right, tmp  {{.CoordType}}
+	var left, right, tmp, ZZ  {{.CoordType}}
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
-	tmp.Square(&p.Z).
-		Square(&tmp).
-		Mul(&tmp, &p.Z).
-		Mul(&tmp, &p.Z).
+	ZZ.Square(&p.Z)
+    tmp.Square(&ZZ).
+		Mul(&tmp, &ZZ).
 		{{- if eq .PointName "g1"}}
 			Mul(&tmp, &bCurveCoeff)
 		{{- else}}

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -438,16 +438,19 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	left.Square(&p.Y)
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
-    tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ)
+    tmp.Square(&ZZ).Mul(&tmp, &ZZ)
 		{{- if eq .PointName "g1"}}
             {{- if or (eq .Name "bls12-381") (eq .Name "bls24-317") (eq .Name "bw6-633")}}
+                // Mul tmp by bCurveCoeff=4
                 tmp.Double(&tmp).Double(&tmp)
             {{- else if eq .Name "bn254"}}
+                // Mul tmp by bCurveCoeff=3
                 fp.MulBy3(&tmp)
             {{- else if eq .Name "bw6-761"}}
+                // Mul tmp by bCurveCoeff=-1
                 tmp.Neg(&tmp)
             {{- else if or (eq .Name "bls12-377") (eq .Name "bls12-378") (eq .Name "bls24-315") (eq .Name "bw6-756")}}
+                // Mul tmp by bCurveCoeff=1 (nothing to do)
             {{- else}}
                 tmp.Mul(&tmp, &bCurveCoeff)
             {{- end}}
@@ -455,8 +458,10 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             {{- if or (eq .Name "bls12-377") (eq .Name "bls12-381") (eq .Name "bn254") (eq .Name "bls24-315") (eq .Name "bls24-317")}}
                 tmp.MulBybTwistCurveCoeff(&tmp)
             {{- else if eq .Name "bw6-761"}}
+                // Mul tmp by bTwistCurveCoeff=4
                 tmp.Double(&tmp).Double(&tmp)
             {{- else if eq .Name "bw6-633"}}
+                // Mul tmp by bTwistCurveCoeff=8
                 tmp.Double(&tmp).Double(&tmp).Double(&tmp)
             {{- else}}
                 tmp.Mul(&tmp, &bTwistCurveCoeff)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -439,11 +439,28 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	right.Square(&p.X).Mul(&right, &p.X)
 	ZZ.Square(&p.Z)
     tmp.Square(&ZZ).
-		Mul(&tmp, &ZZ).
+		Mul(&tmp, &ZZ)
 		{{- if eq .PointName "g1"}}
-			Mul(&tmp, &bCurveCoeff)
+            {{- if or (eq .Name "bls12-381") (eq .Name "bls24-317") (eq .Name "bw6-633")}}
+                tmp.Double(&tmp).Double(&tmp)
+            {{- else if eq .Name "bn254"}}
+                fp.MulBy3(&tmp)
+            {{- else if eq .Name "bw6-761"}}
+                tmp.Neg(&tmp)
+            {{- else if or (eq .Name "bls12-377") (eq .Name "bls12-378") (eq .Name "bls24-315") (eq .Name "bw6-756")}}
+            {{- else}}
+                tmp.Mul(&tmp, &bCurveCoeff)
+            {{- end}}
 		{{- else}}
-			Mul(&tmp, &bTwistCurveCoeff)
+            {{- if or (eq .Name "bls12-377") (eq .Name "bls12-381") (eq .Name "bn254") (eq .Name "bls24-315") (eq .Name "bls24-317")}}
+                tmp.MulBybTwistCurveCoeff(&tmp)
+            {{- else if eq .Name "bw6-761"}}
+                tmp.Double(&tmp).Double(&tmp)
+            {{- else if eq .Name "bw6-633"}}
+                tmp.Double(&tmp).Double(&tmp).Double(&tmp)
+            {{- else}}
+                tmp.Mul(&tmp, &bTwistCurveCoeff)
+            {{- end}}
 		{{- end}}
 	right.Add(&right, &tmp)
 	return left.Equal(&right)


### PR DESCRIPTION
# Description

This PR optimizes the curve membership test `IsOnCurve()` for all curves on both G1 and G2, by:
- [x] saving 1 Fp mul
- [x] specializing the multiplication by the curve coefficient `b`


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Old `TestG1AffineIsOnCurve` and `TestG2AffineIsOnCurve`

# How has this been benchmarked?

e.g. BLS12-381 on AWS z1d.large:

`G1`  335 ns vs. **190.6** ns
`G2` 624 ns vs. **495.3** ns

Compared to [geth/kilic](https://github.com/ethereum/go-ethereum/tree/master/crypto/bls12381) (cc @asanso, @MariusVanDerWijden):
`G1` 320.7 ns vs. **190.6** ns
`G2` 917.9 ns vs. **495.3** ns

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

