### PR TITLE
Typos Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,7 +1225,7 @@
 - dusted off polynomial.go (bls377, no code gen yet)
 
 ### Perf
-- remove unecessary inverse in KZG-verify
+- remove unnecessary inverse in KZG-verify
 - faster GLV scalar decompostion
 
 ### Refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1581,7 +1581,7 @@
 - Full paper implemented, unknown bug
 - Full paper implemented, tests passing
 - **bls24:** experiment with Fp-Fp2-Fp4-Fp12-Fp24 tower
-- **kzg:** test tampered proofs whith quotient set to zero
+- **kzg:** test tampered proofs with quotient set to zero
 - **plookup:** challenges are derived using Fiat Shamir
 - **plookup:** addition of prover and verifier for tables
 - **plookup:** proof generation

--- a/ecc/bn254/shplonk/example_test.go
+++ b/ecc/bn254/shplonk/example_test.go
@@ -50,7 +50,7 @@ func Example_batchOpen() {
 	// hash function that is used for the challenge derivation in Fiat Shamir
 	hf := sha256.New()
 
-	// ceate an opening proof of polynomials[i] on the set points[i]
+	// create an opening proof of polynomials[i] on the set points[i]
 	openingProof, err := BatchOpen(polynomials, digests, points, hf, testSrs.Pk)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Typos Fix Summary

### Files Changed:
1. **CHANGELOG.md**:
   - Corrected "unecessary" to **"unnecessary"** in the sentence:  
     *"remove unnecessary inverse in KZG-verify"*
   - Corrected "whith" to **"with"** in the sentence:  
     *"test tampered proofs with quotient set to zero"*

2. **ecc/bn254/shplonk/example_test.go**:
   - Corrected "ceate" to **"create"** in the comment:  
     *"create an opening proof of polynomials[i] on the set points[i]"*

These updates improve documentation and code readability by fixing typographical errors.
