### PR TITLE
perf(ecc): faster affine Add

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-377] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-377] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-377] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -248,6 +248,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-377] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-377] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-377] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bls12-378/g1.go
+++ b/ecc/bls12-378/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls12-378/g1_test.go
+++ b/ecc/bls12-378/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-378] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-378] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-378] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bls12-378/g2_test.go
+++ b/ecc/bls12-378/g2_test.go
@@ -248,6 +248,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-378] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-378] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-378] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-381] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-381] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-381] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -248,6 +248,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS12-381] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS12-381] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS12-381] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-315] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS24-315] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-315] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -79,12 +79,49 @@ func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G2Affine) Add(a, b *G2Affine) *G2Affine {
 	var q G2Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fptower.E4
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -98,11 +135,9 @@ func (p *G2Affine) Double(a *G2Affine) *G2Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G2Affine) Sub(a, b *G2Affine) *G2Affine {
-	var q G2Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G2Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -248,6 +248,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-315] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS24-315] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-315] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-317] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS24-317] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-317] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -79,12 +79,49 @@ func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G2Affine) Add(a, b *G2Affine) *G2Affine {
 	var q G2Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fptower.E4
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -98,11 +135,9 @@ func (p *G2Affine) Double(a *G2Affine) *G2Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G2Affine) Sub(a, b *G2Affine) *G2Affine {
-	var q G2Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G2Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -248,6 +248,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BLS24-317] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BLS24-317] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BLS24-317] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BN254] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BN254] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BN254] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -247,6 +247,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BN254] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BN254] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BN254] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-633] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-633] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-633] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -79,12 +79,49 @@ func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G2Affine) Add(a, b *G2Affine) *G2Affine {
 	var q G2Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -98,11 +135,9 @@ func (p *G2Affine) Double(a *G2Affine) *G2Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G2Affine) Sub(a, b *G2Affine) *G2Affine {
-	var q G2Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G2Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -234,6 +234,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-633] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-633] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-633] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bw6-756/g1.go
+++ b/ecc/bw6-756/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-756/g1_test.go
+++ b/ecc/bw6-756/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-756] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-756] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-756] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bw6-756/g2.go
+++ b/ecc/bw6-756/g2.go
@@ -79,12 +79,49 @@ func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G2Affine) Add(a, b *G2Affine) *G2Affine {
 	var q G2Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -98,11 +135,9 @@ func (p *G2Affine) Double(a *G2Affine) *G2Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G2Affine) Sub(a, b *G2Affine) *G2Affine {
-	var q G2Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G2Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-756/g2_test.go
+++ b/ecc/bw6-756/g2_test.go
@@ -234,6 +234,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-756] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-756] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-756] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-761] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-761] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-761] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -79,12 +79,49 @@ func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G2Affine) Add(a, b *G2Affine) *G2Affine {
 	var q G2Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -98,11 +135,9 @@ func (p *G2Affine) Double(a *G2Affine) *G2Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G2Affine) Sub(a, b *G2Affine) *G2Affine {
-	var q G2Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G2Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -234,6 +234,39 @@ func TestG2AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[BW6-761] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[BW6-761] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G2Affine
+			var sInt big.Int
+			g := g2GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[BW6-761] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G2Affine

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -87,12 +87,49 @@ func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 }
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *G1Affine) Add(a, b *G1Affine) *G1Affine {
 	var q G1Jac
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V fp.Element
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -106,11 +143,9 @@ func (p *G1Affine) Double(a *G1Affine) *G1Affine {
 
 // Sub subs two point in affine coordinates.
 func (p *G1Affine) Sub(a, b *G1Affine) *G1Affine {
-	var q G1Jac
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg G1Affine
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
 

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -247,6 +247,39 @@ func TestG1AffineOps(t *testing.T) {
 
 	genScalar := GenFr()
 
+	properties.Property("[SECP256K1] Add(P,-P) should return the point at infinity", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.Neg(&op1)
+
+			op1.Add(&op1, &op2)
+			return op1.IsInfinity()
+
+		},
+		GenFr(),
+	))
+
+	properties.Property("[SECP256K1] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+		func(s fr.Element) bool {
+			var op1, op2 G1Affine
+			var sInt big.Int
+			g := g1GenAff
+			s.BigInt(&sInt)
+			op1.ScalarMultiplication(&g, &sInt)
+			op2.setInfinity()
+
+			op1.Add(&op1, &op2)
+			op2.Add(&op2, &op1)
+			return op1.Equal(&op2)
+
+		},
+		GenFr(),
+	))
+
 	properties.Property("[SECP256K1] Add should call double when adding the same point", prop.ForAll(
 		func(s fr.Element) bool {
 			var op1, op2 G1Affine

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -104,12 +104,49 @@ func (p *{{ $TAffine }}) ScalarMultiplicationBase(s *big.Int) *{{ $TAffine }} {
 
 
 // Add adds two point in affine coordinates.
+// Jacobian addition with Z1=Z2=1
+// https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl
 func (p *{{ $TAffine }}) Add(a, b *{{ $TAffine }}) *{{ $TAffine }} {
 	var q {{ $TJacobian }}
-	q.FromAffine(a)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
-	return p
+	// a is infinity, return b
+	if a.IsInfinity() {
+		p.Set(b)
+		return p
+	}
+	// b is infinity, return a
+	if b.IsInfinity() {
+		p.Set(a)
+		return p
+	}
+	if a.X.Equal(&b.X) {
+		// if b == a, we double instead
+		if a.Y.Equal(&b.Y) {
+			q.DoubleMixed(a)
+			return p.FromJacobian(&q)
+		} else {
+			// if b == -a, we return 0
+			return p.setInfinity()
+		}
+	}
+	var H, HH, I, J, r, V {{.CoordType}}
+	H.Sub(&b.X, &a.X)
+	HH.Square(&H)
+	I.Double(&HH).Double(&I)
+	J.Mul(&H, &I)
+	r.Sub(&b.Y, &a.Y)
+	r.Double(&r)
+	V.Mul(&a.X, &I)
+	q.X.Square(&r).
+		Sub(&q.X, &J).
+		Sub(&q.X, &V).
+		Sub(&q.X, &V)
+	q.Y.Sub(&V, &q.X).
+		Mul(&q.Y, &r)
+	J.Mul(&a.Y, &J).Double(&J)
+	q.Y.Sub(&q.Y, &J)
+	q.Z.Double(&H)
+
+	return p.FromJacobian(&q)
 }
 
 // Double doubles a point in affine coordinates.
@@ -123,14 +160,11 @@ func (p *{{ $TAffine }}) Double(a *{{ $TAffine }}) *{{ $TAffine }} {
 
 // Sub subs two point in affine coordinates.
 func (p *{{ $TAffine }}) Sub(a, b *{{ $TAffine }}) *{{ $TAffine }} {
-	var q {{ $TJacobian }}
-	q.FromAffine(a)
-	b.Y.Neg(&b.Y)
-	q.AddMixed(b)
-	p.FromJacobian(&q)
+	var bneg {{ $TAffine }}
+	bneg.Neg(b)
+	p.Add(a, &bneg)
 	return p
 }
-
 
 // Equal tests if two points (in Affine coordinates) are equal
 func (p *{{ $TAffine }}) Equal(a *{{ $TAffine }}) bool {

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -282,6 +282,39 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 
 	genScalar := GenFr()
 
+    properties.Property("[{{ toUpper .Name }}] Add(P,-P) should return the point at infinity", prop.ForAll(
+            func(s fr.Element) bool {
+                var op1, op2 {{ toUpper .PointName }}Affine
+                var sInt big.Int
+                g := {{ toLower .PointName }}GenAff
+                s.BigInt(&sInt)
+                op1.ScalarMultiplication(&g, &sInt)
+                op2.Neg(&op1)
+
+                op1.Add(&op1, &op2)
+                return op1.IsInfinity()
+
+         },
+        GenFr(),
+     ))
+
+    properties.Property("[{{ toUpper .Name }}] Add(P,0) and Add(0,P) should return P", prop.ForAll(
+             func(s fr.Element) bool {
+                    var op1, op2 {{ toUpper .PointName }}Affine
+                    var sInt big.Int
+                    g := {{ toLower .PointName }}GenAff
+                    s.BigInt(&sInt)
+                    op1.ScalarMultiplication(&g, &sInt)
+                    op2.setInfinity()
+
+                    op1.Add(&op1, &op2)
+                    op2.Add(&op2, &op1)
+                    return op1.Equal(&op2)
+
+          },
+         GenFr(),
+    ))
+
     properties.Property("[{{ toUpper .Name }}] Add should call double when adding the same point", prop.ForAll(
         func(s fr.Element) bool {
             var op1, op2 {{ toUpper .PointName }}Affine


### PR DESCRIPTION
# Description

Actually, we can optimize affine addition more than #509 with the assumption that both `Z1` and `Z2` are 1 in Jacobian coordinates.  This PR uses [these EFD formulas](https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-mmadd-2007-bl). Also #509 modifies the second input in the `Sub` method which this PR fixes. 
https://github.com/Consensys/gnark-crypto/blob/364bbceb6d746d027c0e3f78912e61a129b51b8c/internal/generator/ecc/template/point.go.tmpl#L128

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

same tests as #509 

# How has this been benchmarked?

e.g. BLS12-381 G1 addition on a z1d.large AWS machine:
```
goos: linux
goarch: amd64
pkg: github.com/consensys/gnark-crypto/ecc/bls12-381
cpu: Intel(R) Xeon(R) Platinum 8151 CPU @ 3.40GHz
BenchmarkG1AffineAdd
BenchmarkG1AffineAdd-2   	  232734	      5135 ns/op
PASS
```
This is a -3.56% saving compared to #509 
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkG1AffineAdd-2     5135          4952          -3.56%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

