### PR TITLE
fix: ensure fast path is taken only with fixed bound and degree

### DIFF
--- a/ecc/bls12-377/fr/sis/sis.go
+++ b/ecc/bls12-377/fr/sis/sis.go
@@ -101,7 +101,7 @@ func NewRSis(seed int64, logTwoDegree, logTwoBound, maxNbElementsToHash int) (*R
 		maxNbElementsToHash: maxNbElementsToHash,
 	}
 	// for degree == 64 we have a special fast path with a set of unrolled FFTs.
-	if r.Degree == 64 {
+	if r.Degree == 64 && r.LogTwoBound == 16 {
 		// precompute twiddles for the unrolled FFT
 		twiddlesCoset := precomputeTwiddlesCoset(r.Domain.Generator, shift)
 		r.smallFFT = func(k fr.Vector, mask uint64) {
@@ -153,7 +153,7 @@ func (r *RSis) Hash(v, res []fr.Element) error {
 
 	// by default, the mask is ignored (unless we unrolled the FFT and have a degree 64)
 	mask := ^uint64(0)
-	if r.Degree == 64 {
+	if r.Degree == 64 && r.LogTwoBound == 16 {
 		// full FFT
 		mask = uint64(len(partialFFT_64) - 1)
 	}

--- a/field/generator/internal/templates/sis/sis.go.tmpl
+++ b/field/generator/internal/templates/sis/sis.go.tmpl
@@ -116,7 +116,7 @@ func NewRSis(seed int64, logTwoDegree, logTwoBound, maxNbElementsToHash int) (*R
 
 	{{- if .HasUnrolledFFT}}
 		// for degree == 64 we have a special fast path with a set of unrolled FFTs.
-		if r.Degree == 64 {
+		if r.Degree == 64 && r.LogTwoBound == 16 {
 			// precompute twiddles for the unrolled FFT
 			twiddlesCoset := precomputeTwiddlesCoset(r.Domain.Generator, shift)
 			r.smallFFT = func(k {{.FF}}.Vector, mask uint64) {
@@ -222,7 +222,7 @@ func (r *RSis) Hash(v, res []{{ .FF }}.Element) error {
 		}
 	{{- else}}
 		{{- if .HasUnrolledFFT}}
-		if r.Degree == 64 {
+		if r.Degree == 64 && r.LogTwoBound == 16 {
 			// full FFT
 			mask = uint64(len(partialFFT_64) - 1)
 		}

--- a/utils/max.go
+++ b/utils/max.go
@@ -1,0 +1,7 @@
+package utils
+
+// Max returns the maximum of two integers
+func Max(a, b int) int {
+	// Deprecated: but keeping until next major release to avoid breaking some vendored code
+	return max(a, b)
+}


### PR DESCRIPTION
# Description

Fixing an issue when setting SIS parameters w/ log2(bound) == 8 and log2(degree) == 6.