### PR TITLE
fix BuildReaderProof in readers.go typo: we -> be

### DIFF
--- a/accumulator/merkletree/readers.go
+++ b/accumulator/merkletree/readers.go
@@ -64,7 +64,7 @@ func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err err
 
 // BuildReaderProof returns a proof that certain data is in the merkle tree
 // created by the data in the reader. The merkle root, set of proofs, and the
-// number of leaves in the Merkle tree are all returned. All leaves will we
+// number of leaves in the Merkle tree are all returned. All leaves will be
 // 'segmentSize' bytes except the last leaf, which will not be padded out if
 // there are not enough bytes remaining in the reader.
 func BuildReaderProof(r io.Reader, h hash.Hash, segmentSize int, index uint64) (root []byte, proofSet [][]byte, numLeaves uint64, err error) {


### PR DESCRIPTION
# Description

fix BuildReaderProof in readers.go typo: we -> be

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How has this been tested?

- N/A

# How has this been benchmarked?

- N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

