### PR TITLE
CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2213,7 +2213,7 @@
 ### Ci
 - install asmfmt before test step, now that goff field generation tests are included
 - move dep install up
-- ignore G204 rule in gosec (process lauched with var)
+- ignore G204 rule in gosec (process launched with var)
 - testing pr on develop with go 1.15 and go 1.16
 
 ### Docs


### PR DESCRIPTION
# Fix CHANGELOG.md

## Summary
Corrected a typo in the `CHANGELOG.md` file to improve clarity.

## Motivation
This change ensures that the changelog is free from errors and maintains professionalism.

## Changes
- Updated `CHANGELOG.md`:
  - Corrected "lauched" to "launched" in the following entry:
    ```markdown
    - ignore G204 rule in gosec (process launched with var)
    ```

## Testing
- Reviewed the changelog to confirm the typo was fixed.
- Verified no additional changes were required.

## Checklist
- [x] Typo corrected in the changelog.
- [ ] No further updates needed.

---

<!-- Contributions adhere to the project's contributing guidelines, security policy, and code of conduct. -->
