### PR TITLE
fix: gkr add gate evaluate

### DIFF
--- a/ecc/bls12-377/fr/gkr/gkr.go
+++ b/ecc/bls12-377/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-377/fr/gkr/gkr.go
+++ b/ecc/bls12-377/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-377/fr/gkr/gkr.go
+++ b/ecc/bls12-377/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bls12-377/fr/gkr/gkr_test.go
+++ b/ecc/bls12-377/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bls12-378/fr/gkr/gkr.go
+++ b/ecc/bls12-378/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-378/fr/gkr/gkr.go
+++ b/ecc/bls12-378/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-378/fr/gkr/gkr.go
+++ b/ecc/bls12-378/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bls12-378/fr/gkr/gkr_test.go
+++ b/ecc/bls12-378/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bls12-381/fr/gkr/gkr.go
+++ b/ecc/bls12-381/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-381/fr/gkr/gkr.go
+++ b/ecc/bls12-381/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls12-381/fr/gkr/gkr.go
+++ b/ecc/bls12-381/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bls12-381/fr/gkr/gkr_test.go
+++ b/ecc/bls12-381/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bls24-315/fr/gkr/gkr.go
+++ b/ecc/bls24-315/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls24-315/fr/gkr/gkr.go
+++ b/ecc/bls24-315/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls24-315/fr/gkr/gkr.go
+++ b/ecc/bls24-315/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bls24-315/fr/gkr/gkr_test.go
+++ b/ecc/bls24-315/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bls24-317/fr/gkr/gkr.go
+++ b/ecc/bls24-317/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls24-317/fr/gkr/gkr.go
+++ b/ecc/bls24-317/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bls24-317/fr/gkr/gkr.go
+++ b/ecc/bls24-317/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bls24-317/fr/gkr/gkr_test.go
+++ b/ecc/bls24-317/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bn254/fr/gkr/gkr_test.go
+++ b/ecc/bn254/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bw6-633/fr/gkr/gkr.go
+++ b/ecc/bw6-633/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-633/fr/gkr/gkr.go
+++ b/ecc/bw6-633/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-633/fr/gkr/gkr.go
+++ b/ecc/bw6-633/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bw6-633/fr/gkr/gkr_test.go
+++ b/ecc/bw6-633/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bw6-756/fr/gkr/gkr.go
+++ b/ecc/bw6-756/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-756/fr/gkr/gkr.go
+++ b/ecc/bw6-756/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-756/fr/gkr/gkr.go
+++ b/ecc/bw6-756/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bw6-756/fr/gkr/gkr_test.go
+++ b/ecc/bw6-756/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/ecc/bw6-761/fr/gkr/gkr.go
+++ b/ecc/bw6-761/fr/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-761/fr/gkr/gkr.go
+++ b/ecc/bw6-761/fr/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/ecc/bw6-761/fr/gkr/gkr.go
+++ b/ecc/bw6-761/fr/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/ecc/bw6-761/fr/gkr/gkr_test.go
+++ b/ecc/bw6-761/fr/gkr/gkr_test.go
@@ -45,6 +45,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []fr.Element{four, three}, []fr.Element{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []fr.Element{four, three}, []fr.Element{two, three})
 }
@@ -201,6 +209,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate:   Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {

--- a/internal/generator/gkr/template/gkr.go.tmpl
+++ b/internal/generator/gkr/template/gkr.go.tmpl
@@ -871,8 +871,10 @@ func (g AddGate) Evaluate(x ...{{.ElementType}}) (res {{.ElementType}}) {
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/internal/generator/gkr/template/gkr.go.tmpl
+++ b/internal/generator/gkr/template/gkr.go.tmpl
@@ -894,7 +894,7 @@ func (g MulGate) Evaluate(x ...{{.ElementType}}) (res {{.ElementType}}) {
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/internal/generator/gkr/template/gkr.go.tmpl
+++ b/internal/generator/gkr/template/gkr.go.tmpl
@@ -869,8 +869,6 @@ func (g AddGate) Evaluate(x ...{{.ElementType}}) (res {{.ElementType}}) {
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {

--- a/internal/generator/gkr/template/gkr.test.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.go.tmpl
@@ -31,6 +31,14 @@ func TestNoGate(t *testing.T) {
 	testManyInstances(t, 1, testNoGate)
 }
 
+func TestSingleAddGateTwoInstances(t *testing.T) {
+	testSingleAddGate(t, []{{.ElementType}}{four, three}, []{{.ElementType}}{two, three})
+}
+
+func TestSingleAddGate(t *testing.T) {
+	testManyInstances(t, 2, testSingleAddGate)
+}
+
 func TestSingleMulGateTwoInstances(t *testing.T) {
 	testSingleMulGate(t, []{{.ElementType}}{four, three}, []{{.ElementType}}{two, three})
 }
@@ -191,6 +199,25 @@ func testNoGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {
 
 	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
 	assert.NoError(t, err, "proof rejected")
+}
+
+func testSingleAddGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {
+	c := make(Circuit, 3)
+	c[2] = Wire{
+		Gate: Gates["add"],
+		Inputs: []*Wire{&c[0], &c[1]},
+	}
+
+	assignment := WireAssignment{&c[0]: inputAssignments[0], &c[1]: inputAssignments[1]}.Complete(c)
+
+	proof, err := Prove(c, assignment, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t,err)
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(1, 1)))
+	assert.NoError(t, err, "proof rejected")
+
+	err = Verify(c, assignment, proof, fiatshamir.WithHash(test_vector_utils.NewMessageCounter(0, 1)))
+	assert.NotNil(t, err, "bad proof accepted")
 }
 
 func testSingleMulGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {

--- a/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
+++ b/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
@@ -909,7 +909,7 @@ func (g MulGate) Evaluate(x ...small_rational.SmallRational) (res small_rational
 	default:
 		res.Mul(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[2])
+			res.Mul(&res, &x[i])
 		}
 	}
 	return

--- a/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
+++ b/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
@@ -886,8 +886,10 @@ func (g AddGate) Evaluate(x ...small_rational.SmallRational) (res small_rational
 		res.Set(&x[0])
 	case 2:
 		res.Add(&x[0], &x[1])
+	default:
+		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[2])
+			res.Add(&res, &x[i])
 		}
 	}
 	return

--- a/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
+++ b/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
@@ -884,8 +884,6 @@ func (g AddGate) Evaluate(x ...small_rational.SmallRational) (res small_rational
 	// set zero
 	case 1:
 		res.Set(&x[0])
-	case 2:
-		res.Add(&x[0], &x[1])
 	default:
 		res.Add(&x[0], &x[1])
 		for i := 2; i < len(x); i++ {


### PR DESCRIPTION
# Description
This PR addresses a bug in the `gkr` package related to the `Evaluate` function of the `AddGate`. The existing logic within the AddGate evaluation function had an error that caused incorrect addition behavior under certain input scenarios. In addition to fixing the bug, this PR includes related tests as well.

https://github.com/Consensys/gnark-crypto/blob/d72fcb379d3eb894fc18ece74a91f835294e1439/ecc/bn254/fr/gkr/gkr.go#L881-L894

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?
# How has this been benchmarked?
# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I did not modify files generated from templates
- [X] `golangci-lint` does not output errors locally
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

