### PR TITLE
fix: flaky FRI test

### DIFF
--- a/ecc/bls12-377/fr/fri/fri_test.go
+++ b/ecc/bls12-377/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bls12-378/fr/fri/fri_test.go
+++ b/ecc/bls12-378/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bls12-381/fr/fri/fri_test.go
+++ b/ecc/bls12-381/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bls24-315/fr/fri/fri_test.go
+++ b/ecc/bls24-315/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bls24-317/fr/fri/fri_test.go
+++ b/ecc/bls24-317/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bn254/fr/fri/fri_test.go
+++ b/ecc/bn254/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bw6-633/fr/fri/fri_test.go
+++ b/ecc/bw6-633/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bw6-756/fr/fri/fri_test.go
+++ b/ecc/bw6-756/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/ecc/bw6-761/fr/fri/fri_test.go
+++ b/ecc/bw6-761/fr/fri/fri_test.go
@@ -95,7 +95,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(

--- a/internal/generator/fri/template/fri.test.go.tmpl
+++ b/internal/generator/fri/template/fri.test.go.tmpl
@@ -77,7 +77,7 @@ func TestFRI(t *testing.T) {
 			return err != nil
 
 		},
-		gen.Int32Range(0, int32(rho*size)),
+		gen.Int32Range(1, int32(rho*size)),
 	))
 
 	properties.Property("verifying correct opening should succeed", prop.ForAll(


### PR DESCRIPTION
# Description

Fixes flaky test in FRI package. The test generator may output 0 as input, but the tests seem to fail then.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

