### PR TITLE
Feat/write point slice ptr

### DIFF
--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -638,43 +638,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -531,43 +531,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -759,6 +729,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -442,6 +442,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -549,6 +591,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -638,13 +722,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -699,48 +783,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -477,6 +477,48 @@ func isZeroed(firstByte byte, buf []byte) bool {
 	return true
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encode(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -584,6 +626,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 	}
 }
 
+func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineUncompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].RawBytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -673,13 +757,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1SliceRaw(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2SliceRaw(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2SliceRaw(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -734,48 +818,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -435,7 +435,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 }
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -475,48 +475,6 @@ func isZeroed(firstByte byte, buf []byte) bool {
 		}
 	}
 	return true
-}
-
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encode(v interface{}) (err error) {
@@ -607,14 +565,48 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1Slice(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
-	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.encode(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.encode(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineCompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -624,48 +616,6 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		enc.n += int64(n)
 		return
 	}
-}
-
-func (enc *Encoder) writeG1SliceRaw(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2SliceRaw(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineUncompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].RawBytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (enc *Encoder) encodeRaw(v interface{}) (err error) {
@@ -756,14 +706,48 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 			}
 		}
 		return
-	case []G1Affine:
-		return enc.writeG1SliceRaw(t)
 	case *[]G1Affine:
-		return enc.writeG1SliceRaw(*t)
-	case []G2Affine:
-		return enc.writeG2SliceRaw(t)
+		return enc.encodeRaw(*t)
+	case []G1Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case *[]G2Affine:
-		return enc.writeG2SliceRaw(*t)
+		return enc.encodeRaw(*t)
+	case []G2Affine:
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2AffineUncompressed]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].RawBytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -566,43 +566,13 @@ func (enc *Encoder) encode(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineCompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -703,43 +673,13 @@ func (enc *Encoder) encodeRaw(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2AffineUncompressed]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].RawBytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {
@@ -794,6 +734,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	written, err := enc.w.Write(buff[:])
 	enc.n += int64(written)
 	return err
+}
+
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SizeOfG1AffineCompressed represents the size in bytes that a G1Affine need in binary form, compressed

--- a/ecc/utils.go
+++ b/ecc/utils.go
@@ -178,7 +178,8 @@ func getVector(l *Lattice, a, b *big.Int) [2]big.Int {
 	return res
 }
 
-// NextPowerOfTwo returns the next power of 2 of n
+// NextPowerOfTwo(n) = 2^⌈log₂(n)⌉
+// or 2ᵏ where 2ᵏ⁻¹ < n ≤ 2ᵏ
 func NextPowerOfTwo(n uint64) uint64 {
 	c := bits.OnesCount64(n)
 	if c == 0 {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -688,7 +688,7 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice{{- $.Raw}}(t)
+		return enc.writeG1Slice{{- $.Raw}}(t
 	case *[]G1Affine:
 		return enc.writeG1Slice{{- $.Raw}}(*t)
 	case []G2Affine:

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -555,6 +555,48 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	return err
 }
 
+func (enc *Encoder) writeG1Slice(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2AffineCompressed]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 {{ define "encode"}}
 
 func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
@@ -646,43 +688,13 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG1Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].{{- $.Raw}}Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG1Slice(t)
+	case *[]G1Affine:
+		return enc.writeG1Slice(*t)
 	case []G2Affine:
-		// write slice length
-		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-		if err != nil {
-			return
-		}
-		enc.n += 4
-
-		var buf [SizeOfG2Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
-
-		for i := 0; i < len(t); i++ {
-			buf = t[i].{{- $.Raw}}Bytes()
-			written, err = enc.w.Write(buf[:])
-			enc.n += int64(written)
-			if err != nil {
-				return
-			}
-		}
-		return nil
+		return enc.writeG2Slice(t)
+	case *[]G2Affine:
+		return enc.writeG2Slice(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -555,49 +555,49 @@ func (enc *Encoder) writeUint32(a uint32) error {
 	return err
 }
 
-func (enc *Encoder) writeG1Slice(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2AffineCompressed]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 {{ define "encode"}}
+
+func (enc *Encoder) writeG1Slice{{$.Raw}}(t []G1Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG1Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].{{- $.Raw}}Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (enc *Encoder) writeG2Slice{{$.Raw}}(t []G2Affine) error {
+	// write slice length
+	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+	if err != nil {
+		return err
+	}
+	enc.n += 4
+
+	var buf [SizeOfG2Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
+
+	for i := 0; i < len(t); i++ {
+		buf = t[i].{{- $.Raw}}Bytes()
+		written, err := enc.w.Write(buf[:])
+		enc.n += int64(written)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
@@ -688,13 +688,13 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice(t)
+		return enc.writeG1Slice{{- $.Raw}}(t)
 	case *[]G1Affine:
-		return enc.writeG1Slice(*t)
+		return enc.writeG1Slice{{- $.Raw}}(*t)
 	case []G2Affine:
-		return enc.writeG2Slice(t)
+		return enc.writeG2Slice{{- $.Raw}}(t)
 	case *[]G2Affine:
-		return enc.writeG2Slice(*t)
+		return enc.writeG2Slice{{- $.Raw}}(*t)
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -557,48 +557,6 @@ func (enc *Encoder) writeUint32(a uint32) error {
 
 {{ define "encode"}}
 
-func (enc *Encoder) writeG1Slice{{$.Raw}}(t []G1Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG1Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].{{- $.Raw}}Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (enc *Encoder) writeG2Slice{{$.Raw}}(t []G2Affine) error {
-	// write slice length
-	err := binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
-	if err != nil {
-		return err
-	}
-	enc.n += 4
-
-	var buf [SizeOfG2Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
-
-	for i := 0; i < len(t); i++ {
-		buf = t[i].{{- $.Raw}}Bytes()
-		written, err := enc.w.Write(buf[:])
-		enc.n += int64(written)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 	rv := reflect.ValueOf(v)
 	if v == nil || (rv.Kind() == reflect.Ptr && rv.IsNil()) {
@@ -688,13 +646,43 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice{{- $.Raw}}(t)
-	case *[]G1Affine:
-		return enc.writeG1Slice{{- $.Raw}}(*t)
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG1Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].{{- $.Raw}}Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	case []G2Affine:
-		return enc.writeG2Slice{{- $.Raw}}(t)
-	case *[]G2Affine:
-		return enc.writeG2Slice{{- $.Raw}}(*t)
+		// write slice length
+		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
+		if err != nil {
+			return
+		}
+		enc.n += 4
+
+		var buf [SizeOfG2Affine{{- if $.Raw}}Uncompressed{{- else}}Compressed{{- end}}]byte
+
+		for i := 0; i < len(t); i++ {
+			buf = t[i].{{- $.Raw}}Bytes()
+			written, err = enc.w.Write(buf[:])
+			enc.n += int64(written)
+			if err != nil {
+				return
+			}
+		}
+		return nil
 	default:
 		n := binary.Size(t)
 		if n == -1 {

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -464,7 +464,7 @@ func NewEncoder(w io.Writer, options ...func(*Encoder)) *Encoder {
 
 
 // Encode writes the binary encoding of v to the stream
-// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine or []G2Affine
+// type must be uint64, *fr.Element, *fp.Element, *G1Affine, *G2Affine, []G1Affine, []G2Affine, *[]G1Affine or *[]G2Affine
 func (enc *Encoder) Encode(v interface{}) (err error) {
 	if enc.raw {
 		return enc.encodeRaw(v)
@@ -645,6 +645,8 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 			}
 		}
 		return
+	case *[]G1Affine:
+		return enc.encode{{- $.Raw}}(*t)
 	case []G1Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))
@@ -664,6 +666,8 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 			}
 		}
 		return nil
+	case *[]G2Affine:
+		return enc.encode{{- $.Raw}}(*t)
 	case []G2Affine:
 		// write slice length
 		err = binary.Write(enc.w, binary.BigEndian, uint32(len(t)))

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -688,7 +688,7 @@ func (enc *Encoder) encode{{- $.Raw}}(v interface{}) (err error) {
 		}
 		return
 	case []G1Affine:
-		return enc.writeG1Slice{{- $.Raw}}(t
+		return enc.writeG1Slice{{- $.Raw}}(t)
 	case *[]G1Affine:
 		return enc.writeG1Slice{{- $.Raw}}(*t)
 	case []G2Affine:


### PR DESCRIPTION
`Encoder.Write` now also accepts `*[]curve.G1Affine` and `*[]curve.G2Affine`.

It enables convenient functions like `refsSlice` seen here
https://github.com/Consensys/gnark/blob/chore/groth16-mpc/backend/groth16/bn254/mpcsetup/marshal.go#L60
, where the same piece of code orders a struct's fields for both serialization and deserialization.