### PR TITLE
perf: subgroup check

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -493,8 +493,8 @@ func (p *G1Jac) IsInSubGroup() bool {
 	var res G1Jac
 
 	res.phi(p).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -630,7 +630,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMultiplication(q, &xGen).Neg(&res).AddAssign(q)
+	res.mulWindowed(q, &xGen).Neg(&res).AddAssign(q)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -494,7 +494,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMultiplication(p, &xGen).
+	res.mulWindowed(p, &xGen).
 		SubAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -638,8 +638,8 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen)
-	xxg.ScalarMultiplication(&xg, &xGen)
+	xg.mulWindowed(q, &xGen)
+	xxg.mulWindowed(&xg, &xGen)
 
 	res.Set(&xxg).
 		SubAssign(&xg).

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -125,7 +125,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -494,8 +494,8 @@ func (p *G1Jac) IsInSubGroup() bool {
 	var res G1Jac
 
 	res.phi(p).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -631,7 +631,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMultiplication(q, &xGen).AddAssign(q)
+	res.mulWindowed(q, &xGen).AddAssign(q)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -495,7 +495,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMultiplication(p, &xGen).
+	res.mulWindowed(p, &xGen).
 		AddAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -639,8 +639,8 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).Neg(&xg)
-	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
+	xg.mulWindowed(q, &xGen).Neg(&xg)
+	xxg.mulWindowed(&xg, &xGen).Neg(&xxg)
 
 	res.Set(&xxg).
 		SubAssign(&xg).

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -125,7 +125,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -493,10 +493,10 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -632,7 +632,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMultiplication(q, &xGen).AddAssign(q)
+	res.mulWindowed(q, &xGen).AddAssign(q)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -495,7 +495,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMultiplication(p, &xGen).
+	res.mulWindowed(p, &xGen).
 		AddAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -642,10 +642,10 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	// multiply by (3x⁴-3)*cofacor
 
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).Neg(&xg).SubAssign(q)
-	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
-	xxxg.ScalarMultiplication(&xxg, &xGen).Neg(&xxxg)
-	xxxxg.ScalarMultiplication(&xxxg, &xGen).Neg(&xxxxg)
+	xg.mulWindowed(q, &xGen).Neg(&xg).SubAssign(q)
+	xxg.mulWindowed(&xg, &xGen).Neg(&xxg)
+	xxxg.mulWindowed(&xxg, &xGen).Neg(&xxxg)
+	xxxxg.mulWindowed(&xxxg, &xGen).Neg(&xxxxg)
 
 	res.Set(&xxxxg).
 		SubAssign(q)

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -125,7 +125,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE4(),

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -494,10 +494,10 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res G1Jac
 	res.phi(p).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(p)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -633,7 +633,7 @@ func (p *G1Affine) ClearCofactor(a *G1Affine) *G1Affine {
 func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res G1Jac
-	res.ScalarMultiplication(q, &xGen).Neg(&res).AddAssign(q)
+	res.mulWindowed(q, &xGen).Neg(&res).AddAssign(q)
 	p.Set(&res)
 	return p
 

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -495,7 +495,7 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 	var res, tmp G2Jac
 	tmp.psi(p)
-	res.ScalarMultiplication(p, &xGen).
+	res.mulWindowed(p, &xGen).
 		SubAssign(&tmp)
 
 	return res.IsOnCurve() && res.Z.IsZero()
@@ -642,10 +642,10 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	// multiply by (3x⁴-3)*cofacor
 
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).SubAssign(q)
-	xxg.ScalarMultiplication(&xg, &xGen)
-	xxxg.ScalarMultiplication(&xxg, &xGen)
-	xxxxg.ScalarMultiplication(&xxxg, &xGen)
+	xg.mulWindowed(q, &xGen).SubAssign(q)
+	xxg.mulWindowed(&xg, &xGen)
+	xxxg.mulWindowed(&xxg, &xGen)
+	xxxxg.mulWindowed(&xxxg, &xGen)
 
 	res.Set(&xxxxg).
 		SubAssign(q)

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -125,7 +125,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE4(),

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -493,7 +493,7 @@ func (p *G2Jac) IsOnCurve() bool {
 // [r]P == 0 <==> [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) = ψ³([2x₀]P)
 func (p *G2Jac) IsInSubGroup() bool {
 	var a, b, c, res G2Jac
-	a.ScalarMultiplication(p, &xGen)
+	a.mulWindowed(p, &xGen)
 	b.psi(&a)
 	a.AddAssign(p)
 	res.psi(&b)
@@ -646,7 +646,7 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	// cf http://cacr.uwaterloo.ca/techreports/2011/cacr2011-26.pdf, 6.1
 	var points [4]G2Jac
 
-	points[0].ScalarMultiplication(q, &xGen)
+	points[0].mulWindowed(q, &xGen)
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -124,7 +124,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenE2(),

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -489,11 +489,11 @@ func (p *G1Jac) IsOnCurve() bool {
 func (p *G1Jac) IsInSubGroup() bool {
 
 	var uP, u4P, u5P, q, r G1Jac
-	uP.ScalarMultiplication(p, &xGen)
-	u4P.ScalarMultiplication(&uP, &xGen).
-		ScalarMultiplication(&u4P, &xGen).
-		ScalarMultiplication(&u4P, &xGen)
-	u5P.ScalarMultiplication(&u4P, &xGen)
+	uP.mulWindowed(p, &xGen)
+	u4P.mulWindowed(&uP, &xGen).
+		mulWindowed(&u4P, &xGen).
+		mulWindowed(&u4P, &xGen)
+	u5P.mulWindowed(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
 	r.phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
@@ -640,20 +640,20 @@ func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	ht.SetInt64(7)
 	v.Mul(&xGen, &xGen).Add(&v, &one).Mul(&v, &uPlusOne)
 
-	uP.ScalarMultiplication(q, &xGen).Neg(&uP)
+	uP.mulWindowed(q, &xGen).Neg(&uP)
 	vP.Set(q).SubAssign(&uP).
-		ScalarMultiplication(&vP, &v)
-	wP.ScalarMultiplication(&vP, &uMinusOne).Neg(&wP).
+		mulWindowed(&vP, &v)
+	wP.mulWindowed(&vP, &uMinusOne).Neg(&wP).
 		AddAssign(&uP)
-	L0.ScalarMultiplication(&wP, &d1)
-	tmp.ScalarMultiplication(&vP, &ht)
+	L0.mulWindowed(&wP, &d1)
+	tmp.mulWindowed(&vP, &ht)
 	L0.AddAssign(&tmp)
 	tmp.Double(q)
 	L0.AddAssign(&tmp)
-	L1.Set(&uP).AddAssign(q).ScalarMultiplication(&L1, &d1)
-	tmp.ScalarMultiplication(&vP, &d2)
+	L1.Set(&uP).AddAssign(q).mulWindowed(&L1, &d1)
+	tmp.mulWindowed(&vP, &d2)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(q, &ht)
+	tmp.mulWindowed(q, &ht)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -495,11 +495,11 @@ func (p *G2Jac) IsOnCurve() bool {
 func (p *G2Jac) IsInSubGroup() bool {
 
 	var uP, u4P, u5P, q, r G2Jac
-	uP.ScalarMultiplication(p, &xGen)
-	u4P.ScalarMultiplication(&uP, &xGen).
-		ScalarMultiplication(&u4P, &xGen).
-		ScalarMultiplication(&u4P, &xGen)
-	u5P.ScalarMultiplication(&u4P, &xGen)
+	uP.mulWindowed(p, &xGen)
+	u4P.mulWindowed(&uP, &xGen).
+		mulWindowed(&u4P, &xGen).
+		mulWindowed(&u4P, &xGen)
+	u5P.mulWindowed(&u4P, &xGen)
 	q.Set(p).SubAssign(&uP)
 	r.phi(&q).SubAssign(&uP).
 		AddAssign(&u4P).
@@ -641,11 +641,11 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	d1.SetInt64(13)
 	d3.SetInt64(5) // negative
 
-	uP.ScalarMultiplication(q, &xGen) // negative
-	u2P.ScalarMultiplication(&uP, &xGen)
-	u3P.ScalarMultiplication(&u2P, &xGen) // negative
-	u4P.ScalarMultiplication(&u3P, &xGen)
-	u5P.ScalarMultiplication(&u4P, &xGen) // negative
+	uP.mulWindowed(q, &xGen) // negative
+	u2P.mulWindowed(&uP, &xGen)
+	u3P.mulWindowed(&u2P, &xGen) // negative
+	u4P.mulWindowed(&u3P, &xGen)
+	u5P.mulWindowed(&u4P, &xGen) // negative
 	vP.Set(&u2P).AddAssign(&uP).
 		AddAssign(&u3P).
 		Double(&vP).
@@ -653,15 +653,15 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 		AddAssign(q)
 	wP.Set(&uP).SubAssign(&u4P).SubAssign(&u5P)
 	xP.Set(q).AddAssign(&vP)
-	L0.Set(&uP).SubAssign(q).ScalarMultiplication(&L0, &d1)
-	tmp.ScalarMultiplication(&xP, &d3)
+	L0.Set(&uP).SubAssign(q).mulWindowed(&L0, &d1)
+	tmp.mulWindowed(&xP, &d3)
 	L0.AddAssign(&tmp)
-	tmp.ScalarMultiplication(q, &ht) // negative
+	tmp.mulWindowed(q, &ht) // negative
 	L0.SubAssign(&tmp)
-	L1.ScalarMultiplication(&wP, &d1)
-	tmp.ScalarMultiplication(&vP, &ht)
+	L1.mulWindowed(&wP, &d1)
+	tmp.mulWindowed(&vP, &ht)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(q, &d3)
+	tmp.mulWindowed(q, &d3)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -111,7 +111,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -494,13 +494,13 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 	var res, phip G1Jac
 	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
+	res.mulWindowed(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.mulWindowed(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -637,9 +637,9 @@ func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	// https://eprint.iacr.org/2020/351.pdf
 	var points [4]G1Jac
 	points[0].Set(q)
-	points[1].ScalarMultiplication(q, &xGen)
-	points[2].ScalarMultiplication(&points[1], &xGen)
-	points[3].ScalarMultiplication(&points[2], &xGen)
+	points[1].mulWindowed(q, &xGen)
+	points[2].mulWindowed(&points[1], &xGen)
+	points[3].mulWindowed(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -652,18 +652,18 @@ func (p *G1Jac) ClearCofactor(q *G1Jac) *G1Jac {
 	scalars[6].SetInt64(130)
 
 	var p1, p2, tmp G1Jac
-	p1.ScalarMultiplication(&points[3], &scalars[0])
-	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
+	p1.mulWindowed(&points[3], &scalars[0])
+	tmp.mulWindowed(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.mulWindowed(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[3])
+	tmp.mulWindowed(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMultiplication(&points[2], &scalars[4])
-	tmp.ScalarMultiplication(&points[1], &scalars[5])
+	p2.mulWindowed(&points[2], &scalars[4])
+	tmp.mulWindowed(&points[1], &scalars[5])
 	p2.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[6])
+	tmp.mulWindowed(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
 	p2.phi(&p2)
 

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -500,13 +500,13 @@ func (p *G2Jac) IsInSubGroup() bool {
 
 	var res, phip G2Jac
 	phip.phi(p)
-	res.ScalarMultiplication(&phip, &xGen).
+	res.mulWindowed(&phip, &xGen).
 		SubAssign(&phip).
-		ScalarMultiplication(&res, &xGen).
-		ScalarMultiplication(&res, &xGen).
+		mulWindowed(&res, &xGen).
+		mulWindowed(&res, &xGen).
 		AddAssign(&phip)
 
-	phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+	phip.mulWindowed(p, &xGen).AddAssign(p).AddAssign(&res)
 
 	return phip.IsOnCurve() && phip.Z.IsZero()
 
@@ -641,9 +641,9 @@ func (p *G2Affine) ClearCofactor(a *G2Affine) *G2Affine {
 func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	var points [4]G2Jac
 	points[0].Set(q)
-	points[1].ScalarMultiplication(q, &xGen)
-	points[2].ScalarMultiplication(&points[1], &xGen)
-	points[3].ScalarMultiplication(&points[2], &xGen)
+	points[1].mulWindowed(q, &xGen)
+	points[2].mulWindowed(&points[1], &xGen)
+	points[3].mulWindowed(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -656,18 +656,18 @@ func (p *G2Jac) ClearCofactor(q *G2Jac) *G2Jac {
 	scalars[6].SetInt64(109)
 
 	var p1, p2, tmp G2Jac
-	p1.ScalarMultiplication(&points[3], &scalars[0])
-	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
+	p1.mulWindowed(&points[3], &scalars[0])
+	tmp.mulWindowed(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.mulWindowed(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[3])
+	tmp.mulWindowed(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMultiplication(&points[2], &scalars[4])
-	tmp.ScalarMultiplication(&points[1], &scalars[5]).Neg(&tmp)
+	p2.mulWindowed(&points[2], &scalars[4])
+	tmp.mulWindowed(&points[1], &scalars[5]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
+	tmp.mulWindowed(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
 	p2.phi(&p2).phi(&p2)
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -111,7 +111,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G2Jac
 			op1 = fuzzG2Jac(&g2Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -113,7 +113,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 			var op1, op2 G1Jac
 			op1 = fuzzG1Jac(&g1Gen, a)
 			_r := fr.Modulus()
-			op2.ScalarMultiplication(&op1, _r)
+			op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		GenFp(),

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -559,7 +559,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
         // [r]P == 0 <==> [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) = ψ³([2x₀]P)
 		func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var a, b, c, res G2Jac
-            a.ScalarMultiplication(p, &xGen)
+            a.mulWindowed(p, &xGen)
             b.psi(&a)
             a.AddAssign(p)
             res.psi(&b)
@@ -585,20 +585,20 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
 		var res, phip {{ $TJacobian }}
 		phip.phi(p)
-		res.ScalarMultiplication(&phip, &xGen).
+		res.mulWindowed(&phip, &xGen).
 			SubAssign(&phip).
-			ScalarMultiplication(&res, &xGen).
-			ScalarMultiplication(&res, &xGen).
+			mulWindowed(&res, &xGen).
+			mulWindowed(&res, &xGen).
 			AddAssign(&phip)
 
-		phip.ScalarMultiplication(p, &xGen).AddAssign(p).AddAssign(&res)
+		phip.mulWindowed(p, &xGen).AddAssign(p).AddAssign(&res)
 
 		return phip.IsOnCurve() && phip.Z.IsZero()
     {{ else}}
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
 		var res {{ $TJacobian }}
-        res.ScalarMultiplication(p, fr.Modulus())
+        res.mulWindowed(p, fr.Modulus())
 		return res.IsOnCurve() && res.Z.IsZero()
     {{ end}}
 
@@ -610,11 +610,11 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
         var uP, u4P, u5P, q, r {{ $TJacobian }}
-        uP.ScalarMultiplication(p, &xGen)
-        u4P.ScalarMultiplication(&uP, &xGen).
-            ScalarMultiplication(&u4P, &xGen).
-            ScalarMultiplication(&u4P, &xGen)
-        u5P.ScalarMultiplication(&u4P, &xGen)
+        uP.mulWindowed(p, &xGen)
+        u4P.mulWindowed(&uP, &xGen).
+            mulWindowed(&u4P, &xGen).
+            mulWindowed(&u4P, &xGen)
+        u5P.mulWindowed(&u4P, &xGen)
         q.Set(p).SubAssign(&uP)
         r.phi(&q).SubAssign(&uP).
             AddAssign(&u4P).
@@ -624,7 +624,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
         var r {{ $TJacobian }}
-        r.ScalarMultiplication(p, fr.Modulus())
+        r.mulWindowed(p, fr.Modulus())
     {{ end}}
 		return r.IsOnCurve() && r.Z.IsZero()
 	}
@@ -641,16 +641,16 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 
             var res {{ $TJacobian }}
             res.phi(p).
-                ScalarMultiplication(&res, &xGen).
-                ScalarMultiplication(&res, &xGen).
-                ScalarMultiplication(&res, &xGen).
-                ScalarMultiplication(&res, &xGen).
+                mulWindowed(&res, &xGen).
+                mulWindowed(&res, &xGen).
+                mulWindowed(&res, &xGen).
+                mulWindowed(&res, &xGen).
                 AddAssign(p)
     {{ else}}
 	func (p *{{ $TJacobian }}) IsInSubGroup() bool {
 
         var res {{ $TJacobian }}
-        res.ScalarMultiplication(p, fr.Modulus())
+        res.mulWindowed(p, fr.Modulus())
 		return res.IsOnCurve() && res.Z.IsZero()
     {{ end}}
 
@@ -665,7 +665,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
         func (p *{{ $TJacobian }}) IsInSubGroup() bool {
             var res, tmp {{ $TJacobian }}
             tmp.psi(p)
-            res.ScalarMultiplication(p, &xGen).
+            res.mulWindowed(p, &xGen).
             {{ if eq .Name "bls24-315"}}
                 AddAssign(&tmp)
             {{ else }}
@@ -689,11 +689,11 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             var res {{ $TJacobian }}
             {{ if .GLV}}
             res.phi(p).
-                ScalarMultiplication(&res, &xGen).
-                ScalarMultiplication(&res, &xGen).
+                mulWindowed(&res, &xGen).
+                mulWindowed(&res, &xGen).
                 AddAssign(p)
             {{ else}}
-            res.ScalarMultiplication(p, fr.Modulus())
+            res.mulWindowed(p, fr.Modulus())
             {{ end}}
 
             return res.IsOnCurve() && res.Z.IsZero()
@@ -708,7 +708,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
                 tmp.psi(p)
-                res.ScalarMultiplication(p, &xGen).
+                res.mulWindowed(p, &xGen).
                     AddAssign(&tmp)
 
                 return res.IsOnCurve() && res.Z.IsZero()
@@ -720,7 +720,7 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
             func (p *{{ $TJacobian }}) IsInSubGroup() bool {
                 var res, tmp {{ $TJacobian }}
                 tmp.psi(p)
-                res.ScalarMultiplication(p, &xGen).
+                res.mulWindowed(p, &xGen).
                     SubAssign(&tmp)
 
                 return res.IsOnCurve() && res.Z.IsZero()
@@ -893,13 +893,13 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{- if or (eq .Name "bls12-381") (eq .Name "bls24-315")}}
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res {{$TJacobian}}
-	res.ScalarMultiplication(q, &xGen).AddAssign(q)
+	res.mulWindowed(q, &xGen).AddAssign(q)
 	p.Set(&res)
 	return p
 {{else if or (eq .Name "bls12-377") (eq .Name "bls24-317")}}
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 	var res {{$TJacobian}}
-	res.ScalarMultiplication(q, &xGen).Neg(&res).AddAssign(q)
+	res.mulWindowed(q, &xGen).Neg(&res).AddAssign(q)
 	p.Set(&res)
 	return p
 {{else if eq .Name "bw6-761"}}
@@ -907,9 +907,9 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	// https://eprint.iacr.org/2020/351.pdf
 	var points [4]{{$TJacobian}}
 	points[0].Set(q)
-	points[1].ScalarMultiplication(q, &xGen)
-	points[2].ScalarMultiplication(&points[1], &xGen)
-	points[3].ScalarMultiplication(&points[2], &xGen)
+	points[1].mulWindowed(q, &xGen)
+	points[2].mulWindowed(&points[1], &xGen)
+	points[3].mulWindowed(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -922,18 +922,18 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	scalars[6].SetInt64(130)
 
 	var p1, p2, tmp {{$TJacobian}}
-	p1.ScalarMultiplication(&points[3], &scalars[0])
-	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
+	p1.mulWindowed(&points[3], &scalars[0])
+	tmp.mulWindowed(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.mulWindowed(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[3])
+	tmp.mulWindowed(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMultiplication(&points[2], &scalars[4])
-	tmp.ScalarMultiplication(&points[1], &scalars[5])
+	p2.mulWindowed(&points[2], &scalars[4])
+	tmp.mulWindowed(&points[1], &scalars[5])
 	p2.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[6])
+	tmp.mulWindowed(&points[0], &scalars[6])
 	p2.AddAssign(&tmp)
 	p2.phi(&p2)
 
@@ -941,7 +941,7 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{ else}}
     var c1 big.Int
     c1.SetString("26642435879335816683987677701488073867751118270052650655942102502312977592501693353047140953112195348280268661194876", 10)
-    p.ScalarMultiplication(q, &c1)
+    p.mulWindowed(q, &c1)
 {{ end}}
 
 	return p
@@ -957,27 +957,27 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	ht.SetInt64(7)
 	v.Mul(&xGen, &xGen).Add(&v, &one).Mul(&v, &uPlusOne)
 
-	uP.ScalarMultiplication(q, &xGen).Neg(&uP)
+	uP.mulWindowed(q, &xGen).Neg(&uP)
 	vP.Set(q).SubAssign(&uP).
-        ScalarMultiplication(&vP, &v)
-	wP.ScalarMultiplication(&vP, &uMinusOne).Neg(&wP).
+        mulWindowed(&vP, &v)
+	wP.mulWindowed(&vP, &uMinusOne).Neg(&wP).
         AddAssign(&uP)
-	L0.ScalarMultiplication(&wP, &d1)
-	tmp.ScalarMultiplication(&vP, &ht)
+	L0.mulWindowed(&wP, &d1)
+	tmp.mulWindowed(&vP, &ht)
 	L0.AddAssign(&tmp)
 	tmp.Double(q)
 	L0.AddAssign(&tmp)
-	L1.Set(&uP).AddAssign(q).ScalarMultiplication(&L1, &d1)
-	tmp.ScalarMultiplication(&vP, &d2)
+	L1.Set(&uP).AddAssign(q).mulWindowed(&L1, &d1)
+	tmp.mulWindowed(&vP, &d2)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(q, &ht)
+	tmp.mulWindowed(q, &ht)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)
 {{ else}}
     var c1 big.Int
     c1.SetString("516166855112631370346774477030598579858367278343565509012644853411927535599366632765988905418773", 10)
-    p.ScalarMultiplication(q, &c1)
+    p.mulWindowed(q, &c1)
 {{ end}}
 
     return p
@@ -991,7 +991,7 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	// cf http://cacr.uwaterloo.ca/techreports/2011/cacr2011-26.pdf, 6.1
 	var points [4]{{$TJacobian}}
 
-	points[0].ScalarMultiplication(q, &xGen)
+	points[0].mulWindowed(q, &xGen)
 
 	points[1].Double(&points[0]).
 		AddAssign(&points[0]).
@@ -1012,8 +1012,8 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{else if eq .Name "bls12-381"}}
 	// https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).Neg(&xg)
-	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
+	xg.mulWindowed(q, &xGen).Neg(&xg)
+	xxg.mulWindowed(&xg, &xGen).Neg(&xxg)
 
 	res.Set(&xxg).
 		SubAssign(&xg).
@@ -1037,8 +1037,8 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{else if eq .Name "bls12-377"}}
     // https://eprint.iacr.org/2017/419.pdf, 4.1
 	var xg, xxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen)
-	xxg.ScalarMultiplication(&xg, &xGen)
+	xg.mulWindowed(q, &xGen)
+	xxg.mulWindowed(&xg, &xGen)
 
 	res.Set(&xxg).
 		SubAssign(&xg).
@@ -1064,16 +1064,16 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	// multiply by (3x⁴-3)*cofacor
     {{ if eq .Name "bls24-315"}}
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).Neg(&xg).SubAssign(q)
-	xxg.ScalarMultiplication(&xg, &xGen).Neg(&xxg)
-	xxxg.ScalarMultiplication(&xxg, &xGen).Neg(&xxxg)
-	xxxxg.ScalarMultiplication(&xxxg, &xGen).Neg(&xxxxg)
+	xg.mulWindowed(q, &xGen).Neg(&xg).SubAssign(q)
+	xxg.mulWindowed(&xg, &xGen).Neg(&xxg)
+	xxxg.mulWindowed(&xxg, &xGen).Neg(&xxxg)
+	xxxxg.mulWindowed(&xxxg, &xGen).Neg(&xxxxg)
     {{ else }}
 	var xg, xxg, xxxg, xxxxg, res, t G2Jac
-	xg.ScalarMultiplication(q, &xGen).SubAssign(q)
-	xxg.ScalarMultiplication(&xg, &xGen)
-	xxxg.ScalarMultiplication(&xxg, &xGen)
-	xxxxg.ScalarMultiplication(&xxxg, &xGen)
+	xg.mulWindowed(q, &xGen).SubAssign(q)
+	xxg.mulWindowed(&xg, &xGen)
+	xxxg.mulWindowed(&xxg, &xGen)
+	xxxxg.mulWindowed(&xxxg, &xGen)
     {{ end }}
 
 	res.Set(&xxxxg).
@@ -1109,9 +1109,9 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{- if .GLV}}
 	var points [4]{{$TJacobian}}
 	points[0].Set(q)
-	points[1].ScalarMultiplication(q, &xGen)
-	points[2].ScalarMultiplication(&points[1], &xGen)
-	points[3].ScalarMultiplication(&points[2], &xGen)
+	points[1].mulWindowed(q, &xGen)
+	points[2].mulWindowed(&points[1], &xGen)
+	points[3].mulWindowed(&points[2], &xGen)
 
 	var scalars [7]big.Int
 	scalars[0].SetInt64(103)
@@ -1124,18 +1124,18 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	scalars[6].SetInt64(109)
 
 	var p1, p2, tmp {{$TJacobian}}
-	p1.ScalarMultiplication(&points[3], &scalars[0])
-	tmp.ScalarMultiplication(&points[2], &scalars[1]).Neg(&tmp)
+	p1.mulWindowed(&points[3], &scalars[0])
+	tmp.mulWindowed(&points[2], &scalars[1]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[1], &scalars[2]).Neg(&tmp)
+	tmp.mulWindowed(&points[1], &scalars[2]).Neg(&tmp)
 	p1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[3])
+	tmp.mulWindowed(&points[0], &scalars[3])
 	p1.AddAssign(&tmp)
 
-	p2.ScalarMultiplication(&points[2], &scalars[4])
-	tmp.ScalarMultiplication(&points[1], &scalars[5]).Neg(&tmp)
+	p2.mulWindowed(&points[2], &scalars[4])
+	tmp.mulWindowed(&points[1], &scalars[5]).Neg(&tmp)
 	p2.AddAssign(&tmp)
-	tmp.ScalarMultiplication(&points[0], &scalars[6]).Neg(&tmp)
+	tmp.mulWindowed(&points[0], &scalars[6]).Neg(&tmp)
 	p2.AddAssign(&tmp)
 	p2.phi(&p2).phi(&p2)
 
@@ -1143,7 +1143,7 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 {{else}}
     var c2 big.Int
     c2.SetString("26642435879335816683987677701488073867751118270052650655942102502312977592501693353047140953112195348280268661194869", 10)
-    p.ScalarMultiplication(q, &c2)
+    p.mulWindowed(q, &c2)
 {{end}}
 
 	return p
@@ -1155,11 +1155,11 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	d1.SetInt64(13)
 	d3.SetInt64(5) // negative
 
-	uP.ScalarMultiplication(q, &xGen) // negative
-	u2P.ScalarMultiplication(&uP, &xGen)
-	u3P.ScalarMultiplication(&u2P, &xGen) // negative
-	u4P.ScalarMultiplication(&u3P, &xGen)
-	u5P.ScalarMultiplication(&u4P, &xGen) // negative
+	uP.mulWindowed(q, &xGen) // negative
+	u2P.mulWindowed(&uP, &xGen)
+	u3P.mulWindowed(&u2P, &xGen) // negative
+	u4P.mulWindowed(&u3P, &xGen)
+	u5P.mulWindowed(&u4P, &xGen) // negative
 	vP.Set(&u2P).AddAssign(&uP).
 	    AddAssign(&u3P).
 	    Double(&vP).
@@ -1167,22 +1167,22 @@ func (p *{{$TJacobian}}) ClearCofactor(q *{{$TJacobian}}) *{{$TJacobian}} {
 	    AddAssign(q)
 	wP.Set(&uP).SubAssign(&u4P).SubAssign(&u5P)
     xP.Set(q).AddAssign(&vP)
-	L0.Set(&uP).SubAssign(q).ScalarMultiplication(&L0, &d1)
-	tmp.ScalarMultiplication(&xP, &d3)
+	L0.Set(&uP).SubAssign(q).mulWindowed(&L0, &d1)
+	tmp.mulWindowed(&xP, &d3)
 	L0.AddAssign(&tmp)
-    tmp.ScalarMultiplication(q, &ht) // negative
+    tmp.mulWindowed(q, &ht) // negative
 	L0.SubAssign(&tmp)
-	L1.ScalarMultiplication(&wP, &d1)
-	tmp.ScalarMultiplication(&vP, &ht)
+	L1.mulWindowed(&wP, &d1)
+	tmp.mulWindowed(&vP, &ht)
 	L1.AddAssign(&tmp)
-	tmp.ScalarMultiplication(q, &d3)
+	tmp.mulWindowed(q, &d3)
 	L1.AddAssign(&tmp)
 
 	p.phi(&L1).AddAssign(&L0)
 {{else}}
     var c2 big.Int
     c2.SetString("516166855112631370346774477030598579858367278343565509012644853411927535599366632765988905418768", 10)
-    p.ScalarMultiplication(q, &c2)
+    p.mulWindowed(q, &c2)
 {{end}}
 
 	return p

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -144,7 +144,7 @@ func Test{{ $TAffine }}IsOnCurve(t *testing.T) {
             var op1, op2 {{ $TJacobian }}
 			op1 = fuzz{{ $TJacobian }}(&{{.PointName}}Gen, a)
             _r := fr.Modulus()
-            op2.ScalarMultiplication(&op1, _r)
+            op2.mulWindowed(&op1, _r)
 			return op1.IsInSubGroup() && op2.Z.IsZero()
 		},
 		{{$fuzzer}},


### PR DESCRIPTION
# Description

use `mulWindowed` instead of `ScalarMultiplication` is G1 and G2 subgroup membership and cofactor clearing methods. 
1- The point is still purported to be in the prime subgroup where GLV applies
2- multiplying by a small constant is faster with `mulWindowed` 

N.B.: multiplying e.g. twice by `x0` is faster than multiplying by `x0^2` because it has smaller Hamming weight. E.g. for BLS12-381, `mul-by-x0` is 64 dbl + 6 mul while `mul-by-x0^2` is 128 dbl + 17 mul. There is still room for improvement if needed by specialising `mul-by-x0` using a short addition chain.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Same tests.

# How has this been benchmarked?

- BLS12-38
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkG1JacIsInSubGroup-2     59891         46740         -21.96%
```
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkG2JacIsInSubGroup-2     74121         55710          -24.84%
```

- BN254
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkG2JacIsInSubGroup-2     58285         48690        -16.46%
```

- BW6-761
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkG1JacIsInSubGroup-2     410121        322322        -21.41%
```
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkG2JacIsInSubGroup-2     410955        322196        -21.60%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

