### PR TITLE
build: update to latest bavard, paralellize addchain read

### DIFF
--- a/field/generator/asm/amd64/build.go
+++ b/field/generator/asm/amd64/build.go
@@ -80,7 +80,7 @@ func (f *FFAmd64) Define(name string, nbInputs int, fn defineFn) defineFn {
 	for _, ok := f.mDefines[name]; ok; {
 		// name already exist, for code generation purpose we add a suffix
 		// should happen only with e2 deprecated functions
-		fmt.Println("WARNING: function name already defined, adding suffix")
+		// fmt.Println("WARNING: function name already defined, adding suffix")
 		i := 0
 		for {
 			newName := fmt.Sprintf("%s_%d", name, i)

--- a/field/generator/asm/arm64/build.go
+++ b/field/generator/asm/arm64/build.go
@@ -95,7 +95,7 @@ func (f *FFArm64) Define(name string, nbInputs int, fn defineFn) defineFn {
 	for _, ok := f.mDefines[name]; ok; {
 		// name already exist, for code generation purpose we add a suffix
 		// should happen only with e2 deprecated functions
-		fmt.Println("WARNING: function name already defined, adding suffix")
+		// fmt.Println("WARNING: function name already defined, adding suffix")
 		i := 0
 		for {
 			newName := fmt.Sprintf("%s_%d", name, i)

--- a/field/generator/internal/addchain/addchain.go
+++ b/field/generator/internal/addchain/addchain.go
@@ -299,29 +299,38 @@ func initCache() {
 	}
 
 	// preload pre-computed add chains
+	var wg sync.WaitGroup
+	var lock sync.Mutex
 	for _, entry := range files {
 		if entry.IsDir() {
 			continue
 		}
-		f, err := os.Open(filepath.Join(addChainDir, entry.Name()))
-		if err != nil {
-			log.Fatal(err)
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f, err := os.Open(filepath.Join(addChainDir, entry.Name()))
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		// decode the addchain.Program
-		dec := gob.NewDecoder(f)
-		var p addchain.Program
-		err = dec.Decode(&p)
-		_ = f.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-		data := processSearchResult(p, filepath.Base(f.Name()))
-		log.Println("read", filepath.Base(f.Name()))
+			// decode the addchain.Program
+			dec := gob.NewDecoder(f)
+			var p addchain.Program
+			err = dec.Decode(&p)
+			_ = f.Close()
+			if err != nil {
+				log.Fatal(err)
+			}
+			data := processSearchResult(p, filepath.Base(f.Name()))
 
-		// save the data
-		mAddchains[filepath.Base(f.Name())] = data
+			// save the data
+			lock.Lock()
+			mAddchains[filepath.Base(f.Name())] = data
+			lock.Unlock()
+		}()
 
 	}
+
+	wg.Wait()
 
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/bits-and-blooms/bitset v1.14.2
-	github.com/consensys/bavard v0.1.25
+	github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b
 	github.com/leanovate/gopter v0.2.11
 	github.com/mmcloughlin/addchain v0.4.0
 	github.com/spf13/cobra v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/consensys/gnark-crypto
 go 1.22
 
 require (
-	github.com/bits-and-blooms/bitset v1.14.2
-	github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b
+	github.com/bits-and-blooms/bitset v1.20.0
+	github.com/consensys/bavard v0.1.27
 	github.com/leanovate/gopter v0.2.11
 	github.com/mmcloughlin/addchain v0.4.0
 	github.com/spf13/cobra v1.8.1
-	github.com/stretchr/testify v1.9.0
-	golang.org/x/crypto v0.31.0
-	golang.org/x/sync v0.1.0
-	golang.org/x/sys v0.28.0
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/crypto v0.32.0
+	golang.org/x/sync v0.10.0
+	golang.org/x/sys v0.29.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bits-and-blooms/bitset v1.14.2 h1:YXVoyPndbdvcEVcseEovVfp0qjJp7S+i5+xgp/Nfbdc=
-github.com/bits-and-blooms/bitset v1.14.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
+github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -55,8 +55,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b h1:3JAmM7vE99PHb9K5+1OzCHDzGWK74QFvO8PSFm3+QLY=
-github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
+github.com/consensys/bavard v0.1.27 h1:j6hKUrGAy/H+gpNrpLU3I26n1yc+VMGmd6ID5+gAhOs=
+github.com/consensys/bavard v0.1.27/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -250,8 +250,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -281,8 +281,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
+golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -384,8 +384,9 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -434,8 +435,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,10 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/consensys/bavard v0.1.25 h1:5YcSBnp03/HvfpKaIQLr/ecspTp2k8YNR5rQLOWvUyc=
 github.com/consensys/bavard v0.1.25/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
+github.com/consensys/bavard v0.1.26-0.20250118151918-932f450fec8b h1:9ql4W1nwoyV0PboeMrOYlMojGsCn8cCHysxS8pnTTDg=
+github.com/consensys/bavard v0.1.26-0.20250118151918-932f450fec8b/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
+github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b h1:3JAmM7vE99PHb9K5+1OzCHDzGWK74QFvO8PSFm3+QLY=
+github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/consensys/bavard v0.1.25 h1:5YcSBnp03/HvfpKaIQLr/ecspTp2k8YNR5rQLOWvUyc=
-github.com/consensys/bavard v0.1.25/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
-github.com/consensys/bavard v0.1.26-0.20250118151918-932f450fec8b h1:9ql4W1nwoyV0PboeMrOYlMojGsCn8cCHysxS8pnTTDg=
-github.com/consensys/bavard v0.1.26-0.20250118151918-932f450fec8b/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b h1:3JAmM7vE99PHb9K5+1OzCHDzGWK74QFvO8PSFm3+QLY=
 github.com/consensys/bavard v0.1.26-0.20250118152544-d6b9e5dffb3b/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"hash"
+
+    "github.com/consensys/bavard"
 )
 
 func main() {
@@ -38,6 +40,9 @@ func GenerateVectors() error {
             if filepath.Ext(dirEntry.Name()) == ".json" {
                 fmt.Println("\tprocessing", dirEntry.Name())
                 path := filepath.Join(testDirPath, dirEntry.Name())
+                if !bavard.ShouldGenerate(path) {
+                    continue
+                }
                 if err = run(path); err != nil {
                     return err
                 }

--- a/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
@@ -38,11 +38,11 @@ func GenerateVectors() error {
         if !dirEntry.IsDir() {
 
             if filepath.Ext(dirEntry.Name()) == ".json" {
-                fmt.Println("\tprocessing", dirEntry.Name())
                 path := filepath.Join(testDirPath, dirEntry.Name())
                 if !bavard.ShouldGenerate(path) {
                     continue
                 }
+                fmt.Println("\tprocessing", dirEntry.Name())
                 if err = run(path); err != nil {
                     return err
                 }

--- a/internal/generator/gkr/test_vectors/main.go
+++ b/internal/generator/gkr/test_vectors/main.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+
+	"github.com/consensys/bavard"
 )
 
 func main() {
@@ -45,6 +47,9 @@ func GenerateVectors() error {
 			if filepath.Ext(dirEntry.Name()) == ".json" {
 				fmt.Println("\tprocessing", dirEntry.Name())
 				path := filepath.Join(testDirPath, dirEntry.Name())
+				if !bavard.ShouldGenerate(path) {
+					continue
+				}
 				if err = run(path); err != nil {
 					return err
 				}

--- a/internal/generator/gkr/test_vectors/main.go
+++ b/internal/generator/gkr/test_vectors/main.go
@@ -45,11 +45,11 @@ func GenerateVectors() error {
 		if !dirEntry.IsDir() {
 
 			if filepath.Ext(dirEntry.Name()) == ".json" {
-				fmt.Println("\tprocessing", dirEntry.Name())
 				path := filepath.Join(testDirPath, dirEntry.Name())
 				if !bavard.ShouldGenerate(path) {
 					continue
 				}
+				fmt.Println("\tprocessing", dirEntry.Name())
 				if err = run(path); err != nil {
 					return err
 				}


### PR DESCRIPTION
# Description

Update bavard to https://github.com/Consensys/bavard/pull/11 . 

Enables running `BAVARD=fft go generate ./...` or `BAVARD=koalabear go generate ./...` to generate only files whose output path contains the env var filter.

