### PR TITLE
fix: buffer sufficient size

### DIFF
--- a/ecc/bls12-377/shplonk/shplonk.go
+++ b/ecc/bls12-377/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bls12-381/shplonk/shplonk.go
+++ b/ecc/bls12-381/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bls24-315/shplonk/shplonk.go
+++ b/ecc/bls24-315/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bls24-317/shplonk/shplonk.go
+++ b/ecc/bls24-317/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bn254/shplonk/shplonk.go
+++ b/ecc/bn254/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bw6-633/shplonk/shplonk.go
+++ b/ecc/bw6-633/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/ecc/bw6-761/shplonk/shplonk.go
+++ b/ecc/bw6-761/shplonk/shplonk.go
@@ -80,6 +80,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {

--- a/internal/generator/shplonk/template/shplonk.go.tmpl
+++ b/internal/generator/shplonk/template/shplonk.go.tmpl
@@ -62,6 +62,11 @@ func BatchOpen(polynomials [][]fr.Element, digests []kzg.Digest, points [][]fr.E
 			maxSizePolys = len(polynomials[i])
 		}
 	}
+	for i := range points {
+		if len(points[i])+1 > maxSizePolys {
+			maxSizePolys = len(points[i]) + 1
+		}
+	}
 	nbPoints := 0
 	sizeSi := make([]int, len(points))
 	for i := 0; i < nbPolynomials; i++ {


### PR DESCRIPTION
# Description

At some point in shplonk batch opening we computed difference of two polynomials. But the buffer we subtracted from wasn't sufficiently big. Allocate now enough space.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

