### PR TITLE
perf: add kzg.UnsafeToBytes and kzg.UnsafeFromBytes methods

### DIFF
--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bls12377.G1Affine) {

--- a/ecc/bls12-377/kzg/marshal.go
+++ b/ecc/bls12-377/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12377.Encoder))
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bls12377.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bls12377.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bls12-377/kzg/marshal.go
+++ b/ecc/bls12-377/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bls12378.G1Affine) {

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bls12-378/kzg/marshal.go
+++ b/ecc/bls12-378/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378"
+	"github.com/consensys/gnark-crypto/ecc/bls12-378/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12378.Encoder))
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bls12378.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bls12378.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bls12-378/kzg/marshal.go
+++ b/ecc/bls12-378/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bls12381.G1Affine) {

--- a/ecc/bls12-381/kzg/marshal.go
+++ b/ecc/bls12-381/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls12381.Encoder))
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bls12381.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bls12381.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bls12-381/kzg/marshal.go
+++ b/ecc/bls12-381/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bls24315.G1Affine) {

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bls24-315/kzg/marshal.go
+++ b/ecc/bls24-315/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315"
+	"github.com/consensys/gnark-crypto/ecc/bls24-315/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls24315.Encoder))
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bls24315.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bls24315.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bls24-315/kzg/marshal.go
+++ b/ecc/bls24-315/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bls24317.G1Affine) {

--- a/ecc/bls24-317/kzg/marshal.go
+++ b/ecc/bls24-317/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317"
+	"github.com/consensys/gnark-crypto/ecc/bls24-317/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bls24317.Encoder))
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bls24317.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bls24317.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bls24-317/kzg/marshal.go
+++ b/ecc/bls24-317/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bn254.G1Affine) {

--- a/ecc/bn254/kzg/marshal.go
+++ b/ecc/bn254/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bn254/kzg/marshal.go
+++ b/ecc/bn254/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bn254.Encoder)) (i
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bn254.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bn254.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bw6-633/kzg/marshal.go
+++ b/ecc/bw6-633/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bw6756.G1Affine) {

--- a/ecc/bw6-756/kzg/marshal.go
+++ b/ecc/bw6-756/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756"
+	"github.com/consensys/gnark-crypto/ecc/bw6-756/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bw6756.Encoder)) (
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bw6756.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bw6756.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bw6-756/kzg/marshal.go
+++ b/ecc/bw6-756/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -17,6 +17,7 @@
 package kzg
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -620,6 +622,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func fillBenchBasesG1(samplePoints []bw6761.G1Affine) {

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -704,7 +704,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -709,31 +709,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -744,11 +726,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -433,7 +433,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1<<10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1<<8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/ecc/bw6-761/kzg/marshal.go
+++ b/ecc/bw6-761/kzg/marshal.go
@@ -17,7 +17,10 @@
 package kzg
 
 import (
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fp"
 	"io"
 )
 
@@ -74,6 +77,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*bw6761.Encoder)) (
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0 {
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, bw6761.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2*maxG1*fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes+j*8:fp.Bytes+j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]bw6761.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
+		}
+		for j := 0; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes+j*8 : fp.Bytes+j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/ecc/bw6-761/kzg/marshal.go
+++ b/ecc/bw6-761/kzg/marshal.go
@@ -126,17 +126,24 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
 	}
 
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
+	}
+
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints)*2*fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
@@ -148,9 +155,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i*2*fp.Bytes:(i+1)*2*fp.Bytes])
 		for j := 0; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8 : j*8+8])
 		}

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -693,31 +693,13 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 		b.Fatal(err)
 	}
 	
-	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
-	// omitting this one it's slow...
-	// b.Run("ReadFrom", func(b *testing.B) {
-	// 	b.ResetTimer()
-	// 	var buf bytes.Buffer
-	// 	_, err := srs.WriteTo(&buf)
-	// 	if err != nil {
-	// 		b.Fatal(err)
-	// 	}
-	// 	for i := 0; i < b.N; i++ {
-	// 		var newSRS SRS
-	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
-	// 		if err != nil {
-	// 			b.Fatal(err)
-	// 		}
-	// 	}
-	// })
-
 	b.Run("UnsafeReadFrom", func(b *testing.B) {
-		b.ResetTimer()
 		var buf bytes.Buffer
 		_, err := srs.WriteRawTo(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
@@ -728,11 +710,11 @@ func BenchmarkDeserializeSRS(b *testing.B) {
 	})
 
 	b.Run("UnsafeFromBytes", func(b *testing.B) {
-		b.ResetTimer()
 		d, err := srs.UnsafeToBytes()
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var newSRS SRS
 			if err := newSRS.UnsafeFromBytes(d); err != nil {

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -416,7 +416,38 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
 
+func TestUnsafeToBytesTruncating(t *testing.T) {
+	assert := require.New(t)
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1 << 10), big.NewInt(-1))
+	assert.NoError(err)
+
+	// marshal the SRS, but explicitly with less points.
+	d, err := srs.UnsafeToBytes(1 << 9)
+	assert.NoError(err)
+
+	// unmarshal the SRS
+	var newSRS SRS
+	err = newSRS.UnsafeFromBytes(d)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 9 points
+	assert.Equal(1<<9, len(newSRS.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<9], newSRS.Pk.G1)
+
+	// read even less points.
+	var newSRSPartial SRS
+	err = newSRSPartial.UnsafeFromBytes(d, 1 << 8)
+	assert.NoError(err)
+
+	// check that the SRS proving key has only 1 << 8 points
+	assert.Equal(1<<8, len(newSRSPartial.Pk.G1))
+
+	// ensure they are equal to the original SRS
+	assert.Equal(srs.Pk.G1[:1<<8], newSRSPartial.Pk.G1)
 }
 
 const benchSize = 1 << 16

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -688,7 +688,7 @@ func BenchmarkSerializeSRS(b *testing.B) {
 
 func BenchmarkDeserializeSRS(b *testing.B) {
 	// let's create a quick SRS
-	srs, err := NewSRS(ecc.NextPowerOfTwo(1 << 26), big.NewInt(-1))
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1 << 24), big.NewInt(-1))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
+	"bytes"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
@@ -144,6 +145,7 @@ func TestSerializationSRS(t *testing.T) {
 	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
 	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
 	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {
@@ -604,6 +606,109 @@ func BenchmarkToLagrangeG1(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkSerializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1 << 24), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// now we can benchmark the WriteTo, WriteRawTo and UnsafeToBytes methods
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("WriteRawTo", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_, err := srs.WriteRawTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeToBytes", func(b *testing.B) {
+		b.ResetTimer()
+		var d []byte
+		var err error
+		for i := 0; i < b.N; i++ {
+			d, err = srs.UnsafeToBytes()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = d 
+	})
+
+}
+
+func BenchmarkDeserializeSRS(b *testing.B) {
+	// let's create a quick SRS
+	srs, err := NewSRS(ecc.NextPowerOfTwo(1 << 26), big.NewInt(-1))
+	if err != nil {
+		b.Fatal(err)
+	}
+	
+	// now we can benchmark the ReadFrom, ReadRawFrom and UnsafeFromBytes methods
+	// omitting this one it's slow...
+	// b.Run("ReadFrom", func(b *testing.B) {
+	// 	b.ResetTimer()
+	// 	var buf bytes.Buffer
+	// 	_, err := srs.WriteTo(&buf)
+	// 	if err != nil {
+	// 		b.Fatal(err)
+	// 	}
+	// 	for i := 0; i < b.N; i++ {
+	// 		var newSRS SRS
+	// 		_, err := newSRS.ReadFrom(bytes.NewReader(buf.Bytes()))
+	// 		if err != nil {
+	// 			b.Fatal(err)
+	// 		}
+	// 	}
+	// })
+
+	b.Run("UnsafeReadFrom", func(b *testing.B) {
+		b.ResetTimer()
+		var buf bytes.Buffer
+		_, err := srs.WriteRawTo(&buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			_, err := newSRS.UnsafeReadFrom(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnsafeFromBytes", func(b *testing.B) {
+		b.ResetTimer()
+		d, err := srs.UnsafeToBytes()
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			var newSRS SRS
+			if err := newSRS.UnsafeFromBytes(d); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 

--- a/internal/generator/kzg/template/marshal.go.tmpl
+++ b/internal/generator/kzg/template/marshal.go.tmpl
@@ -122,18 +122,26 @@ func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
 // and doesn't encode points in a canonical form.
 // @unstable: the format may change in the future
 func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
-	buf := bytes.NewReader(data)
-
 	// first we read the VerifyingKey; it is small so we re-use ReadFrom
-	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+	n, err := srs.Vk.ReadFrom(bytes.NewReader(data))
+	if err != nil {
 		return err
+	}
+
+	data = data[n:]
+	if len(data) < 8 {
+		return io.ErrUnexpectedEOF
 	}
 
 	// read nb points we encode.
-	var nbPoints uint64
-	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
-		return err
+	nbPoints := binary.LittleEndian.Uint64(data[:8])
+	data = data[8:]
+
+	// check the length of data
+	if len(data) < int(nbPoints) * 2 * fp.Bytes {
+		return io.ErrUnexpectedEOF
 	}
+
 
 	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
 		nbPoints = uint64(maxPkPoints[0])
@@ -144,9 +152,7 @@ func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
 	// read the limbs directly
 	var bbuf [fp.Bytes * 2]byte
 	for i := 0; i < int(nbPoints); i++ {
-		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
-			return err
-		}
+		copy(bbuf[:], data[i * 2 * fp.Bytes:(i+1) * 2 * fp.Bytes])
 		for j:= 0 ; j < fp.Limbs; j++ {
 			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8:j*8+8])
 		}

--- a/internal/generator/kzg/template/marshal.go.tmpl
+++ b/internal/generator/kzg/template/marshal.go.tmpl
@@ -1,7 +1,10 @@
 
 import (
 	"io"
+	"bytes"
+	"encoding/binary"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fp"
 )
 
 // WriteTo writes binary encoding of the ProvingKey
@@ -70,6 +73,88 @@ func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*{{.CurvePackage}}.
 	}
 
 	return enc.BytesWritten(), nil
+}
+
+// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
+func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
+	maxG1 := len(srs.Pk.G1)
+	if len(maxPkPoints) > 0 && maxPkPoints[0] < maxG1 && maxPkPoints[0] > 0{
+		maxG1 = maxPkPoints[0]
+	}
+	// first we write the VerifyingKey; it is small so we re-use WriteTo
+	var buf bytes.Buffer
+
+	if _, err := srs.Vk.writeTo(&buf, {{.CurvePackage}}.RawEncoding()); err != nil {
+		return nil, err
+	}
+
+	buf.Grow(2 * maxG1 * fp.Bytes + 8) // pre-allocate space for the ProvingKey
+
+	// write nb points we encode.
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(maxG1)); err != nil {
+		return nil, err
+	}
+
+	// write the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < maxG1; i++ {
+		for j:= 0 ; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[j*8:j*8+8], srs.Pk.G1[i].X[j])
+		}
+		for j:= 0 ; j < fp.Limbs; j++ {
+			binary.LittleEndian.PutUint64(bbuf[fp.Bytes + j*8:fp.Bytes + j*8+8], srs.Pk.G1[i].Y[j])
+		}
+		if _, err := buf.Write(bbuf[:]); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnsafeFromBytes deserializes the SRS from a byte slice
+// It is meant to be use to achieve fast serialization/deserialization and
+// is not compatible with WriteTo / ReadFrom. It does not do any validation
+// and doesn't encode points in a canonical form.
+// @unstable: the format may change in the future
+func (srs *SRS) UnsafeFromBytes(data []byte, maxPkPoints ...int) error {
+	buf := bytes.NewReader(data)
+
+	// first we read the VerifyingKey; it is small so we re-use ReadFrom
+	if _, err := srs.Vk.ReadFrom(buf); err != nil {
+		return err
+	}
+
+	// read nb points we encode.
+	var nbPoints uint64
+	if err := binary.Read(buf, binary.LittleEndian, &nbPoints); err != nil {
+		return err
+	}
+
+	if len(maxPkPoints) == 1 && maxPkPoints[0] > 0 && int(nbPoints) > maxPkPoints[0] {
+		nbPoints = uint64(maxPkPoints[0])
+	}
+
+	srs.Pk.G1 = make([]{{.CurvePackage}}.G1Affine, nbPoints)
+
+	// read the limbs directly
+	var bbuf [fp.Bytes * 2]byte
+	for i := 0; i < int(nbPoints); i++ {
+		if _, err := io.ReadFull(buf, bbuf[:]); err != nil {
+			return err
+		}
+		for j:= 0 ; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].X[j] = binary.LittleEndian.Uint64(bbuf[j*8:j*8+8])
+		}
+		for j:= 0 ; j < fp.Limbs; j++ {
+			srs.Pk.G1[i].Y[j] = binary.LittleEndian.Uint64(bbuf[fp.Bytes + j*8:fp.Bytes + j*8+8])
+		}
+	}
+	return nil
 }
 
 // WriteTo writes binary encoding of the entire SRS

--- a/kzg/kzg.go
+++ b/kzg/kzg.go
@@ -25,6 +25,9 @@ type Serializable interface {
 
 	WriteRawTo(w io.Writer) (n int64, err error)
 	UnsafeReadFrom(r io.Reader) (int64, error)
+
+	UnsafeToBytes(maxPkPoints ...int) ([]byte, error)
+	UnsafeFromBytes(data []byte, maxPkPoints ...int) error
 }
 
 type SRS Serializable

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Serializable interface {
@@ -15,6 +16,11 @@ type Serializable interface {
 
 type RawSerializable interface {
 	WriteRawTo(io.Writer) (int64, error)
+}
+
+type UnsafeBinaryMarshaler interface {
+	UnsafeToBytes(maxPkPoints ...int) ([]byte, error)
+	UnsafeFromBytes(data []byte, maxPkPoints ...int) error
 }
 
 func SerializationRoundTrip(o Serializable) func(*testing.T) {
@@ -44,6 +50,22 @@ func SerializationRoundTripRaw(o RawSerializable) func(*testing.T) {
 		// reconstruct the object
 		_o := reflect.New(reflect.TypeOf(o).Elem()).Interface().(Serializable)
 		_, err = _o.ReadFrom(&buf)
+		assert.NoError(t, err)
+
+		// compare
+		assert.Equal(t, o, _o)
+	}
+}
+
+func UnsafeBinaryMarshalerRoundTrip(o UnsafeBinaryMarshaler) func(*testing.T) {
+	return func(t *testing.T) {
+		// serialize it...
+		data, err := o.UnsafeToBytes()
+		assert.NoError(t, err)
+
+		// reconstruct the object
+		_o := reflect.New(reflect.TypeOf(o).Elem()).Interface().(UnsafeBinaryMarshaler)
+		err = _o.UnsafeFromBytes(data)
 		assert.NoError(t, err)
 
 		// compare


### PR DESCRIPTION
# Description

TLDR; adds a method (no breaking changes) to `kzg.SRS` object that quickly dumps a binary representation without doing any checks, and optionally, enables to truncate the SRS at writing / reading time. `UnsafeFromBytes` is 6x time faster than `UnsafeReadFrom` 

godoc:
```
// UnsafeToBytes returns the binary encoding of the entire SRS memory representation
// It is meant to be use to achieve fast serialization/deserialization and
// is not compatible with WriteTo / ReadFrom. It does not do any validation
// and doesn't encode points in a canonical form.
// @unstable: the format may change in the future
// If maxPkPoints is provided, the number of points in the ProvingKey will be limited to maxPkPoints
func (srs *SRS) UnsafeToBytes(maxPkPoints ...int) ([]byte, error) {
```

benchmark, 1 <<24 points bls12377
```
BenchmarkSerializeSRS/WriteTo-10                       1        1183526917 ns/op        2147545088 B/op      550 allocs/op
BenchmarkSerializeSRS/WriteRawTo-10                    1        1249923583 ns/op        4295028640 B/op      542 allocs/op
BenchmarkSerializeSRS/UnsafeToBytes-10                 4         287003656 ns/op        1610821252 B/op      522 allocs/op
BenchmarkDeserializeSRS/UnsafeReadFrom-10                      1        2677718292 ns/op        5922632568 B/op     1597 allocs/op
BenchmarkDeserializeSRS/UnsafeFromBytes-10                     3         419717778 ns/op        2147761242 B/op     1205 allocs/op
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] New and existing unit tests pass locally with my changes

