### PR TITLE
feat: ECDSA error types

### DIFF
--- a/ecc/bn254/ecdsa/ecdsa.go
+++ b/ecc/bn254/ecdsa/ecdsa.go
@@ -42,6 +42,13 @@ const (
 	sizeSignature  = 2 * sizeFr
 )
 
+var (
+	// ErrNoSqrtR is returned when x^3+ax+b is not a square in the field. This
+	// is used for public key recovery and allows to detect if the signature is
+	// valid or not.
+	ErrNoSqrtR = errors.New("x^3+ax+b is not a square in the field")
+)
+
 var order = fr.Modulus()
 
 // PublicKey represents an ECDSA public key
@@ -139,7 +146,8 @@ func RecoverP(v uint, r *big.Int) (*bn254.G1Affine, error) {
 	y.Mod(y, fp.Modulus())
 	// y = sqrt(y^2)
 	if y.ModSqrt(y, fp.Modulus()) == nil {
-		return nil, errors.New("no square root")
+		// there is no square root, return error constant
+		return nil, ErrNoSqrtR
 	}
 	// check that y has same oddity as defined by v
 	if y.Bit(0) != yChoice {

--- a/ecc/bn254/ecdsa/ecdsa.go
+++ b/ecc/bn254/ecdsa/ecdsa.go
@@ -116,10 +116,10 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
-// RecoverP recovers the value P (prover commitment) when creating a signature.
+// recoverP recovers the value P (prover commitment) when creating a signature.
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
-func RecoverP(v uint, r *big.Int) (*bn254.G1Affine, error) {
+func recoverP(v uint, r *big.Int) (*bn254.G1Affine, error) {
 	if r.Cmp(fr.Modulus()) >= 0 {
 		return nil, errors.New("r is larger than modulus")
 	}

--- a/ecc/bn254/ecdsa/marshal.go
+++ b/ecc/bn254/ecdsa/marshal.go
@@ -73,7 +73,7 @@ func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
 	if s.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("s is negative")
 	}
-	P, err := RecoverP(v, r)
+	P, err := recoverP(v, r)
 	if err != nil {
 		return err
 	}

--- a/ecc/secp256k1/ecdsa/ecdsa.go
+++ b/ecc/secp256k1/ecdsa/ecdsa.go
@@ -42,6 +42,13 @@ const (
 	sizeSignature  = 2 * sizeFr
 )
 
+var (
+	// ErrNoSqrtR is returned when x^3+ax+b is not a square in the field. This
+	// is used for public key recovery and allows to detect if the signature is
+	// valid or not.
+	ErrNoSqrtR = errors.New("x^3+ax+b is not a square in the field")
+)
+
 var order = fr.Modulus()
 
 // PublicKey represents an ECDSA public key
@@ -139,7 +146,8 @@ func RecoverP(v uint, r *big.Int) (*secp256k1.G1Affine, error) {
 	y.Mod(y, fp.Modulus())
 	// y = sqrt(y^2)
 	if y.ModSqrt(y, fp.Modulus()) == nil {
-		return nil, errors.New("no square root")
+		// there is no square root, return error constant
+		return nil, ErrNoSqrtR
 	}
 	// check that y has same oddity as defined by v
 	if y.Bit(0) != yChoice {

--- a/ecc/secp256k1/ecdsa/ecdsa.go
+++ b/ecc/secp256k1/ecdsa/ecdsa.go
@@ -116,10 +116,10 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
-// RecoverP recovers the value P (prover commitment) when creating a signature.
+// recoverP recovers the value P (prover commitment) when creating a signature.
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
-func RecoverP(v uint, r *big.Int) (*secp256k1.G1Affine, error) {
+func recoverP(v uint, r *big.Int) (*secp256k1.G1Affine, error) {
 	if r.Cmp(fr.Modulus()) >= 0 {
 		return nil, errors.New("r is larger than modulus")
 	}

--- a/ecc/secp256k1/ecdsa/marshal.go
+++ b/ecc/secp256k1/ecdsa/marshal.go
@@ -73,7 +73,7 @@ func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
 	if s.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("s is negative")
 	}
-	P, err := RecoverP(v, r)
+	P, err := recoverP(v, r)
 	if err != nil {
 		return err
 	}

--- a/ecc/stark-curve/ecdsa/ecdsa.go
+++ b/ecc/stark-curve/ecdsa/ecdsa.go
@@ -116,10 +116,10 @@ func HashToInt(hash []byte) *big.Int {
 	return ret
 }
 
-// RecoverP recovers the value P (prover commitment) when creating a signature.
+// recoverP recovers the value P (prover commitment) when creating a signature.
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
-func RecoverP(v uint, r *big.Int) (*starkcurve.G1Affine, error) {
+func recoverP(v uint, r *big.Int) (*starkcurve.G1Affine, error) {
 	if r.Cmp(fr.Modulus()) >= 0 {
 		return nil, errors.New("r is larger than modulus")
 	}

--- a/ecc/stark-curve/ecdsa/ecdsa.go
+++ b/ecc/stark-curve/ecdsa/ecdsa.go
@@ -42,6 +42,13 @@ const (
 	sizeSignature  = 2 * sizeFr
 )
 
+var (
+	// ErrNoSqrtR is returned when x^3+ax+b is not a square in the field. This
+	// is used for public key recovery and allows to detect if the signature is
+	// valid or not.
+	ErrNoSqrtR = errors.New("x^3+ax+b is not a square in the field")
+)
+
 var order = fr.Modulus()
 
 // PublicKey represents an ECDSA public key
@@ -139,7 +146,8 @@ func RecoverP(v uint, r *big.Int) (*starkcurve.G1Affine, error) {
 	y.Mod(y, fp.Modulus())
 	// y = sqrt(y^2)
 	if y.ModSqrt(y, fp.Modulus()) == nil {
-		return nil, errors.New("no square root")
+		// there is no square root, return error constant
+		return nil, ErrNoSqrtR
 	}
 	// check that y has same oddity as defined by v
 	if y.Bit(0) != yChoice {

--- a/ecc/stark-curve/ecdsa/marshal.go
+++ b/ecc/stark-curve/ecdsa/marshal.go
@@ -73,7 +73,7 @@ func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
 	if s.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("s is negative")
 	}
-	P, err := RecoverP(v, r)
+	P, err := recoverP(v, r)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -112,10 +112,10 @@ func HashToInt(hash []byte) *big.Int {
 }
 
 {{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
-// RecoverP recovers the value P (prover commitment) when creating a signature.
+// recoverP recovers the value P (prover commitment) when creating a signature.
 // It uses the recovery information v and part of the decomposed signature r. It
 // is used internally for recovering the public key.
-func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
+func recoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
 	if r.Cmp(fr.Modulus()) >= 0 {
 		return nil, errors.New("r is larger than modulus")
 	}

--- a/internal/generator/ecdsa/template/ecdsa.go.tmpl
+++ b/internal/generator/ecdsa/template/ecdsa.go.tmpl
@@ -30,6 +30,15 @@ const (
 	sizeSignature  = 2 * sizeFr
 )
 
+{{- if or (eq .Name "secp256k1") (eq .Name "bn254") (eq .Name "stark-curve") }}
+var (
+	// ErrNoSqrtR is returned when x^3+ax+b is not a square in the field. This
+	// is used for public key recovery and allows to detect if the signature is
+	// valid or not.
+	ErrNoSqrtR = errors.New("x^3+ax+b is not a square in the field")
+)
+{{- end }}
+
 var order = fr.Modulus()
 
 // PublicKey represents an ECDSA public key
@@ -135,7 +144,8 @@ func RecoverP(v uint, r *big.Int) (*{{ .CurvePackage }}.G1Affine, error) {
 	y.Mod(y, fp.Modulus())
 	// y = sqrt(y^2)
 	if y.ModSqrt(y, fp.Modulus()) == nil {
-		return nil, errors.New("no square root")
+		// there is no square root, return error constant
+		return nil, ErrNoSqrtR
 	}
 	// check that y has same oddity as defined by v
 	if y.Bit(0) != yChoice {

--- a/internal/generator/ecdsa/template/marshal.go.tmpl
+++ b/internal/generator/ecdsa/template/marshal.go.tmpl
@@ -62,7 +62,7 @@ func (pk *PublicKey) RecoverFrom(msg []byte, v uint, r, s *big.Int) error {
 	if s.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("s is negative")
 	}
-	P, err := RecoverP(v, r)
+	P, err := recoverP(v, r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR returns error constants when ECDSA signature is invalid due to `r^3 + ax + b` being quadratic non-residue. This is used in gnark for handling edge cases. This also allows to make an internal method private.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

