### PR TITLE
Fix: Add "GitHub" reference in issue creation instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ happens and under which conditions it normally happens.
 suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
-Enhancement suggestions are tracked as GitHub issues. Create an issue on and provide 
+Enhancement suggestions are tracked as GitHub issues. Create an issue on GitHub and provide 
 the following information:
 
 * Use a **clear and descriptive title** for the issue to identify the suggestion.


### PR DESCRIPTION
### Fixed a missing platform name in the instruction. Changed:

"Create an issue on and provide the following information:"

To:

"Create an issue on GitHub and provide the following information:"