### PR TITLE
refactor: remove E3 Conjugate from BW6

### DIFF
--- a/ecc/bw6-633/internal/fptower/e3.go
+++ b/ecc/bw6-633/internal/fptower/e3.go
@@ -128,14 +128,6 @@ func (z *E3) String() string {
 	return (z.A0.String() + "+(" + z.A1.String() + ")*u+(" + z.A2.String() + ")*u**2")
 }
 
-// Conjugate conjugates an element in E3
-func (z *E3) Conjugate(x *E3) *E3 {
-	z.A0.Set(&x.A0)
-	z.A1.Neg(&x.A1)
-	z.A2.Set(&x.A2)
-	return z
-}
-
 // MulByElement multiplies an element in E3 by an element in fp
 func (z *E3) MulByElement(x *E3, y *fp.Element) *E3 {
 	var yCopy fp.Element

--- a/ecc/bw6-633/internal/fptower/e3_test.go
+++ b/ecc/bw6-633/internal/fptower/e3_test.go
@@ -111,16 +111,6 @@ func TestE3ReceiverIsOperand(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW6-633] Having the receiver as operand (Conjugate) should output the same result", prop.ForAll(
-		func(a *E3) bool {
-			var b E3
-			b.Conjugate(a)
-			a.Conjugate(a)
-			return a.Equal(&b)
-		},
-		genA,
-	))
-
 	properties.Property("[BW6-633] Having the receiver as operand (mul by element) should output the same result", prop.ForAll(
 		func(a *E3, b fp.Element) bool {
 			var c E3
@@ -246,20 +236,6 @@ func TestE3Ops(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW6-633] a + pi(a), a-pi(a) should be real", prop.ForAll(
-		func(a *E3) bool {
-			var b, c, d E3
-			var e, f fp.Element
-			b.Conjugate(a)
-			c.Add(a, &b)
-			d.Sub(a, &b)
-			e.Double(&a.A0)
-			f.Double(&a.A1)
-			return c.A1.IsZero() && d.A0.IsZero() && e.Equal(&c.A0) && f.Equal(&d.A1)
-		},
-		genA,
-	))
-
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
@@ -331,14 +307,5 @@ func BenchmarkE3MulNonRes(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
-	}
-}
-
-func BenchmarkE3Conjugate(b *testing.B) {
-	var a E3
-	_, _ = a.SetRandom()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		a.Conjugate(&a)
 	}
 }

--- a/ecc/bw6-756/internal/fptower/e3.go
+++ b/ecc/bw6-756/internal/fptower/e3.go
@@ -124,13 +124,6 @@ func (z *E3) String() string {
 	return (z.A0.String() + "+(" + z.A1.String() + ")*u+(" + z.A2.String() + ")*u**2")
 }
 
-// Conjugate conjugates an element in E3
-func (z *E3) Conjugate(x *E3) *E3 {
-	*z = *x
-	z.A1.Neg(&z.A1)
-	return z
-}
-
 // MulByElement multiplies an element in E3 by an element in fp
 func (z *E3) MulByElement(x *E3, y *fp.Element) *E3 {
 	_y := *y

--- a/ecc/bw6-756/internal/fptower/e3_test.go
+++ b/ecc/bw6-756/internal/fptower/e3_test.go
@@ -112,16 +112,6 @@ func TestE3ReceiverIsOperand(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW756] Having the receiver as operand (Conjugate) should output the same result", prop.ForAll(
-		func(a *E3) bool {
-			var b E3
-			b.Conjugate(a)
-			a.Conjugate(a)
-			return a.Equal(&b)
-		},
-		genA,
-	))
-
 	properties.Property("[BW756] Having the receiver as operand (mul by element) should output the same result", prop.ForAll(
 		func(a *E3, b fp.Element) bool {
 			var c E3
@@ -248,20 +238,6 @@ func TestE3Ops(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW756] a + pi(a), a-pi(a) should be real", prop.ForAll(
-		func(a *E3) bool {
-			var b, c, d E3
-			var e, f fp.Element
-			b.Conjugate(a)
-			c.Add(a, &b)
-			d.Sub(a, &b)
-			e.Double(&a.A0)
-			f.Double(&a.A1)
-			return c.A1.IsZero() && d.A0.IsZero() && e.Equal(&c.A0) && f.Equal(&d.A1)
-		},
-		genA,
-	))
-
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
@@ -333,14 +309,5 @@ func BenchmarkE3MulNonRes(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
-	}
-}
-
-func BenchmarkE3Conjugate(b *testing.B) {
-	var a E3
-	_, _ = a.SetRandom()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		a.Conjugate(&a)
 	}
 }

--- a/ecc/bw6-761/internal/fptower/e3.go
+++ b/ecc/bw6-761/internal/fptower/e3.go
@@ -124,13 +124,6 @@ func (z *E3) String() string {
 	return (z.A0.String() + "+(" + z.A1.String() + ")*u+(" + z.A2.String() + ")*u**2")
 }
 
-// Conjugate conjugates an element in E3
-func (z *E3) Conjugate(x *E3) *E3 {
-	*z = *x
-	z.A1.Neg(&z.A1)
-	return z
-}
-
 // MulByElement multiplies an element in E3 by an element in fp
 func (z *E3) MulByElement(x *E3, y *fp.Element) *E3 {
 	_y := *y

--- a/ecc/bw6-761/internal/fptower/e3_test.go
+++ b/ecc/bw6-761/internal/fptower/e3_test.go
@@ -111,16 +111,6 @@ func TestE3ReceiverIsOperand(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW761] Having the receiver as operand (Conjugate) should output the same result", prop.ForAll(
-		func(a *E3) bool {
-			var b E3
-			b.Conjugate(a)
-			a.Conjugate(a)
-			return a.Equal(&b)
-		},
-		genA,
-	))
-
 	properties.Property("[BW761] Having the receiver as operand (mul by element) should output the same result", prop.ForAll(
 		func(a *E3, b fp.Element) bool {
 			var c E3
@@ -246,20 +236,6 @@ func TestE3Ops(t *testing.T) {
 		genA,
 	))
 
-	properties.Property("[BW761] a + pi(a), a-pi(a) should be real", prop.ForAll(
-		func(a *E3) bool {
-			var b, c, d E3
-			var e, f fp.Element
-			b.Conjugate(a)
-			c.Add(a, &b)
-			d.Sub(a, &b)
-			e.Double(&a.A0)
-			f.Double(&a.A1)
-			return c.A1.IsZero() && d.A0.IsZero() && e.Equal(&c.A0) && f.Equal(&d.A1)
-		},
-		genA,
-	))
-
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
@@ -331,14 +307,5 @@ func BenchmarkE3MulNonRes(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
-	}
-}
-
-func BenchmarkE3Conjugate(b *testing.B) {
-	var a E3
-	_, _ = a.SetRandom()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		a.Conjugate(&a)
 	}
 }


### PR DESCRIPTION
# Description

`Conjugate` in `Fp3` for BW6-761, BW6-756 and BW6-633 are incorrect but they are not used anywhere. This PR removes the corresponding code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

`Conjugate` tests are removed too.

# How has this been benchmarked?

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

