### PR TITLE
build: improve go generate generation time by checking git status

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: generated files should not be modified
       run: |
-        go generate ./...
+        go generate -tags=forcegen ./...
         git update-index --assume-unchanged go.mod
         git update-index --assume-unchanged go.sum
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after running go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: generated files should not be modified
       run: |
-        go generate ./...
+        go generate  -tags=forcegen ./...
         git update-index --assume-unchanged go.mod
         git update-index --assume-unchanged go.sum
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after running go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi

--- a/ecc/bn254/fr/mimc/test_vectors/main.go
+++ b/ecc/bn254/fr/mimc/test_vectors/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 type numericalMiMCTestCase struct {
@@ -23,6 +24,10 @@ func assertNoError(err error) {
 
 //go:generate go run main.go
 func main() {
+	if !git.HasChanges("mimc/vectors.json") {
+		fmt.Println("no changes in mimc/vectors.json, skipping generation")
+		return
+	}
 	fmt.Println("generating test vectors for MiMC...")
 	var tests []numericalMiMCTestCase
 

--- a/field/generator/internal/addchain/addchain.go
+++ b/field/generator/internal/addchain/addchain.go
@@ -43,6 +43,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/mmcloughlin/addchain"
 	"github.com/mmcloughlin/addchain/acc"
 	"github.com/mmcloughlin/addchain/acc/ast"
@@ -64,6 +65,9 @@ var (
 
 // GetAddChain returns template data of a short addition chain for given big.Int
 func GetAddChain(n *big.Int) *AddChainData {
+	if !git.HasChanges("field") {
+		return nil // a bit risky but well.
+	}
 
 	// init the cache only once.
 	once.Do(initCache)

--- a/field/internal/main.go
+++ b/field/internal/main.go
@@ -6,12 +6,16 @@ import (
 
 	"github.com/consensys/gnark-crypto/field/generator"
 	"github.com/consensys/gnark-crypto/field/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 //go:generate go run main.go
 func main() {
 	// generate the following fields
-
+	if !git.HasChanges("field") {
+		fmt.Printf("no changes in field, skipping generation\n")
+		return
+	}
 	type field struct {
 		name    string
 		modulus string

--- a/internal/generator/crypto/hash/mimc/generate.go
+++ b/internal/generator/crypto/hash/mimc/generate.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./hash/mimc/template/") {
+		return nil
+	}
 	conf.Package = "mimc"
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "doc.go"), Templates: []string{"doc.go.tmpl"}},

--- a/internal/generator/crypto/hash/poseidon2/generate.go
+++ b/internal/generator/crypto/hash/poseidon2/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./hash/poseidon2/template/") {
+		return nil
+	}
 	conf.Package = "poseidon2"
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "poseidon2.go"), Templates: []string{"poseidon2.go.tmpl"}},

--- a/internal/generator/ecc/generate.go
+++ b/internal/generator/ecc/generate.go
@@ -11,10 +11,15 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./ecc/template") {
+		// note; we could wrap the bavard gen function here, and filter out the entries
+		// that have changes to be more granular in the skip.
+		return nil
+	}
 	packageName := strings.ReplaceAll(conf.Name, "-", "")
 
 	var entries []bavard.Entry

--- a/internal/generator/ecdsa/generate.go
+++ b/internal/generator/ecdsa/generate.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !(git.HasChanges("./ecdsa/template")) {
+		return nil
+	}
 	// ecdsa
 	conf.Package = "ecdsa"
 	baseDir = filepath.Join(baseDir, conf.Package)

--- a/internal/generator/edwards/eddsa/generate.go
+++ b/internal/generator/edwards/eddsa/generate.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.TwistedEdwardsCurve, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !(git.HasChanges("./edwards/eddsa/template")) {
+		return nil
+	}
 	// eddsa
 	conf.Package = "eddsa"
 	baseDir = filepath.Join(baseDir, conf.Package)

--- a/internal/generator/edwards/generate.go
+++ b/internal/generator/edwards/generate.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.TwistedEdwardsCurve, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !(git.HasChanges("./edwards/template")) {
+		return nil
+	}
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "point.go"), Templates: []string{"point.go.tmpl"}},
 		{File: filepath.Join(baseDir, "point_test.go"), Templates: []string{"tests/point.go.tmpl"}},

--- a/internal/generator/fflonk/generator.go
+++ b/internal/generator/fflonk/generator.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./fflonk/template")) {
+		return nil
+	}
 	// kzg commitment scheme
 	conf.Package = "fflonk"
 	entries := []bavard.Entry{

--- a/internal/generator/fri/template/generate.go
+++ b/internal/generator/fri/template/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./fri/template/") {
+		return nil
+	}
 	// fri commitment scheme
 	conf.Package = "fri"
 	entries := []bavard.Entry{

--- a/internal/generator/git/git.go
+++ b/internal/generator/git/git.go
@@ -16,7 +16,6 @@ func HasChanges(dir string) bool {
 	dir = filepath.Clean(dir)
 	once.Do(func() {
 		cmd := exec.Command("git", "status", "--porcelain")
-		cmd.Dir = dir
 		output, _ := cmd.Output()
 		gitStatusDiff = string(output)
 	})

--- a/internal/generator/git/git.go
+++ b/internal/generator/git/git.go
@@ -22,7 +22,7 @@ func HasChanges(dir string) bool {
 	})
 
 	// if status contains bavard or addchain, we return true by default
-	if strings.Contains(gitStatusDiff, "bavard") || strings.Contains(gitStatusDiff, "addchain") {
+	if strings.Contains(gitStatusDiff, "go.mod") || strings.Contains(gitStatusDiff, "go.sum") {
 		return true
 	}
 

--- a/internal/generator/git/git.go
+++ b/internal/generator/git/git.go
@@ -1,0 +1,30 @@
+//go:build !forcegen
+
+package git
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var gitStatusDiff string
+var once sync.Once
+
+func HasChanges(dir string) bool {
+	dir = filepath.Clean(dir)
+	once.Do(func() {
+		cmd := exec.Command("git", "status", "--porcelain")
+		cmd.Dir = dir
+		output, _ := cmd.Output()
+		gitStatusDiff = string(output)
+	})
+
+	// if status contains bavard or addchain, we return true by default
+	if strings.Contains(gitStatusDiff, "bavard") || strings.Contains(gitStatusDiff, "addchain") {
+		return true
+	}
+
+	return strings.Contains(gitStatusDiff, dir)
+}

--- a/internal/generator/git/git_forceregen.go
+++ b/internal/generator/git/git_forceregen.go
@@ -1,0 +1,7 @@
+//go:build forcegen
+
+package git
+
+func HasChanges(dir string) bool {
+	return true
+}

--- a/internal/generator/gkr/generate.go
+++ b/internal/generator/gkr/generate.go
@@ -1,9 +1,11 @@
 package gkr
 
 import (
+	"path/filepath"
+
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
-	"path/filepath"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 type Config struct {
@@ -15,6 +17,9 @@ type Config struct {
 }
 
 func Generate(config Config, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !git.HasChanges("./gkr/template/") {
+		return nil
+	}
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "gkr.go"), Templates: []string{"gkr.go.tmpl"}},
 	}

--- a/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
@@ -2,6 +2,7 @@ import (
 	"encoding/json"
 	"fmt"
 	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
+    "github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational/gkr"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational/polynomial"
@@ -21,6 +22,11 @@ func main() {
 }
 
 func GenerateVectors() error {
+    if !git.HasChanges("gkr/test_vectors") {
+        fmt.Println("no changes in gkr/test_vectors, skipping generation")
+        return nil
+    }
+
     testDirPath, err := filepath.Abs("gkr/test_vectors")
     if err != nil {
         return err

--- a/internal/generator/gkr/test_vectors/main.go
+++ b/internal/generator/gkr/test_vectors/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational/gkr"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational/polynomial"
@@ -28,6 +29,11 @@ func main() {
 }
 
 func GenerateVectors() error {
+	if !git.HasChanges("gkr/test_vectors") {
+		fmt.Println("no changes in gkr/test_vectors, skipping generation")
+		return nil
+	}
+
 	testDirPath, err := filepath.Abs("gkr/test_vectors")
 	if err != nil {
 		return err

--- a/internal/generator/hash_to_field/generate.go
+++ b/internal/generator/hash_to_field/generate.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.FieldDependency, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !git.HasChanges("./hash_to_field/template/") {
+		return nil
+	}
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "doc.go"), Templates: []string{"doc.go.tmpl"}},
 		{File: filepath.Join(baseDir, "hash_to_field.go"), Templates: []string{"hash_to_field.go.tmpl"}},

--- a/internal/generator/iop/generate.go
+++ b/internal/generator/iop/generate.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !git.HasChanges("./iop/template/") {
+		return nil
+	}
 
 	// fri commitment scheme
 	conf.Package = "iop"

--- a/internal/generator/kzg/generate.go
+++ b/internal/generator/kzg/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./kzg/template")) {
+		return nil
+	}
 	// kzg commitment scheme
 	conf.Package = "kzg"
 	entries := []bavard.Entry{

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/consensys/gnark-crypto/internal/generator/edwards/eddsa"
 	"github.com/consensys/gnark-crypto/internal/generator/fflonk"
 	fri "github.com/consensys/gnark-crypto/internal/generator/fri/template"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/consensys/gnark-crypto/internal/generator/gkr"
 	"github.com/consensys/gnark-crypto/internal/generator/hash_to_field"
 	"github.com/consensys/gnark-crypto/internal/generator/iop"
@@ -82,8 +83,10 @@ func main() {
 			if conf.Equal(config.BLS12_377) {
 				frOpts = append(frOpts, generator.WithSIS())
 			}
-			assertNoError(generator.GenerateFF(conf.Fr, filepath.Join(curveDir, "fr"), frOpts...))
-			assertNoError(generator.GenerateFF(conf.Fp, filepath.Join(curveDir, "fp"), generator.WithASM(asmConfig)))
+			if git.HasChanges("field") {
+				assertNoError(generator.GenerateFF(conf.Fr, filepath.Join(curveDir, "fr"), frOpts...))
+				assertNoError(generator.GenerateFF(conf.Fp, filepath.Join(curveDir, "fp"), generator.WithASM(asmConfig)))
+			}
 
 			// generate ecdsa
 			assertNoError(ecdsa.Generate(conf, curveDir, bgen))

--- a/internal/generator/pairing/generate.go
+++ b/internal/generator/pairing/generate.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./pairing/template")) {
+		return nil
+	}
 	packageName := strings.ReplaceAll(conf.Name, "-", "")
 	return bgen.Generate(conf, packageName, "./pairing/template", bavard.Entry{
 		File: filepath.Join(baseDir, "pairing_test.go"), Templates: []string{"tests/pairing.go.tmpl"},

--- a/internal/generator/pedersen/generate.go
+++ b/internal/generator/pedersen/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./pedersen/template")) {
+		return nil
+	}
 	// pedersen commitment scheme
 	conf.Package = "pedersen"
 	entries := []bavard.Entry{

--- a/internal/generator/permutation/generator.go
+++ b/internal/generator/permutation/generator.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./permutation/template")) {
+		return nil
+	}
 	// permutation data
 	conf.Package = "permutation"
 	entries := []bavard.Entry{

--- a/internal/generator/plookup/generate.go
+++ b/internal/generator/plookup/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !(git.HasChanges("./plookup/template")) {
+		return nil
+	}
 	// kzg commitment scheme
 	conf.Package = "plookup"
 	entries := []bavard.Entry{

--- a/internal/generator/polynomial/generate.go
+++ b/internal/generator/polynomial/generate.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.FieldDependency, baseDir string, generateTests bool, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./polynomial/template/") {
+		return nil
+	}
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "doc.go"), Templates: []string{"doc.go.tmpl"}},
 		{File: filepath.Join(baseDir, "polynomial.go"), Templates: []string{"polynomial.go.tmpl"}},

--- a/internal/generator/shplonk/generator.go
+++ b/internal/generator/shplonk/generator.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
-
+	if !git.HasChanges("./shplonk/template/") {
+		return nil
+	}
 	// kzg commitment scheme
 	conf.Package = "shplonk"
 	entries := []bavard.Entry{

--- a/internal/generator/sumcheck/generate.go
+++ b/internal/generator/sumcheck/generate.go
@@ -1,12 +1,17 @@
 package sumcheck
 
 import (
+	"path/filepath"
+
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
-	"path/filepath"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 )
 
 func Generate(conf config.FieldDependency, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !git.HasChanges("./sumcheck/template/") {
+		return nil
+	}
 	entries := []bavard.Entry{
 		{File: filepath.Join(baseDir, "sumcheck.go"), Templates: []string{"sumcheck.go.tmpl"}},
 		{File: filepath.Join(baseDir, "sumcheck_test.go"), Templates: []string{"sumcheck.test.go.tmpl"}},

--- a/internal/generator/test_vector_utils/generate.go
+++ b/internal/generator/test_vector_utils/generate.go
@@ -1,12 +1,14 @@
 package test_vector_utils
 
 import (
+	"path/filepath"
+
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/consensys/gnark-crypto/internal/generator/gkr"
 	"github.com/consensys/gnark-crypto/internal/generator/polynomial"
 	"github.com/consensys/gnark-crypto/internal/generator/sumcheck"
-	"path/filepath"
 )
 
 type Config struct {
@@ -49,6 +51,9 @@ func GenerateRationals(bgen *bavard.BatchGenerator) error {
 }
 
 func Generate(conf Config, baseDir string, bgen *bavard.BatchGenerator) error {
+	if !git.HasChanges("./test_vector_utils/template/") {
+		return nil
+	}
 	entry := bavard.Entry{
 		File: filepath.Join(baseDir, "test_vector_utils.go"), Templates: []string{"test_vector_utils.go.tmpl"},
 	}

--- a/internal/generator/test_vector_utils/generate.go
+++ b/internal/generator/test_vector_utils/generate.go
@@ -43,6 +43,10 @@ func GenerateRationals(bgen *bavard.BatchGenerator) error {
 	}
 
 	// generate gkr test vector generator for rationals
+	if !git.HasChanges("./gkr/template/") {
+		return nil
+	}
+
 	gkrConf.OutsideGkrPackage = true
 	return bgen.Generate(gkrConf, "main", "./gkr/template", bavard.Entry{
 		File: filepath.Join("gkr", "test_vectors", "main.go"), Templates: []string{"gkr.test.vectors.gen.go.tmpl", "gkr.test.vectors.go.tmpl"},

--- a/internal/generator/tower/generate.go
+++ b/internal/generator/tower/generate.go
@@ -7,12 +7,17 @@ import (
 
 	"github.com/consensys/bavard"
 	"github.com/consensys/gnark-crypto/internal/generator/config"
+	"github.com/consensys/gnark-crypto/internal/generator/git"
 	"github.com/consensys/gnark-crypto/internal/generator/tower/asm/amd64"
 )
 
 // Generate generates a tower 2->6->12 over fp
 func Generate(conf config.Curve, baseDir string, bgen *bavard.BatchGenerator) error {
 	if conf.Equal(config.BW6_761) || conf.Equal(config.BW6_633) || conf.Equal(config.BLS24_315) || conf.Equal(config.BLS24_317) {
+		return nil
+	}
+
+	if !(git.HasChanges("./tower/template")) {
 		return nil
 	}
 


### PR DESCRIPTION
# Description

Not fail proof, but added a `git.HasChanges(..)` internal api, which check if templates have changes before regen files.

The CI has a special build tag that bypasses this, in case some templates end up having some weird dependency chain, we should detect it.

Speeds up dev process when changing only one part of the code base, doesn't regenerate everything.