### PR TITLE
perf(bn254): optimize affine pairing with doubleAndAdd

### DIFF
--- a/ecc/bn254/pairing.go
+++ b/ecc/bn254/pairing.go
@@ -439,13 +439,15 @@ func PrecomputeLines(Q G2Affine) (PrecomputedLines [2][len(LoopCounter)]LineEval
 
 	n := len(LoopCounter)
 	for i := n - 2; i >= 0; i-- {
-		accQ.doubleStep(&PrecomputedLines[0][i])
-		if LoopCounter[i] == 1 {
-			accQ.addStep(&PrecomputedLines[1][i], &Q)
-		} else if LoopCounter[i] == -1 {
-			accQ.addStep(&PrecomputedLines[1][i], &negQ)
-		} else {
-			continue
+		switch LoopCounter[i] {
+		case 0:
+			accQ.doubleStep(&PrecomputedLines[0][i])
+		case 1:
+			accQ.doubleAndAddStep(&PrecomputedLines[0][i], &PrecomputedLines[1][i], &Q)
+		case -1:
+			accQ.doubleAndAddStep(&PrecomputedLines[0][i], &PrecomputedLines[1][i], &negQ)
+		default:
+			return [2][len(LoopCounter)]LineEvaluationAff{}
 		}
 	}
 
@@ -672,4 +674,50 @@ func (p *G2Affine) addStep(evaluations *LineEvaluationAff, a *G2Affine) {
 
 	p.X.Set(&xr)
 	p.Y.Set(&yr)
+}
+
+func (p *G2Affine) doubleAndAddStep(evaluations1, evaluations2 *LineEvaluationAff, a *G2Affine) {
+	var n, d, l1, x3, l2, x4, y4 fptower.E2
+
+	// compute λ1 = (y2-y1)/(x2-x1)
+	n.Sub(&p.Y, &a.Y)
+	d.Sub(&p.X, &a.X)
+	l1.Div(&n, &d)
+
+	// compute x3 =λ1²-x1-x2
+	x3.Square(&l1)
+	x3.Sub(&x3, &p.X)
+	x3.Sub(&x3, &a.X)
+
+	// omit y3 computation
+
+	// compute line1
+	evaluations1.R0.Set(&l1)
+	evaluations1.R1.Mul(&l1, &p.X)
+	evaluations1.R1.Sub(&evaluations1.R1, &p.Y)
+
+	// compute λ2 = -λ1-2y1/(x3-x1)
+	n.Double(&p.Y)
+	d.Sub(&x3, &p.X)
+	l2.Div(&n, &d)
+	l2.Add(&l2, &l1)
+	l2.Neg(&l2)
+
+	// compute x4 = λ2²-x1-x3
+	x4.Square(&l2)
+	x4.Sub(&x4, &p.X)
+	x4.Sub(&x4, &x3)
+
+	// compute y4 = λ2(x1 - x4)-y1
+	y4.Sub(&p.X, &x4)
+	y4.Mul(&l2, &y4)
+	y4.Sub(&y4, &p.Y)
+
+	// compute line2
+	evaluations2.R0.Set(&l2)
+	evaluations2.R1.Mul(&l2, &p.X)
+	evaluations2.R1.Sub(&evaluations2.R1, &p.Y)
+
+	p.X.Set(&x4)
+	p.Y.Set(&y4)
 }


### PR DESCRIPTION
# Description

In affine pairing (`MillerLoopFixedQ`), use `doubleAndAdd` to compute `2P+Q` as of `P+Q+P`. This optimizes the one-time line precomputation for KZG in gnark-crypto, but most importantly matches gnark in-circuit implementation. This is now important since after https://github.com/Consensys/gnark/pull/1143 we need to have the exact same lines so that the witness residue is the same.

## Type of change


- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

pairing tests pass.

# How has this been benchmarked?

In gnark-crypto, only the lines precompuation should be affected (faster) but it's just a one-time computation.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

