### PR TITLE
perf(ecc): optimize affine Add, Sub and Double

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-377] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-377] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-377] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-377] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -248,6 +248,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-377] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-377] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -295,7 +311,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-377] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-377] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E2) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-378/g1_test.go
+++ b/ecc/bls12-378/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-378] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-378] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-378] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-378] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bls12-378/g2.go
+++ b/ecc/bls12-378/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -248,6 +248,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-378] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-378] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -295,7 +311,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-378] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-378] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E2) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-381] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-381] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-381] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-381] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -248,6 +248,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-381] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-381] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -295,7 +311,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS12-381] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS12-381] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E2) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-315] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-315] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS24-315] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS24-315] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -248,6 +248,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-315] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-315] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -295,7 +311,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS24-315] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS24-315] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E4) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-317] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-317] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS24-317] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS24-317] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -248,6 +248,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-317] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-317] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -295,7 +311,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BLS24-317] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BLS24-317] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E4) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BN254] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BN254] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BN254] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BN254] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -247,6 +247,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BN254] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BN254] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BN254] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BN254] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fptower.E2) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-633] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-633] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-633] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-633] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -234,6 +234,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-633] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-633] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -281,7 +297,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-633] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-633] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-756/g1_test.go
+++ b/ecc/bw6-756/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-756] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-756] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-756] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-756] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-756/g2_test.go
+++ b/ecc/bw6-756/g2_test.go
@@ -234,6 +234,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-756] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-756] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -281,7 +297,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-756] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-756] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-761] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-761] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-761] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-761] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -325,7 +325,7 @@ func (p *G2Jac) AddMixed(a *G2Affine) *G2Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -234,6 +234,22 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-761] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-761] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -281,7 +297,7 @@ func TestG2AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[BW6-761] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[BW6-761] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG2Jac(&g2Gen, a)
 			fop2 := fuzzG2Jac(&g2Gen, b)

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -333,7 +333,7 @@ func (p *G1Jac) AddMixed(a *G1Affine) *G1Jac {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -247,6 +247,22 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[SECP256K1] Add should call double when adding the same point", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+
+			op2.Double(&op1)
+			op1.Add(&op1, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[SECP256K1] [2]G = double(G) + G - G", prop.ForAll(
 		func(s fr.Element) bool {
 			var sInt big.Int
@@ -294,7 +310,7 @@ func TestG1AffineOps(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[SECP256K1] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[SECP256K1] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b fp.Element) bool {
 			fop1 := fuzzG1Jac(&g1Gen, a)
 			fop2 := fuzzG1Jac(&g1Gen, b)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -359,7 +359,7 @@ func (p *{{ $TJacobian }}) AddMixed(a *{{ $TAffine }}) *{{ $TJacobian }} {
 
 	// if p == a, we double instead
 	if U2.Equal(&p.X) && S2.Equal(&p.Y) {
-		return p.DoubleAssign()
+		return p.DoubleMixed(a)
 	}
 
 	H.Sub(&U2, &p.X)

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -282,6 +282,22 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 
 	genScalar := GenFr()
 
+    properties.Property("[{{ toUpper .Name }}] Add should call double when adding the same point", prop.ForAll(
+        func(s fr.Element) bool {
+            var op1, op2 {{ toUpper .PointName }}Affine
+            var sInt big.Int
+            g := {{ toLower .PointName }}GenAff
+            s.BigInt(&sInt)
+            op1.ScalarMultiplication(&g, &sInt)
+
+            op2.Double(&op1)
+            op1.Add(&op1, &op1)
+            return op1.Equal(&op2)
+
+       },
+       GenFr(),
+   ))
+
     properties.Property("[{{ toUpper .Name }}] [2]G = double(G) + G - G", prop.ForAll(
        func(s fr.Element) bool {
             var sInt big.Int
@@ -329,7 +345,7 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 		GenFr(),
 	))
 
-	properties.Property("[{{ toUpper .Name }}] [Jacobian] Add should call double when having adding the same point", prop.ForAll(
+	properties.Property("[{{ toUpper .Name }}] [Jacobian] Add should call double when adding the same point", prop.ForAll(
 		func(a, b {{ .CoordType}}) bool {
 			fop1 := fuzz{{ $TJacobian }}(&{{ toLower .PointName }}Gen, a)
 			fop2 := fuzz{{ $TJacobian }}(&{{ toLower .PointName }}Gen, b)


### PR DESCRIPTION
# Description

Currently for affine `Add`, `Sub` and `Double`, we convert both points to Jacobian coordinates and do the arithmetic there. Instead, in this PR, we convert only one point and do mixed arithmetic. Formulas for `AddMixed` are already implemented in gnark-crypto and here we add the implementation of `DoubleMixed` as per [EFD](https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-mdbl-2007-bl).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- Added a test for `2*P == double(P) +  P - P` which checks all the `Add`, `Sub` and `Double` affine methods.

# How has this been benchmarked?

e.g. BLS12-381 G1 and G2 additions on a M1 macbook Air:
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkG1AffineAdd-8     4359          4207          -3.49%
BenchmarkG2AffineAdd-8     6195          5681          -8.30%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

