### PR TITLE
typo-Update fflonk.go

### DIFF
--- a/ecc/bls12-377/fflonk/fflonk.go
+++ b/ecc/bls12-377/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bls12-381/fflonk/fflonk.go
+++ b/ecc/bls12-381/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bls24-315/fflonk/fflonk.go
+++ b/ecc/bls24-315/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bls24-317/fflonk/fflonk.go
+++ b/ecc/bls24-317/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bn254/fflonk/fflonk.go
+++ b/ecc/bn254/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bw6-633/fflonk/fflonk.go
+++ b/ecc/bw6-633/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/ecc/bw6-761/fflonk/fflonk.go
+++ b/ecc/bw6-761/fflonk/fflonk.go
@@ -153,7 +153,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}

--- a/internal/generator/fflonk/template/fflonk.go.tmpl
+++ b/internal/generator/fflonk/template/fflonk.go.tmpl
@@ -146,7 +146,7 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	for i := 0; i < len(proof.ClaimedValues); i++ {
 		sizeSi := len(proof.ClaimedValues[i][0])
 		for j := 1; j < len(proof.ClaimedValues[i]); j++ {
-			// each set of opening must be of the same size (opeings on powers of Si)
+			// each set of opening must be of the same size (openings on powers of Si)
 			if sizeSi != len(proof.ClaimedValues[i][j]) {
 				return ErrNbPolynomialsNbPoints
 			}


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `ecc/bls12-377/fflonk/fflonk.go:156`: "opeings" corrected to "openings".

## Purpose
- Improved code accuracy and maintained professionalism.

