### PR TITLE
perf: make SetBytes not allocate errors in non-fast path

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -1214,6 +1214,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1231,7 +1233,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1265,7 +1267,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -1214,6 +1214,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1231,7 +1233,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1265,7 +1267,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -1130,6 +1130,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1146,7 +1148,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1178,7 +1180,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -1130,6 +1130,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1146,7 +1148,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1178,7 +1180,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -1610,6 +1610,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1631,7 +1633,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[9] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1673,7 +1675,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[9] = binary.LittleEndian.Uint64((*b)[72:80])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -1130,6 +1130,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1146,7 +1148,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1178,7 +1180,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[4] = binary.LittleEndian.Uint64((*b)[32:40])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -1844,6 +1844,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1867,7 +1869,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[11] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1913,7 +1915,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[11] = binary.LittleEndian.Uint64((*b)[88:96])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -1214,6 +1214,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1231,7 +1233,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1265,7 +1267,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[5] = binary.LittleEndian.Uint64((*b)[40:48])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -1083,6 +1083,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1098,7 +1100,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1128,7 +1130,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -1083,6 +1083,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1098,7 +1100,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1128,7 +1130,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fp.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fp.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -1055,6 +1055,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid fr.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -1070,7 +1072,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -1100,7 +1102,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[3] = binary.LittleEndian.Uint64((*b)[24:32])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid fr.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/field/babybear/element.go
+++ b/field/babybear/element.go
@@ -768,6 +768,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid babybear.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -780,7 +782,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.BigEndian.Uint32((*b)[0:4])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid babybear.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -804,7 +806,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.LittleEndian.Uint32((*b)[0:4])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid babybear.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/field/generator/internal/templates/element/conv.go
+++ b/field/generator/internal/templates/element/conv.go
@@ -327,6 +327,8 @@ type ByteOrder interface {
 }
 
 
+var errInvalidEncoding = errors.New("invalid {{.PackageName}}.{{.ElementName}} encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -345,7 +347,7 @@ func (bigEndian) Element(b *[Bytes]byte) ({{.ElementName}}, error) {
 	{{- end}}
 
 	if !z.smallerThanModulus() {
-		return {{.ElementName}}{}, errors.New("invalid {{.PackageName}}.{{.ElementName}} encoding")
+		return {{.ElementName}}{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -382,7 +384,7 @@ func (littleEndian) Element(b *[Bytes]byte) ({{.ElementName}}, error) {
 	{{- end}}
 
 	if !z.smallerThanModulus() {
-		return {{.ElementName}}{}, errors.New("invalid {{.PackageName}}.{{.ElementName}} encoding")
+		return {{.ElementName}}{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -801,6 +801,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid goldilocks.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -813,7 +815,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.BigEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid goldilocks.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -837,7 +839,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.LittleEndian.Uint64((*b)[0:8])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid goldilocks.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()

--- a/field/koalabear/element.go
+++ b/field/koalabear/element.go
@@ -768,6 +768,8 @@ type ByteOrder interface {
 	String() string
 }
 
+var errInvalidEncoding = errors.New("invalid koalabear.Element encoding")
+
 // BigEndian is the big-endian implementation of ByteOrder and AppendByteOrder.
 var BigEndian bigEndian
 
@@ -780,7 +782,7 @@ func (bigEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.BigEndian.Uint32((*b)[0:4])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid koalabear.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()
@@ -804,7 +806,7 @@ func (littleEndian) Element(b *[Bytes]byte) (Element, error) {
 	z[0] = binary.LittleEndian.Uint32((*b)[0:4])
 
 	if !z.smallerThanModulus() {
-		return Element{}, errors.New("invalid koalabear.Element encoding")
+		return Element{}, errInvalidEncoding
 	}
 
 	z.toMont()


### PR DESCRIPTION
# Description

Noticed a minor issue when benchmark memory allocations in some gnark-crypto upstream code; calling many `SetBytes()` that are larger than modulus, would result in `bigEndian.Element` calling `errors.New(...)` and allocating new error objects at each call. Not needed obviously.