### PR TITLE
feat: generate uint32 arith only for babybear and koalabear

### DIFF
--- a/field/generator/config/field_config.go
+++ b/field/generator/config/field_config.go
@@ -103,7 +103,10 @@ func NewFieldConfig(packageName, elementName, modulus string, useAddChain bool) 
 	}
 	// pre compute field constants
 	F.NbBits = bModulus.BitLen()
-	F.F31 = F.NbBits <= 31
+	// note: here we set F31 only for BabyBear and KoalaBear;
+	// we could do uint32 bit size for all fields with NbBits <= 31, but we keep it as is for now
+	// to avoid breaking changes
+	F.F31 = F.ModulusHex == "7f000001" || F.ModulusHex == "78000001" // F.NbBits <= 31
 	F.NbWords = len(bModulus.Bits())
 	F.NbWordsLastIndex = F.NbWords - 1
 

--- a/field/generator/generator_asm.go
+++ b/field/generator/generator_asm.go
@@ -28,7 +28,10 @@ func generateARM64(F *config.Field, asm *config.Assembly) (string, error) {
 		return "", nil
 	}
 
-	os.MkdirAll(asm.BuildDir, 0755)
+	err := os.MkdirAll(asm.BuildDir, 0755)
+	if err != nil {
+		return "", fmt.Errorf("failed to create directory %s: %w", asm.BuildDir, err)
+	}
 	pathSrc := filepath.Join(asm.BuildDir, fmt.Sprintf(arm64.ElementASMFileName, F.NbWords))
 
 	hash, ok := mARM64.Load(pathSrc)
@@ -70,7 +73,10 @@ func generateAMD64(F *config.Field, asm *config.Assembly) (string, error) {
 	if !F.GenerateOpsAMD64 {
 		return "", nil
 	}
-	os.MkdirAll(asm.BuildDir, 0755)
+	err := os.MkdirAll(asm.BuildDir, 0755)
+	if err != nil {
+		return "", fmt.Errorf("failed to create directory %s: %w", asm.BuildDir, err)
+	}
 	pathSrc := filepath.Join(asm.BuildDir, fmt.Sprintf(amd64.ElementASMFileName, F.NbWords))
 
 	hash, ok := mAMD64.Load(pathSrc)

--- a/field/generator/options.go
+++ b/field/generator/options.go
@@ -16,11 +16,11 @@ func (cfg *generatorConfig) HasFFT() bool {
 }
 
 func (cfg *generatorConfig) HasArm64() bool {
-	return cfg.asmConfig != nil
+	return cfg.asmConfig != nil && cfg.asmConfig.BuildDir != ""
 }
 
 func (cfg *generatorConfig) HasAMD64() bool {
-	return cfg.asmConfig != nil
+	return cfg.asmConfig != nil && cfg.asmConfig.BuildDir != ""
 }
 
 func WithFFT(cfg *config.FFT) Option {
@@ -38,7 +38,9 @@ func WithASM(cfg *config.Assembly) Option {
 // default options
 func generatorOptions(opts ...Option) generatorConfig {
 	// apply options
-	opt := generatorConfig{}
+	opt := generatorConfig{
+		asmConfig: &config.Assembly{},
+	}
 	for _, option := range opts {
 		option(&opt)
 	}


### PR DESCRIPTION
To avoid breaking changes on caller side, small fields (< 31bits) will still generate uint64 arith for now.