### PR TITLE
fix(bandersnatch): GLV bounds + test

### DIFF
--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bls12-378/twistededwards/point.go
+++ b/ecc/bls12-378/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -525,6 +525,22 @@ func TestOps(t *testing.T) {
 		},
 		genS1,
 	))
+	properties.Property("(projective) GLV and double-and-add scalar multiplications give the same results", prop.ForAll(
+		func(s1 big.Int) bool {
+
+			params := GetEdwardsCurve()
+
+			var baseProj, p1, p2 PointProj
+			baseProj.FromAffine(&params.Base)
+
+			p1.scalarMulWindowed(&baseProj, &s1)
+			p2.scalarMulGLV(&baseProj, &s1)
+
+			return p2.Equal(&p1)
+
+		},
+		genS1,
+	))
 
 	// extended
 	properties.Property("(extended) 0+0=0", prop.ForAll(
@@ -606,6 +622,22 @@ func TestOps(t *testing.T) {
 			p1.ScalarMultiplication(&p1, five)
 
 			return p2.Equal(&p1)
+		},
+		genS1,
+	))
+	properties.Property("(extended) GLV and double-and-add scalar multiplications give the same results", prop.ForAll(
+		func(s1 big.Int) bool {
+
+			params := GetEdwardsCurve()
+
+			var baseExtended, p1, p2 PointExtended
+			baseExtended.FromAffine(&params.Base)
+
+			p1.scalarMulWindowed(&baseExtended, &s1)
+			p2.scalarMulGLV(&baseExtended, &s1)
+
+			return p2.Equal(&p1)
+
 		},
 		genS1,
 	))

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bw6-756/twistededwards/point.go
+++ b/ecc/bw6-756/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -419,9 +419,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -447,6 +448,12 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	return p.scalarMulWindowed(p1, scalar)
 }
 
 // ------- Extended coordinates
@@ -628,9 +635,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -656,4 +664,10 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	return p.scalarMulWindowed(p1, scalar)
 }

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -2,9 +2,7 @@ import (
 	"crypto/subtle"
 	"io"
 	"math/big"
-	{{- if not .HasEndomorphism}}
 	"math/bits"
-	{{- end }}
 
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/fr"
 )
@@ -403,12 +401,10 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in projective coordinates with a scalar in big.Int
-func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
-	{{- if .HasEndomorphism}}
-		return p.scalarMulGLV(p1, scalar)
-	{{- else }}
+// using the windowed double-and-add method.
+func (p *PointProj) scalarMulWindowed(p1 *PointProj, scalar *big.Int) *PointProj {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -434,6 +430,15 @@ func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointP
 
 	p.Set(&resProj)
 	return p
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in projective coordinates with a scalar in big.Int
+func (p *PointProj) ScalarMultiplication(p1 *PointProj, scalar *big.Int) *PointProj {
+	{{- if .HasEndomorphism}}
+		return p.scalarMulGLV(p1, scalar)
+	{{- else }}
+		return p.scalarMulWindowed(p1, scalar)
 	{{- end}}
 }
 
@@ -624,12 +629,10 @@ func (p *PointExtended) setInfinity() *PointExtended {
 	return p
 }
 
-// ScalarMultiplication scalar multiplication of a point
+// scalarMulWindowed scalar multiplication of a point
 // p1 in extended coordinates with a scalar in big.Int
-func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
-	{{- if .HasEndomorphism}}
-		return p.scalarMulGLV(p1, scalar)
-	{{- else }}
+// using the windowed double-and-add method.
+func (p *PointExtended) scalarMulWindowed(p1 *PointExtended, scalar *big.Int) *PointExtended {
 	var _scalar big.Int
 	_scalar.Set(scalar)
 	p.Set(p1)
@@ -655,5 +658,14 @@ func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int)
 
 	p.Set(&resExtended)
 	return p
-	{{- end }}
+}
+
+// ScalarMultiplication scalar multiplication of a point
+// p1 in extended coordinates with a scalar in big.Int
+func (p *PointExtended) ScalarMultiplication(p1 *PointExtended, scalar *big.Int) *PointExtended {
+	{{- if .HasEndomorphism}}
+		return p.scalarMulGLV(p1, scalar)
+	{{- else }}
+		return p.scalarMulWindowed(p1, scalar)
+	{{- end}}
 }

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -508,6 +508,26 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	{{- if .HasEndomorphism}}
+           properties.Property("(projective) GLV and double-and-add scalar multiplications give the same results", prop.ForAll(
+               func(s1 big.Int) bool {
+
+                       params := GetEdwardsCurve()
+
+                       var baseProj, p1, p2 PointProj
+                       baseProj.FromAffine(&params.Base)
+
+                       p1.scalarMulWindowed(&baseProj, &s1)
+                       p2.scalarMulGLV(&baseProj, &s1)
+
+                       return p2.Equal(&p1)
+
+                },
+               genS1,
+
+                ))
+	{{- end}}
+
 	// extended
 	properties.Property("(extended) 0+0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -591,6 +611,26 @@ func TestOps(t *testing.T) {
 		},
 		genS1,
 	))
+	{{- if .HasEndomorphism}}
+           properties.Property("(extended) GLV and double-and-add scalar multiplications give the same results", prop.ForAll(
+                               func(s1 big.Int) bool {
+
+                       params := GetEdwardsCurve()
+
+                       var baseExtended, p1, p2 PointExtended
+                       baseExtended.FromAffine(&params.Base)
+
+                       p1.scalarMulWindowed(&baseExtended, &s1)
+                       p2.scalarMulGLV(&baseExtended, &s1)
+
+                       return p2.Equal(&p1)
+
+                },
+               genS1,
+
+                ))
+	{{- end}}
+
 
 	// mixed affine+extended
 	properties.Property("(mixed affine+extended) P+(-P)=O", prop.ForAll(
@@ -879,7 +919,7 @@ func BenchmarkAdd(b *testing.B) {
 	params := GetEdwardsCurve()
 	var s big.Int
 	s.SetString("52435875175126190479447705081859658376581184513", 10)
-	
+
 	b.Run("Affine", func(b *testing.B) {
 		var point PointAffine
 		point.ScalarMultiplication(&params.Base, &s)


### PR DESCRIPTION
# Description

When we revisited GLV scalar decomposition https://github.com/Consensys/gnark-crypto/pull/213, we increased conditionally the loop bounds by 1 for all `mulGLV` methods for all curves but we forgot to do so for Bandersnatch twisted Edwards curve. This PR fixes the issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

added `scalarMulWindowed` which does a windowed double-and-add and compares the result with `scalarMulGLV` which uses the endomorphism. The method `ScalarMultiplication` picks `scalarMulGLV` whenever an efficient endomorphism is available (currently only for Bandersnatch).

# How has this been benchmarked?

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkScalarMulExtended-8       30378         30271         -0.35%
BenchmarkScalarMulProjective-8     33844         33941         +0.29%
```

No major diff for random scalars.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

