### PR TITLE
refactor: move test utils package into isolation to avoid every user to import test stuff

### DIFF
--- a/ecc/bls12-377/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bls12-378/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-378/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-378"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bls12-378/kzg/kzg_test.go
+++ b/ecc/bls12-378/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-378/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bls12-381/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bls24-315/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bls24-317/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bn254/fr/pedersen/pedersen_test.go
+++ b/ecc/bn254/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bw6-633/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bw6-756/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-756/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-756"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bw6-756/kzg/kzg_test.go
+++ b/ecc/bw6-756/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-756/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/ecc/bw6-761/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -178,8 +178,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -158,11 +158,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/fft"
 
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 )
 
 // Test SRS re-used across tests of the KZG scheme
@@ -141,11 +141,11 @@ func TestSerializationSRS(t *testing.T) {
 	// create a SRS
 	srs, err := NewSRS(64, new(big.Int).SetInt64(42))
 	assert.NoError(t, err)
-	t.Run("proving key round-trip", utils.SerializationRoundTrip(&srs.Pk))
-	t.Run("proving key raw round-trip", utils.SerializationRoundTripRaw(&srs.Pk))
-	t.Run("verifying key round-trip", utils.SerializationRoundTrip(&srs.Vk))
-	t.Run("whole SRS round-trip", utils.SerializationRoundTrip(srs))
-	t.Run("unsafe whole SRS round-trip", utils.UnsafeBinaryMarshalerRoundTrip(srs))
+	t.Run("proving key round-trip", testutils.SerializationRoundTrip(&srs.Pk))
+	t.Run("proving key raw round-trip", testutils.SerializationRoundTripRaw(&srs.Pk))
+	t.Run("verifying key round-trip", testutils.SerializationRoundTrip(&srs.Vk))
+	t.Run("whole SRS round-trip", testutils.SerializationRoundTrip(srs))
+	t.Run("unsafe whole SRS round-trip", testutils.UnsafeBinaryMarshalerRoundTrip(srs))
 }
 
 func TestCommit(t *testing.T) {

--- a/internal/generator/pedersen/template/pedersen.test.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.test.go.tmpl
@@ -2,7 +2,7 @@ import (
 	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/{{.Name}}"
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
-	"github.com/consensys/gnark-crypto/utils"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -52,7 +52,7 @@ func testCommit(t *testing.T, values ...interface{}) {
 	var (
 		pk              []ProvingKey
 		vk              VerifyingKey
-		err 			error
+		err             error
 		commitment, pok curve.G1Affine
 	)
 	valuesFr := interfaceSliceToFrSlice(t, values...)
@@ -103,7 +103,7 @@ func TestFoldProofs(t *testing.T) {
 		assert.Equal(t, pok, pokFolded)
 	})
 
-	t.Run("run empty", func (t *testing.T) {
+	t.Run("run empty", func(t *testing.T) {
 		var foldedCommitment curve.G1Affine
 		pok, err := BatchProve([]ProvingKey{}, [][]fr.Element{}, []byte("test"))
 		assert.NoError(t, err)
@@ -160,8 +160,8 @@ func TestMarshal(t *testing.T) {
 	vk.GRootSigmaNeg, err = randomOnG2()
 	assert.NoError(t, err)
 
-	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", utils.SerializationRoundTrip(&pk))
-	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&pk))
-	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", utils.SerializationRoundTrip(&vk))
-	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", utils.SerializationRoundTripRaw(&vk))
+	t.Run("ProvingKey -> Bytes -> ProvingKey must remain identical.", testutils.SerializationRoundTrip(&pk))
+	t.Run("ProvingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&pk))
+	t.Run("VerifyingKey -> Bytes -> VerifyingKey must remain identical.", testutils.SerializationRoundTrip(&vk))
+	t.Run("VerifyingKey -> Bytes (raw) -> ProvingKey must remain identical.", testutils.SerializationRoundTripRaw(&vk))
 }

--- a/utils/testutils/testing.go
+++ b/utils/testutils/testing.go
@@ -1,4 +1,4 @@
-package utils
+package testutils
 
 import (
 	"bytes"


### PR DESCRIPTION
Previous state forced any package that imported `utils` (meaning a lot...) to import test stuff as side effect, and for example forced binaries building on top of gnark/gnark-crypto to embed testify/... 