### PR TITLE
refactor: make pedersen vk fields public

### DIFF
--- a/ecc/bls12-377/fr/pedersen/pedersen.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bls12-377/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bls12-378/fr/pedersen/pedersen.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bls12-378/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bls12-381/fr/pedersen/pedersen.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bls12-381/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bls24-315/fr/pedersen/pedersen.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bls24-315/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bls24-317/fr/pedersen/pedersen.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bls24-317/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bn254/fr/pedersen/pedersen.go
+++ b/ecc/bn254/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bn254/fr/pedersen/pedersen_test.go
+++ b/ecc/bn254/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bw6-633/fr/pedersen/pedersen.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bw6-633/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bw6-756/fr/pedersen/pedersen.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bw6-756/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/ecc/bw6-761/fr/pedersen/pedersen.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen.go
@@ -35,8 +35,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-	g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-	gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+	G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+	GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -55,7 +55,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-	if vk.g, err = randomOnG2(); err != nil {
+	if vk.G, err = randomOnG2(); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
 	var sigmaInvNeg big.Int
 	sigmaInvNeg.ModInverse(sigma, fr.Modulus())
 	sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-	vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+	vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
 	pk = make([]ProvingKey, len(bases))
 	for i := range bases {
@@ -215,7 +215,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
 		return fmt.Errorf("subgroup check failed")
 	}
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -290,10 +290,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -309,9 +309,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/ecc/bw6-761/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen_test.go
@@ -173,9 +173,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))

--- a/internal/generator/pedersen/template/pedersen.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.go.tmpl
@@ -17,8 +17,8 @@ type ProvingKey struct {
 }
 
 type VerifyingKey struct {
-    g             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
-    gRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
+    G             curve.G2Affine // TODO @tabaie: does this really have to be randomized?
+    GRootSigmaNeg curve.G2Affine //gRootSigmaNeg = g^{-1/σ}
 }
 
 func randomFrSizedBytes() ([]byte, error) {
@@ -37,7 +37,7 @@ func randomOnG2() (curve.G2Affine, error) { // TODO: Add to G2.go?
 
 func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err error) {
 
-    if vk.g, err = randomOnG2(); err != nil {
+    if vk.G, err = randomOnG2(); err != nil {
         return
     }
 
@@ -52,7 +52,7 @@ func Setup(bases ...[]curve.G1Affine) (pk []ProvingKey, vk VerifyingKey, err err
     var sigmaInvNeg big.Int
     sigmaInvNeg.ModInverse(sigma, fr.Modulus())
     sigmaInvNeg.Sub(fr.Modulus(), &sigmaInvNeg)
-    vk.gRootSigmaNeg.ScalarMultiplication(&vk.g, &sigmaInvNeg)
+    vk.GRootSigmaNeg.ScalarMultiplication(&vk.G, &sigmaInvNeg)
 
     pk = make([]ProvingKey, len(bases))
     for i := range bases {
@@ -197,7 +197,7 @@ func (vk *VerifyingKey) Verify(commitment curve.G1Affine, knowledgeProof curve.G
         return fmt.Errorf("subgroup check failed")
     }
 
-	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.g, vk.gRootSigmaNeg}); err != nil {
+	if isOne, err := curve.PairingCheck([]curve.G1Affine{commitment, knowledgeProof}, []curve.G2Affine{vk.G, vk.GRootSigmaNeg}); err != nil {
 		return err
 	} else if !isOne {
 		return fmt.Errorf("proof rejected")
@@ -272,10 +272,10 @@ func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
 func (vk *VerifyingKey) writeTo(enc *curve.Encoder) (int64, error) {
 	var err error
 
-	if err = enc.Encode(&vk.g); err != nil {
+	if err = enc.Encode(&vk.G); err != nil {
 		return enc.BytesWritten(), err
 	}
-	err = enc.Encode(&vk.gRootSigmaNeg)
+	err = enc.Encode(&vk.GRootSigmaNeg)
 	return enc.BytesWritten(), err
 }
 
@@ -291,9 +291,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)
 	dec := curve.NewDecoder(r, decOptions...)
 	var err error
 
-	if err = dec.Decode(&vk.g); err != nil {
+	if err = dec.Decode(&vk.G); err != nil {
 		return dec.BytesRead(), err
 	}
-	err = dec.Decode(&vk.gRootSigmaNeg)
+	err = dec.Decode(&vk.GRootSigmaNeg)
 	return dec.BytesRead(), err
 }

--- a/internal/generator/pedersen/template/pedersen.test.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.test.go.tmpl
@@ -155,9 +155,9 @@ func TestMarshal(t *testing.T) {
 		vk  VerifyingKey
 		err error
 	)
-	vk.g, err = randomOnG2()
+	vk.G, err = randomOnG2()
 	assert.NoError(t, err)
-	vk.gRootSigmaNeg, err = randomOnG2()
+	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
 	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))


### PR DESCRIPTION
# Description

This PR makes `pedersen.VerifyingKey` fields (`G` and `GRootSigmaNeg`) public to be able to read/copy at `gnark/std/recursion/groth16/verifier.ValueOfVerifyingKey`

## Type of change


# How has this been tested?


# How has this been benchmarked?


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

