### PR TITLE
GKR Gate Registry

### DIFF
--- a/ecc/bls12-377/fr/gkr/gkr.go
+++ b/ecc/bls12-377/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bls12-377/fr/gkr/gkr_test.go
+++ b/ecc/bls12-377/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bls12-377/fr/polynomial/polynomial.go
+++ b/ecc/bls12-377/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bls12-381/fr/gkr/gkr.go
+++ b/ecc/bls12-381/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bls12-381/fr/gkr/gkr_test.go
+++ b/ecc/bls12-381/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bls12-381/fr/polynomial/polynomial.go
+++ b/ecc/bls12-381/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bls24-315/fr/gkr/gkr.go
+++ b/ecc/bls24-315/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bls24-315/fr/gkr/gkr_test.go
+++ b/ecc/bls24-315/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bls24-315/fr/polynomial/polynomial.go
+++ b/ecc/bls24-315/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bls24-317/fr/gkr/gkr.go
+++ b/ecc/bls24-317/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bls24-317/fr/gkr/gkr_test.go
+++ b/ecc/bls24-317/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bls24-317/fr/polynomial/polynomial.go
+++ b/ecc/bls24-317/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -21,6 +21,7 @@ import (
 
 // The goal is to prove/verify evaluations of many instances of the same circuit
 
+// a Gate is a low-degree multivariate polynomial
 type Gate struct {
 	f         func(...fr.Element) fr.Element
 	nbIn      int // number of inputs

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -21,14 +21,236 @@ import (
 
 // The goal is to prove/verify evaluations of many instances of the same circuit
 
-// Gate must be a low-degree polynomial
-type Gate interface {
-	Evaluate(...fr.Element) fr.Element
-	Degree() int
+type Gate struct {
+	f         func(...fr.Element) fr.Element
+	nbIn      int // number of inputs
+	degree    int // total degree of f
+	linearVar int // if there is a variable of degree 1, its index, -1 otherwise
+}
+
+func (g *Gate) Evaluate(inputs ...fr.Element) fr.Element {
+	if len(inputs) != g.nbIn {
+		panic("invalid number of inputs")
+	}
+	return g.f(inputs...)
+}
+
+// Degree returns the total degree of the gate's polynomial i.e. Degree(xy²) = 3
+func (g *Gate) Degree() int {
+	return g.degree
+}
+
+// LinearVar returns the index of a variable of degree 1 in the gate's polynomial. If there is no such variable, it returns -1.
+func (g *Gate) LinearVar() int {
+	return g.linearVar
+}
+
+var (
+	gates     = make(map[string]*Gate)
+	gatesLock sync.Mutex
+)
+
+type registerGateSettings struct {
+	linearVar               int
+	noLinearVarVerification bool
+	noDegreeVerification    bool
+	degree                  int
+}
+
+type registerGateOption func(*registerGateSettings)
+
+// WithLinearVar gives the index of a variable of degree 1 in the gate's polynomial. RegisterGate will return an error if the given index is not correct.
+func WithLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = linearVar
+	}
+}
+
+// WithUnverifiedLinearVar sets the index of a variable of degree 1 in the gate's polynomial. RegisterGate will not verify that the given index is correct.
+func WithUnverifiedLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noLinearVarVerification = true
+		settings.linearVar = linearVar
+	}
+}
+
+// WithNoLinearVar sets the gate as having no variable of degree 1. RegisterGate will not check the correctness of this claim.
+func WithNoLinearVar() registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = -1
+		settings.noLinearVarVerification = true
+	}
+}
+
+// WithUnverifiedDegree sets the degree of the gate. RegisterGate will not verify that the given degree is correct.
+func WithUnverifiedDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noDegreeVerification = true
+		settings.degree = degree
+	}
+}
+
+// WithDegree sets the degree of the gate. RegisterGate will return an error if the degree is not correct.
+func WithDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.degree = degree
+	}
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, nbIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
+}
+
+// fitPoly tries to fit a polynomial of maximum degree maxDeg to f
+func fitPoly(f func(...fr.Element) fr.Element, nbIn, maxDeg int) (p polynomial.Polynomial, ok bool, err error) {
+
+	// turn f univariate by defining p(x) as f(x, x, ..., x)
+	// evaluate p at random points
+	x := make([]fr.Element, maxDeg+1)
+	y := make([]fr.Element, maxDeg+1)
+	fIn := make([]fr.Element, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+		for j := range fIn {
+			fIn[j] = x[i]
+		}
+		y[i] = f(fIn...)
+	}
+
+	// interpolate p
+	p, err = polynomial.Interpolate(x, y)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// check if p is equal to f. This not being the case means that f is of a degree higher than maxDeg
+	setRandom(&fIn[0])
+	for i := range fIn {
+		fIn[i] = fIn[0]
+	}
+	pAt := p.Eval(&fIn[0])
+	fAt := f(fIn...)
+	if !pAt.Equal(&fAt) {
+		return nil, false, nil
+	}
+
+	// trim p
+	lastNonZero := len(p) - 1
+	for lastNonZero >= 0 && p[lastNonZero].IsZero() {
+		lastNonZero--
+	}
+	return p[:lastNonZero+1], true, nil
+}
+
+// RegisterGate creates a gate object and stores it in the gates registry
+// name is a human-readable name for the gate
+// f is the polynomial function defining the gate
+// nbIn is the number of inputs to the gate
+func RegisterGate(name string, f func(...fr.Element) fr.Element, nbIn int, options ...registerGateOption) error {
+	s := registerGateSettings{degree: -1, linearVar: -1}
+	for _, option := range options {
+		option(&s)
+	}
+
+	if s.linearVar == -1 {
+		if !s.noLinearVarVerification { // find a linear variable
+			for i := range nbIn {
+				if isLinear(f, i, nbIn) {
+					s.linearVar = i
+					break
+				}
+			}
+		}
+	} else {
+		// linear variable given
+		if !s.noLinearVarVerification && !isLinear(f, s.linearVar, nbIn) {
+			return fmt.Errorf("variable %d is not linear in gate %s", s.linearVar, name)
+		}
+	}
+
+	if s.degree == -1 { // find a degree
+		if s.noDegreeVerification {
+			panic("invalid settings")
+		}
+		found := false
+		const maxAutoDegree = 10
+		for s.degree = 5; s.degree <= maxAutoDegree; s.degree += 5 {
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if ok {
+				found = true
+				s.degree = len(p) - 1
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("could not find a degree for gate %s: tried up to %d", name, maxAutoDegree)
+		}
+	} else {
+		if !s.noDegreeVerification { // check that the given degree is correct
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("detected a higher degree than %d for gate %s", s.degree, name)
+			}
+			if len(p)-1 != s.degree {
+				return fmt.Errorf("detected degree %d for gate %s, claimed %d", len(p)-1, name, s.degree)
+			}
+		}
+	}
+
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	gates[name] = &Gate{f: f, nbIn: nbIn, degree: s.degree, linearVar: s.linearVar}
+	return nil
+}
+
+func GetGate(name string) *Gate {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	return gates[name]
+}
+
+func RemoveGate(name string) bool {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	_, found := gates[name]
+	if found {
+		delete(gates, name)
+	}
+	return found
 }
 
 type Wire struct {
-	Gate            Gate
+	Gate            *Gate
 	Inputs          []*Wire // if there are no Inputs, the wire is assumed an input wire
 	nbUniqueOutputs int     // number of other wires using it as input, not counting duplicates (i.e. providing two inputs to the same gate counts as one)
 }
@@ -690,12 +912,13 @@ func Verify(c Circuit, assignment WireAssignment, proof Proof, transcriptSetting
 
 // outputsList also sets the nbUniqueOutputs fields. It also sets the wire metadata.
 func outputsList(c Circuit, indexes map[*Wire]int) [][]int {
+	idGate := GetGate("identity")
 	res := make([][]int, len(c))
 	for i := range c {
 		res[i] = make([]int, 0)
 		c[i].nbUniqueOutputs = 0
 		if c[i].IsInput() {
-			c[i].Gate = IdentityGate{}
+			c[i].Gate = idGate
 		}
 	}
 	ins := make(map[int]struct{}, len(c))
@@ -845,136 +1068,44 @@ func frToBigInts(dst []*big.Int, src []fr.Element) {
 	}
 }
 
-// Gates defined by name
-var Gates = map[string]Gate{
-	"identity": IdentityGate{},
-	"add":      AddGate{},
-	"sub":      SubGate{},
-	"neg":      NegGate{},
-	"mul":      MulGate(2),
-}
+func init() {
+	// register some basic gates
 
-type IdentityGate struct{}
-type AddGate struct{}
-type MulGate int
-type SubGate struct{}
-type NegGate struct{}
+	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 1); err != nil {
+		panic(err)
+	}
 
-func (IdentityGate) Evaluate(input ...fr.Element) fr.Element {
-	return input[0]
-}
-
-func (IdentityGate) Degree() int {
-	return 1
-}
-
-func (g AddGate) Evaluate(x ...fr.Element) (res fr.Element) {
-	switch len(x) {
-	case 0:
-	// set zero
-	case 1:
-		res.Set(&x[0])
-	default:
+	if err := RegisterGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
 		res.Add(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
 
-func (g AddGate) Degree() int {
-	return 1
-}
-
-func (g MulGate) Evaluate(x ...fr.Element) (res fr.Element) {
-	if len(x) != int(g) {
-		panic("wrong input count")
+	if err := RegisterGate("sub2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Sub(&x[0], &x[1])
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	switch len(x) {
-	case 0:
-		res.SetOne()
-	case 1:
-		res.Set(&x[0])
-	default:
+
+	if err := RegisterGate("neg", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Neg(&x[0])
+		return res
+	}, 1); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
 		res.Mul(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
-
-func (g MulGate) Degree() int {
-	return int(g)
-}
-
-func (g SubGate) Evaluate(element ...fr.Element) (diff fr.Element) {
-	if len(element) > 2 {
-		panic("not implemented") //TODO
-	}
-	diff.Sub(&element[0], &element[1])
-	return
-}
-
-func (g SubGate) Degree() int {
-	return 1
-}
-
-func (g NegGate) Evaluate(element ...fr.Element) (neg fr.Element) {
-	if len(element) != 1 {
-		panic("univariate gate")
-	}
-	neg.Neg(&element[0])
-	return
-}
-
-func (g NegGate) Degree() int {
-	return 1
-}
-
-// TestGateDegree checks if deg(g) = g.Degree()
-func TestGateDegree(g Gate, nbIn int) error {
-	// TODO when Gate is a struct, turn this into a method
-	if nbIn < 1 {
-		return errors.New("at least one input required")
-	}
-
-	d := g.Degree()
-	// evaluate g at 0 .. d
-	var one, _x fr.Element
-	one.SetOne()
-	x := make([]fr.Element, nbIn)
-	y := make([]fr.Element, d+1)
-	for i := range y {
-		y[i] = g.Evaluate(x...)
-		_x.Add(&_x, &one)
-		for j := range x {
-			x[j] = _x
-		}
-	}
-
-	p := polynomial.InterpolateOnRange(y)
-	// test if p matches g
-	if _, err := _x.SetRandom(); err != nil {
-		return err
-	}
-	for j := range x {
-		x[j] = _x
-	}
-
-	if expected, encountered := p.Eval(&x[0]), g.Evaluate(x...); !expected.Equal(&encountered) {
-		return fmt.Errorf("interpolation failed: not a polynomial of degree %d or lower", d)
-	}
-
-	// check if the degree is LESS than d
-	degP := d
-	for degP >= 0 && p[degP].IsZero() {
-		degP--
-	}
-	if degP != d {
-		return fmt.Errorf("expected polynomial of degree %d, interpolation yielded %d", d, degP)
-	}
-
-	return nil
 }

--- a/ecc/bn254/fr/gkr/gkr.go
+++ b/ecc/bn254/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bn254/fr/gkr/gkr_test.go
+++ b/ecc/bn254/fr/gkr/gkr_test.go
@@ -560,22 +560,22 @@ func mimcRound(input ...fr.Element) (res fr.Element) {
 
 	sum.
 		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
-	res.Square(&sum)              // sum^2
-	res.Mul(&res, &sum)           // sum^3
-	res.Square(&res)              //sum^6
-	res.Mul(&res, &sum)           //sum^7
+	res.Square(&sum)    // sum^2
+	res.Mul(&res, &sum) // sum^3
+	res.Square(&res)    //sum^6
+	res.Mul(&res, &sum) //sum^7
 
 	return
 }
 
 func init() {
-	if err := RegisterGate("mimc", mimcRound, 2); err != nil {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
 		panic(err)
 	}
 
 	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
 		return input[2]
-	}, 3); err != nil {
+	}, 3, WithUnverifiedDegree(1)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bn254/fr/gkr/gkr_test.go
+++ b/ecc/bn254/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,32 +555,29 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
-	res.Square(&sum)    // sum^2
-	res.Mul(&res, &sum) // sum^3
-	res.Square(&res)    //sum^6
-	res.Mul(&res, &sum) //sum^7
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
+	res.Square(&sum)              // sum^2
+	res.Mul(&res, &sum)           // sum^3
+	res.Square(&res)              //sum^6
+	res.Mul(&res, &sum)           //sum^7
 
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bn254/fr/polynomial/polynomial.go
+++ b/ecc/bn254/fr/polynomial/polynomial.go
@@ -333,7 +333,7 @@ func Interpolate(X, Y []fr.Element) (Polynomial, error) {
 		// use row i to eliminate the ith element in all rows below
 		var negInv fr.Element
 		if augmentedRows[i][i].IsZero() {
-			return nil, errors.New("lower degree than expected")
+			return nil, errors.New("singular matrix")
 		}
 		negInv.Inverse(&augmentedRows[i][i])
 		negInv.Neg(&negInv)
@@ -362,4 +362,32 @@ func Interpolate(X, Y []fr.Element) (Polynomial, error) {
 	}
 
 	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bn254/fr/polynomial/polynomial.go
+++ b/ecc/bn254/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,59 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("lower degree than expected")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
 }

--- a/ecc/bn254/fr/polynomial/polynomial_test.go
+++ b/ecc/bn254/fr/polynomial/polynomial_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 )
@@ -252,23 +251,4 @@ func TestLagrangeCache(t *testing.T) {
 		b := getLagrangeBasis(uint8(i))
 		assert.Equal(t, b, getLagrangeBasis(uint8(i))) // second call must yield the same result
 	}
-}
-
-func TestInterpolate(t *testing.T) {
-	x := make([]fr.Element, 3)
-	y := make([]fr.Element, 3)
-
-	x[0].SetUint64(1)
-	x[1].SetUint64(2)
-	x[2].SetUint64(3)
-
-	y[0].SetUint64(2)
-	y[1].SetUint64(4)
-	y[2].SetUint64(8)
-
-	p, err := Interpolate(x, y)
-	require.NoError(t, err)
-	assert.Equal(t, "2", p[0].String())
-	assert.Equal(t, "-1", p[1].String())
-	assert.Equal(t, "1", p[2].String())
 }

--- a/ecc/bn254/fr/polynomial/polynomial_test.go
+++ b/ecc/bn254/fr/polynomial/polynomial_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 )
@@ -251,4 +252,23 @@ func TestLagrangeCache(t *testing.T) {
 		b := getLagrangeBasis(uint8(i))
 		assert.Equal(t, b, getLagrangeBasis(uint8(i))) // second call must yield the same result
 	}
+}
+
+func TestInterpolate(t *testing.T) {
+	x := make([]fr.Element, 3)
+	y := make([]fr.Element, 3)
+
+	x[0].SetUint64(1)
+	x[1].SetUint64(2)
+	x[2].SetUint64(3)
+
+	y[0].SetUint64(2)
+	y[1].SetUint64(4)
+	y[2].SetUint64(8)
+
+	p, err := Interpolate(x, y)
+	require.NoError(t, err)
+	assert.Equal(t, "2", p[0].String())
+	assert.Equal(t, "-1", p[1].String())
+	assert.Equal(t, "1", p[2].String())
 }

--- a/ecc/bw6-633/fr/gkr/gkr.go
+++ b/ecc/bw6-633/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bw6-633/fr/gkr/gkr_test.go
+++ b/ecc/bw6-633/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bw6-633/fr/polynomial/polynomial.go
+++ b/ecc/bw6-633/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/bw6-761/fr/gkr/gkr.go
+++ b/ecc/bw6-761/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/bw6-761/fr/gkr/gkr_test.go
+++ b/ecc/bw6-761/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/bw6-761/fr/polynomial/polynomial.go
+++ b/ecc/bw6-761/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/ecc/grumpkin/fr/gkr/gkr.go
+++ b/ecc/grumpkin/fr/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...fr.Element) fr.Element {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res fr.Element
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res fr.Element
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res fr.Element
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res fr.Element
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/ecc/grumpkin/fr/gkr/gkr_test.go
+++ b/ecc/grumpkin/fr/gkr/gkr_test.go
@@ -99,7 +99,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]fr.Element) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	}}
@@ -167,7 +167,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]fr
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]fr.Element, numInput)
@@ -203,7 +203,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]fr.Element) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["add"],
+		Gate:   GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -223,7 +223,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]fr.Element) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -243,12 +243,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]fr.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -268,7 +268,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]fr.Element) {
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -291,11 +291,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -316,7 +316,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -353,7 +353,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -370,7 +370,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []fr.Element) {
+func setRandomSlice(slice []fr.Element) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -448,8 +448,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -545,7 +545,7 @@ func getCircuit(path string) (Circuit, error) {
 func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	circuit = make(Circuit, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*Wire, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -555,22 +555,11 @@ func (c CircuitInfo) toCircuit() (circuit Circuit) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark fr.Element
-}
-
-func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
+func mimcRound(input ...fr.Element) (res fr.Element) {
 	var sum fr.Element
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
+		Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
 	res.Square(&sum)    // sum^2
 	res.Mul(&res, &sum) // sum^3
 	res.Square(&res)    //sum^6
@@ -579,8 +568,16 @@ func (m mimcCipherGate) Evaluate(input ...fr.Element) (res fr.Element) {
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...fr.Element) fr.Element {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -728,44 +725,59 @@ func newTestCase(path string) (*TestCase, error) {
 	return tCase, nil
 }
 
-type _select int
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g _select) Evaluate(in ...fr.Element) fr.Element {
-	return in[g]
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g _select) Degree() int {
-	return 1
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
-
-func (g gateWrapper) Evaluate(inputs ...fr.Element) fr.Element {
-	return g.g.Evaluate(inputs...)
-}
-
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/ecc/grumpkin/fr/polynomial/polynomial.go
+++ b/ecc/grumpkin/fr/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/ecc/grumpkin/fr"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []fr.Element) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]fr.Element, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]fr.Element, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv fr.Element
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c fr.Element
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t fr.Element
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t fr.Element
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *fr.Element) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...fr.Element) fr.Element, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]fr.Element, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/internal/generator/gkr/template/gkr.go.tmpl
+++ b/internal/generator/gkr/template/gkr.go.tmpl
@@ -1070,7 +1070,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...{{.ElementType}}) {{.ElementType}} {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1078,7 +1078,7 @@ func init() {
 		var res {{.ElementType}}
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1086,7 +1086,7 @@ func init() {
 		var res {{.ElementType}}
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1094,7 +1094,7 @@ func init() {
 		var res {{.ElementType}}
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1102,7 +1102,7 @@ func init() {
 		var res {{.ElementType}}
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/internal/generator/gkr/template/gkr.go.tmpl
+++ b/internal/generator/gkr/template/gkr.go.tmpl
@@ -16,14 +16,237 @@ import (
 
 // The goal is to prove/verify evaluations of many instances of the same circuit
 
-// Gate must be a low-degree polynomial
-type Gate interface {
-	Evaluate(...{{.ElementType}}) {{.ElementType}}
-	Degree() int
+// a Gate is a low-degree multivariate polynomial
+type Gate struct {
+	f         func(...{{.ElementType}}) {{.ElementType}}
+	nbIn      int // number of inputs
+	degree    int // total degree of f
+	linearVar int // if there is a variable of degree 1, its index, -1 otherwise
+}
+
+func (g *Gate) Evaluate(inputs ...{{.ElementType}}) {{.ElementType}} {
+	if len(inputs) != g.nbIn {
+		panic("invalid number of inputs")
+	}
+	return g.f(inputs...)
+}
+
+// Degree returns the total degree of the gate's polynomial i.e. Degree(xy²) = 3
+func (g *Gate) Degree() int {
+	return g.degree
+}
+
+// LinearVar returns the index of a variable of degree 1 in the gate's polynomial. If there is no such variable, it returns -1.
+func (g *Gate) LinearVar() int {
+	return g.linearVar
+}
+
+var (
+	gates     = make(map[string]*Gate)
+	gatesLock sync.Mutex
+)
+
+type registerGateSettings struct {
+	linearVar               int
+	noLinearVarVerification bool
+	noDegreeVerification    bool
+	degree                  int
+}
+
+type registerGateOption func(*registerGateSettings)
+
+// WithLinearVar gives the index of a variable of degree 1 in the gate's polynomial. RegisterGate will return an error if the given index is not correct.
+func WithLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = linearVar
+	}
+}
+
+// WithUnverifiedLinearVar sets the index of a variable of degree 1 in the gate's polynomial. RegisterGate will not verify that the given index is correct.
+func WithUnverifiedLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noLinearVarVerification = true
+		settings.linearVar = linearVar
+	}
+}
+
+// WithNoLinearVar sets the gate as having no variable of degree 1. RegisterGate will not check the correctness of this claim.
+func WithNoLinearVar() registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = -1
+		settings.noLinearVarVerification = true
+	}
+}
+
+// WithUnverifiedDegree sets the degree of the gate. RegisterGate will not verify that the given degree is correct.
+func WithUnverifiedDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noDegreeVerification = true
+		settings.degree = degree
+	}
+}
+
+// WithDegree sets the degree of the gate. RegisterGate will return an error if the degree is not correct.
+func WithDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.degree = degree
+	}
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *{{.ElementType}}) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...{{.ElementType}}) {{.ElementType}}, i, nbIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]{{.ElementType}}, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
+}
+
+// fitPoly tries to fit a polynomial of maximum degree maxDeg to f
+func fitPoly(f func(...{{.ElementType}}) {{.ElementType}}, nbIn, maxDeg int) (p polynomial.Polynomial, ok bool, err error) {
+
+	// turn f univariate by defining p(x) as f(x, x, ..., x)
+	// evaluate p at random points
+	x := make([]{{.ElementType}}, maxDeg+1)
+	y := make([]{{.ElementType}}, maxDeg+1)
+	fIn := make([]{{.ElementType}}, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+		for j := range fIn {
+			fIn[j] = x[i]
+		}
+		y[i] = f(fIn...)
+	}
+
+	// interpolate p
+	p, err = polynomial.Interpolate(x, y)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// check if p is equal to f. This not being the case means that f is of a degree higher than maxDeg
+	setRandom(&fIn[0])
+	for i := range fIn {
+		fIn[i] = fIn[0]
+	}
+	pAt := p.Eval(&fIn[0])
+	fAt := f(fIn...)
+	if !pAt.Equal(&fAt) {
+		return nil, false, nil
+	}
+
+	// trim p
+	lastNonZero := len(p) - 1
+	for lastNonZero >= 0 && p[lastNonZero].IsZero() {
+		lastNonZero--
+	}
+	return p[:lastNonZero+1], true, nil
+}
+
+// RegisterGate creates a gate object and stores it in the gates registry
+// name is a human-readable name for the gate
+// f is the polynomial function defining the gate
+// nbIn is the number of inputs to the gate
+func RegisterGate(name string, f func(...{{.ElementType}}) {{.ElementType}}, nbIn int, options ...registerGateOption) error {
+	s := registerGateSettings{degree: -1, linearVar: -1}
+	for _, option := range options {
+		option(&s)
+	}
+
+	if s.linearVar == -1 {
+		if !s.noLinearVarVerification { // find a linear variable
+			for i := range nbIn {
+				if isLinear(f, i, nbIn) {
+					s.linearVar = i
+					break
+				}
+			}
+		}
+	} else {
+		// linear variable given
+		if !s.noLinearVarVerification && !isLinear(f, s.linearVar, nbIn) {
+			return fmt.Errorf("variable %d is not linear in gate %s", s.linearVar, name)
+		}
+	}
+
+	if s.degree == -1 { // find a degree
+		if s.noDegreeVerification {
+			panic("invalid settings")
+		}
+		found := false
+		const maxAutoDegree = 10
+		for s.degree = 5; s.degree <= maxAutoDegree; s.degree += 5 {
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if ok {
+				found = true
+				s.degree = len(p) - 1
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("could not find a degree for gate %s: tried up to %d", name, maxAutoDegree)
+		}
+	} else {
+		if !s.noDegreeVerification { // check that the given degree is correct
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("detected a higher degree than %d for gate %s", s.degree, name)
+			}
+			if len(p)-1 != s.degree {
+				return fmt.Errorf("detected degree %d for gate %s, claimed %d", len(p)-1, name, s.degree)
+			}
+		}
+	}
+
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	gates[name] = &Gate{f: f, nbIn: nbIn, degree: s.degree, linearVar: s.linearVar}
+	return nil
+}
+
+func GetGate(name string) *Gate {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	return gates[name]
+}
+
+func RemoveGate(name string) bool {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	_, found := gates[name]
+	if found {
+		delete(gates, name)
+	}
+	return found
 }
 
 type Wire struct {
-	Gate            Gate
+	Gate            *Gate
 	Inputs          []*Wire // if there are no Inputs, the wire is assumed an input wire
 	nbUniqueOutputs int     // number of other wires using it as input, not counting duplicates (i.e. providing two inputs to the same gate counts as one)
 }
@@ -686,12 +909,13 @@ func Verify(c Circuit, assignment WireAssignment, proof Proof, transcriptSetting
 
 // outputsList also sets the nbUniqueOutputs fields. It also sets the wire metadata.
 func outputsList(c Circuit, indexes map[*Wire]int) [][]int {
+	idGate := GetGate("identity")
 	res := make([][]int, len(c))
 	for i := range c {
 		res[i] = make([]int, 0)
 		c[i].nbUniqueOutputs = 0
 		if c[i].IsInput() {
-			c[i].Gate = IdentityGate{}
+			c[i].Gate = idGate
 		}
 	}
 	ins := make(map[int]struct{}, len(c))
@@ -841,136 +1065,44 @@ func frToBigInts(dst []*big.Int, src []{{.ElementType}}) {
 	}
 }
 
-// Gates defined by name
-var Gates = map[string]Gate{
-	"identity": IdentityGate{},
-	"add":		AddGate{},
-	"sub":		SubGate{},
-	"neg":		NegGate{},
-	"mul":      MulGate(2),
-}
+func init() {
+	// register some basic gates
 
-type IdentityGate struct{}
-type AddGate struct{}
-type MulGate int
-type SubGate struct{}
-type NegGate struct{}
+	if err := RegisterGate("identity", func(x ...{{.ElementType}}) {{.ElementType}} {
+		return x[0]
+	}, 1); err != nil {
+		panic(err)
+	}
 
-func (IdentityGate) Evaluate(input ...{{.ElementType}}) {{.ElementType}} {
-	return input[0]
-}
-
-func (IdentityGate) Degree() int {
-	return 1
-}
-
-func (g AddGate) Evaluate(x ...{{.ElementType}}) (res {{.ElementType}}) {
-	switch len(x) {
-	case 0:
-	// set zero
-	case 1:
-		res.Set(&x[0])
-	default:
+	if err := RegisterGate("add2", func(x ...{{.ElementType}}) {{.ElementType}} {
+		var res {{.ElementType}}
 		res.Add(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
 
-func (g AddGate) Degree() int {
-	return 1
-}
-
-func (g MulGate) Evaluate(x ...{{.ElementType}}) (res {{.ElementType}}) {
-	if len(x) != int(g) {
-		panic("wrong input count")
+	if err := RegisterGate("sub2", func(x ...{{.ElementType}}) {{.ElementType}} {
+		var res {{.ElementType}}
+		res.Sub(&x[0], &x[1])
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	switch len(x) {
-	case 0:
-		res.SetOne()
-	case 1:
-		res.Set(&x[0])
-	default:
+
+	if err := RegisterGate("neg", func(x ...{{.ElementType}}) {{.ElementType}} {
+		var res {{.ElementType}}
+		res.Neg(&x[0])
+		return res
+	}, 1); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("mul2", func(x ...{{.ElementType}}) {{.ElementType}} {
+		var res {{.ElementType}}
 		res.Mul(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
-
-func (g MulGate) Degree() int {
-	return int(g)
-}
-
-func (g SubGate) Evaluate(element ...{{.ElementType}}) (diff {{.ElementType}}) {
-	if len(element) > 2 {
-		panic("not implemented") //TODO
-	}
-	diff.Sub(&element[0], &element[1])
-	return
-}
-
-func (g SubGate) Degree() int {
-	return 1
-}
-
-func (g NegGate) Evaluate(element ...{{.ElementType}}) (neg {{.ElementType}}) {
-	if len(element) != 1 {
-		panic("univariate gate")
-	}
-	neg.Neg(&element[0])
-	return
-}
-
-func (g NegGate) Degree() int {
-	return 1
-}
-
-// TestGateDegree checks if deg(g) = g.Degree()
-func TestGateDegree(g Gate, nbIn int) error {
-	// TODO when Gate is a struct, turn this into a method
-	if nbIn < 1 {
-		return errors.New("at least one input required")
-	}
-
-	d := g.Degree()
-	// evaluate g at 0 .. d
-	var one, _x {{.ElementType}}
-	one.SetOne()
-	x := make([]{{.ElementType}}, nbIn)
-	y := make([]{{.ElementType}}, d+1)
-	for i := range y {
-		y[i] = g.Evaluate(x...)
-		_x.Add(&_x, &one)
-		for j := range x {
-			x[j] = _x
-		}
-	}
-
-	p := polynomial.InterpolateOnRange(y)
-	// test if p matches g
-	if _, err := _x.SetRandom(); err != nil {
-		return err
-	}
-	for j := range x {
-		x[j] = _x
-	}
-
-	if expected, encountered := p.Eval(&x[0]), g.Evaluate(x...); !expected.Equal(&encountered) {
-		return fmt.Errorf("interpolation failed: not a polynomial of degree %d or lower", d)
-	}
-
-	// check if the degree is LESS than d
-	degP := d
-	for degP >= 0 && p[degP].IsZero() {
-		degP--
-	}
-	if degP != d {
-		return fmt.Errorf("expected polynomial of degree %d, interpolation yielded %d", d, degP)
-	}
-
-	return nil
 }

--- a/internal/generator/gkr/template/gkr.test.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.go.tmpl
@@ -100,7 +100,7 @@ func generateTestMimc(numRounds int) func(*testing.T, ...[]{{.ElementType}}) {
 
 func TestSumcheckFromSingleInputTwoIdentityGatesGateTwoInstances(t *testing.T) {
 	circuit := Circuit{ Wire{
-		Gate:            IdentityGate{},
+		Gate:            GetGate("identity"),
 		Inputs:          []*Wire{},
 		nbUniqueOutputs: 2,
 	} }
@@ -168,7 +168,7 @@ func testManyInstances(t *testing.T, numInput int, test func(*testing.T, ...[]{{
 
 	for i := range fullAssignments {
 		fullAssignments[i] = make([]fr.Element, maxSize)
-		setRandom(fullAssignments[i])
+		setRandomSlice(fullAssignments[i])
 	}
 
 	inputAssignments := make([][]{{.ElementType}}, numInput)
@@ -204,7 +204,7 @@ func testNoGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {
 func testSingleAddGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate: Gates["add"],
+		Gate: GetGate("add2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -224,7 +224,7 @@ func testSingleMulGate(t *testing.T, inputAssignments ...[]{{.ElementType}}) {
 
 	c := make(Circuit, 3)
 	c[2] = Wire{
-		Gate:   Gates["mul"],
+		Gate:   GetGate("mul2"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -244,12 +244,12 @@ func testSingleInputTwoIdentityGates(t *testing.T, inputAssignments ...[]{{.Elem
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 
@@ -269,7 +269,7 @@ func testSingleMimcCipherGate(t *testing.T, inputAssignments ...[]{{.ElementType
 	c := make(Circuit, 3)
 
 	c[2] = Wire{
-		Gate:   mimcCipherGate{},
+		Gate:   GetGate("mimc"),
 		Inputs: []*Wire{&c[0], &c[1]},
 	}
 
@@ -292,11 +292,11 @@ func testSingleInputTwoIdentityGatesComposed(t *testing.T, inputAssignments ...[
 	c := make(Circuit, 3)
 
 	c[1] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[0]},
 	}
 	c[2] = Wire{
-		Gate:   IdentityGate{},
+		Gate:   GetGate("identity"),
 		Inputs: []*Wire{&c[1]},
 	}
 
@@ -317,7 +317,7 @@ func mimcCircuit(numRounds int) Circuit {
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   mimcCipherGate{},
+			Gate:   GetGate("mimc"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -354,7 +354,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]{{.El
 
 	for i := 2; i < len(c); i++ {
 		c[i] = Wire{
-			Gate:   Gates["mul"],
+			Gate:   GetGate("mul2"),
 			Inputs: []*Wire{&c[i-1], &c[0]},
 		}
 	}
@@ -371,7 +371,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]{{.El
 	assert.NotNil(t, err, "bad proof accepted")
 }
 
-func setRandom(slice []{{.ElementType}}) {
+func setRandomSlice(slice []{{.ElementType}}) {
 	for i := range slice {
 		slice[i].SetRandom()
 	}
@@ -449,8 +449,8 @@ func benchmarkGkrMiMC(b *testing.B, nbInstances, mimcDepth int) {
 
 	in0 := make([]fr.Element, nbInstances)
 	in1 := make([]fr.Element, nbInstances)
-	setRandom(in0)
-	setRandom(in1)
+	setRandomSlice(in0)
+	setRandomSlice(in1)
 
 	fmt.Println("evaluating circuit")
 	start := time.Now().UnixMicro()
@@ -513,34 +513,59 @@ func TestTopSortWide(t *testing.T) {
 
 {{template "gkrTestVectors" .}}
 
-// gateWrapper enables assigning an arbitrary degree to a gate
-type gateWrapper struct {
-	g Gate
-	d int
-}
+func TestRegisterGateDegreeDetection(t *testing.T) {
+	testGate := func(name string, f func(...fr.Element) fr.Element, nbIn, degree int) {
+		t.Run(name, func(t *testing.T) {
+			name = name + "-register-gate-test"
 
-func (g gateWrapper) Degree() int {
-	return g.d
-}
+			assert.NoError(t, RegisterGate(name, f, nbIn, WithDegree(degree)), "given degree must be accepted")
+			RemoveGate(name)
 
-func (g gateWrapper) Evaluate(inputs ...{{.ElementType}}) {{.ElementType}} {
-	return g.g.Evaluate(inputs...)
-}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree-1)), "lower degree must be rejected")
+			RemoveGate(name)
 
-func TestTestGateDegree(t *testing.T) {
-	onGate := func(g Gate, nbIn int) func(t *testing.T) {
-		return func(t *testing.T) {
-			w := gateWrapper{g: g, d: g.Degree()}
-			assert.NoError(t, TestGateDegree(w, nbIn), "must succeed on the gate itself")
-			w.d--
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an underreported degree")
-			w.d += 2
-			assert.Error(t, TestGateDegree(w, nbIn), "must fail on an over-reported degree")
-		}
+			assert.Error(t, RegisterGate(name, f, nbIn, WithDegree(degree+1)), "higher degree must be rejected")
+			RemoveGate(name)
+
+			assert.NoError(t, RegisterGate(name, f, nbIn), "no degree must be accepted")
+			assert.Equal(t, degree, GetGate(name).Degree(), "degree must be detected correctly")
+			RemoveGate(name)
+		})
 	}
 
-	t.Run("select", onGate(_select(0), 1))
-	t.Run("add", onGate(Gates["add"], 2))
-	t.Run("mul", onGate(Gates["mul"], 2))
-	t.Run("mimc", onGate(mimcCipherGate{}, 2))
+	testGate("select", func(x ...fr.Element) fr.Element {
+		return x[0]
+	}, 3, 1)
+
+	testGate("add2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Add(&res, &x[2])
+		return res
+	}, 3, 1)
+
+	testGate("mul2", func(x ...fr.Element) fr.Element {
+		var res fr.Element
+		res.Mul(&x[0], &x[1])
+		return res
+	}, 2, 2)
+
+	testGate("mimc", mimcRound, 2, 7)
+}
+
+func TestIsLinear(t *testing.T) {
+
+	// f: x,y -> x² + xy
+	f := func(x ...fr.Element) fr.Element {
+		if len(x) != 2 {
+			panic("bivariate input needed")
+		}
+		var res fr.Element
+		res.Add(&x[0], &x[1])
+		res.Mul(&res, &x[0])
+		return res
+	}
+
+	assert.True(t, isLinear(f, 1, 2))
+	assert.False(t, isLinear(f, 0, 2))
 }

--- a/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.vectors.gen.go.tmpl
@@ -120,6 +120,11 @@ func toPrintableProof(proof gkr.Proof) (PrintableProof, error) {
 	return res, nil
 }
 
-var Gates = gkr.Gates
+var (
+	GetGate = gkr.GetGate
+	RegisterGate = gkr.RegisterGate
+	WithUnverifiedDegree = gkr.WithUnverifiedDegree
+)
+
 
 {{template "gkrTestVectors" .}}

--- a/internal/generator/gkr/template/gkr.test.vectors.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.vectors.go.tmpl
@@ -45,7 +45,7 @@ func getCircuit(path string) ({{$Circuit}}, error) {
 func (c CircuitInfo) toCircuit() (circuit {{$Circuit}}) {
 	circuit = make({{$Circuit}}, len(c))
 	for i := range c {
-		circuit[i].Gate = Gates[c[i].Gate]
+		circuit[i].Gate = GetGate(c[i].Gate)
 		circuit[i].Inputs = make([]*{{$Wire}}, len(c[i].Inputs))
 		for k, inputCoord := range c[i].Inputs {
 			input := &circuit[inputCoord]
@@ -55,32 +55,29 @@ func (c CircuitInfo) toCircuit() (circuit {{$Circuit}}) {
 	return
 }
 
-func init() {
-	Gates["mimc"] = mimcCipherGate{} //TODO: Add ark
-	Gates["select-input-3"] = _select(2)
-}
-
-type mimcCipherGate struct {
-	ark {{.ElementType}}
-}
-
-func (m mimcCipherGate) Evaluate(input ...{{.ElementType}}) (res {{.ElementType}}) {
+func mimcRound(input ...{{.ElementType}}) (res {{.ElementType}}) {
 	var sum {{.ElementType}}
 
 	sum.
-		Add(&input[0], &input[1]).
-		Add(&sum, &m.ark)
-
-	res.Square(&sum)    // sum^2
-	res.Mul(&res, &sum) // sum^3
-	res.Square(&res)    //sum^6
-	res.Mul(&res, &sum) //sum^7
+	Add(&input[0], &input[1]) //.Add(&sum, &m.ark)  TODO: add ark
+	res.Square(&sum)              // sum^2
+	res.Mul(&res, &sum)           // sum^3
+	res.Square(&res)              //sum^6
+	res.Mul(&res, &sum)           //sum^7
 
 	return
 }
 
-func (m mimcCipherGate) Degree() int {
-	return 7
+func init() {
+	if err := RegisterGate("mimc", mimcRound, 2, WithUnverifiedDegree(7)); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("select-input-3", func(input ...{{.ElementType}}) {{.ElementType}} {
+		return input[2]
+	}, 3, WithUnverifiedDegree(1)); err != nil {
+		panic(err)
+	}
 }
 
 type PrintableProof []PrintableSumcheckProof
@@ -234,16 +231,6 @@ func newTestCase(path string) (*TestCase, error) {
 	}
 
 	return tCase, nil
-}
-
-type _select int
-
-func (g _select) Evaluate(in ...{{.ElementType}}) {{.ElementType}} {
-	return in[g]
-}
-
-func (g _select) Degree() int {
-	return 1
 }
 
 {{end}}

--- a/internal/generator/gkr/test_vectors/resources/single_input_two_outs.json
+++ b/internal/generator/gkr/test_vectors/resources/single_input_two_outs.json
@@ -4,7 +4,7 @@
     "inputs": []
   },
   {
-    "gate": "mul",
+    "gate": "mul2",
     "inputs": [0, 0]
   },
   {

--- a/internal/generator/gkr/test_vectors/resources/single_mul_gate.json
+++ b/internal/generator/gkr/test_vectors/resources/single_mul_gate.json
@@ -8,7 +8,7 @@
     "inputs": []
   },
   {
-    "gate": "mul",
+    "gate": "mul2",
     "inputs": [0, 1]
   }
 ]

--- a/internal/generator/polynomial/template/polynomial.go.tmpl
+++ b/internal/generator/polynomial/template/polynomial.go.tmpl
@@ -1,4 +1,5 @@
 import (
+	"errors"
 	"{{.FieldPackagePath}}"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -299,4 +300,88 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []{{.ElementType}}) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]{{.ElementType}}, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]{{.ElementType}}, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv {{.ElementType}}
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c {{.ElementType}}
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t {{.ElementType}}
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t {{.ElementType}}
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *{{.ElementType}}) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...{{.ElementType}}) {{.ElementType}}, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]{{.ElementType}}, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
+++ b/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
@@ -1074,7 +1074,7 @@ func init() {
 
 	if err := RegisterGate("identity", func(x ...small_rational.SmallRational) small_rational.SmallRational {
 		return x[0]
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1082,7 +1082,7 @@ func init() {
 		var res small_rational.SmallRational
 		res.Add(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1090,7 +1090,7 @@ func init() {
 		var res small_rational.SmallRational
 		res.Sub(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1098,7 +1098,7 @@ func init() {
 		var res small_rational.SmallRational
 		res.Neg(&x[0])
 		return res
-	}, 1); err != nil {
+	}, 1, WithUnverifiedDegree(1), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 
@@ -1106,7 +1106,7 @@ func init() {
 		var res small_rational.SmallRational
 		res.Mul(&x[0], &x[1])
 		return res
-	}, 2); err != nil {
+	}, 2, WithUnverifiedDegree(2), WithUnverifiedLinearVar(0)); err != nil {
 		panic(err)
 	}
 }

--- a/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
+++ b/internal/generator/test_vector_utils/small_rational/gkr/gkr.go
@@ -21,14 +21,237 @@ import (
 
 // The goal is to prove/verify evaluations of many instances of the same circuit
 
-// Gate must be a low-degree polynomial
-type Gate interface {
-	Evaluate(...small_rational.SmallRational) small_rational.SmallRational
-	Degree() int
+// a Gate is a low-degree multivariate polynomial
+type Gate struct {
+	f         func(...small_rational.SmallRational) small_rational.SmallRational
+	nbIn      int // number of inputs
+	degree    int // total degree of f
+	linearVar int // if there is a variable of degree 1, its index, -1 otherwise
+}
+
+func (g *Gate) Evaluate(inputs ...small_rational.SmallRational) small_rational.SmallRational {
+	if len(inputs) != g.nbIn {
+		panic("invalid number of inputs")
+	}
+	return g.f(inputs...)
+}
+
+// Degree returns the total degree of the gate's polynomial i.e. Degree(xy²) = 3
+func (g *Gate) Degree() int {
+	return g.degree
+}
+
+// LinearVar returns the index of a variable of degree 1 in the gate's polynomial. If there is no such variable, it returns -1.
+func (g *Gate) LinearVar() int {
+	return g.linearVar
+}
+
+var (
+	gates     = make(map[string]*Gate)
+	gatesLock sync.Mutex
+)
+
+type registerGateSettings struct {
+	linearVar               int
+	noLinearVarVerification bool
+	noDegreeVerification    bool
+	degree                  int
+}
+
+type registerGateOption func(*registerGateSettings)
+
+// WithLinearVar gives the index of a variable of degree 1 in the gate's polynomial. RegisterGate will return an error if the given index is not correct.
+func WithLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = linearVar
+	}
+}
+
+// WithUnverifiedLinearVar sets the index of a variable of degree 1 in the gate's polynomial. RegisterGate will not verify that the given index is correct.
+func WithUnverifiedLinearVar(linearVar int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noLinearVarVerification = true
+		settings.linearVar = linearVar
+	}
+}
+
+// WithNoLinearVar sets the gate as having no variable of degree 1. RegisterGate will not check the correctness of this claim.
+func WithNoLinearVar() registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.linearVar = -1
+		settings.noLinearVarVerification = true
+	}
+}
+
+// WithUnverifiedDegree sets the degree of the gate. RegisterGate will not verify that the given degree is correct.
+func WithUnverifiedDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.noDegreeVerification = true
+		settings.degree = degree
+	}
+}
+
+// WithDegree sets the degree of the gate. RegisterGate will return an error if the degree is not correct.
+func WithDegree(degree int) registerGateOption {
+	return func(settings *registerGateSettings) {
+		settings.degree = degree
+	}
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *small_rational.SmallRational) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...small_rational.SmallRational) small_rational.SmallRational, i, nbIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]small_rational.SmallRational, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
+}
+
+// fitPoly tries to fit a polynomial of maximum degree maxDeg to f
+func fitPoly(f func(...small_rational.SmallRational) small_rational.SmallRational, nbIn, maxDeg int) (p polynomial.Polynomial, ok bool, err error) {
+
+	// turn f univariate by defining p(x) as f(x, x, ..., x)
+	// evaluate p at random points
+	x := make([]small_rational.SmallRational, maxDeg+1)
+	y := make([]small_rational.SmallRational, maxDeg+1)
+	fIn := make([]small_rational.SmallRational, nbIn)
+	for i := range x {
+		setRandom(&x[i])
+		for j := range fIn {
+			fIn[j] = x[i]
+		}
+		y[i] = f(fIn...)
+	}
+
+	// interpolate p
+	p, err = polynomial.Interpolate(x, y)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// check if p is equal to f. This not being the case means that f is of a degree higher than maxDeg
+	setRandom(&fIn[0])
+	for i := range fIn {
+		fIn[i] = fIn[0]
+	}
+	pAt := p.Eval(&fIn[0])
+	fAt := f(fIn...)
+	if !pAt.Equal(&fAt) {
+		return nil, false, nil
+	}
+
+	// trim p
+	lastNonZero := len(p) - 1
+	for lastNonZero >= 0 && p[lastNonZero].IsZero() {
+		lastNonZero--
+	}
+	return p[:lastNonZero+1], true, nil
+}
+
+// RegisterGate creates a gate object and stores it in the gates registry
+// name is a human-readable name for the gate
+// f is the polynomial function defining the gate
+// nbIn is the number of inputs to the gate
+func RegisterGate(name string, f func(...small_rational.SmallRational) small_rational.SmallRational, nbIn int, options ...registerGateOption) error {
+	s := registerGateSettings{degree: -1, linearVar: -1}
+	for _, option := range options {
+		option(&s)
+	}
+
+	if s.linearVar == -1 {
+		if !s.noLinearVarVerification { // find a linear variable
+			for i := range nbIn {
+				if isLinear(f, i, nbIn) {
+					s.linearVar = i
+					break
+				}
+			}
+		}
+	} else {
+		// linear variable given
+		if !s.noLinearVarVerification && !isLinear(f, s.linearVar, nbIn) {
+			return fmt.Errorf("variable %d is not linear in gate %s", s.linearVar, name)
+		}
+	}
+
+	if s.degree == -1 { // find a degree
+		if s.noDegreeVerification {
+			panic("invalid settings")
+		}
+		found := false
+		const maxAutoDegree = 10
+		for s.degree = 5; s.degree <= maxAutoDegree; s.degree += 5 {
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if ok {
+				found = true
+				s.degree = len(p) - 1
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("could not find a degree for gate %s: tried up to %d", name, maxAutoDegree)
+		}
+	} else {
+		if !s.noDegreeVerification { // check that the given degree is correct
+			p, ok, err := fitPoly(f, nbIn, s.degree)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("detected a higher degree than %d for gate %s", s.degree, name)
+			}
+			if len(p)-1 != s.degree {
+				return fmt.Errorf("detected degree %d for gate %s, claimed %d", len(p)-1, name, s.degree)
+			}
+		}
+	}
+
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	gates[name] = &Gate{f: f, nbIn: nbIn, degree: s.degree, linearVar: s.linearVar}
+	return nil
+}
+
+func GetGate(name string) *Gate {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	return gates[name]
+}
+
+func RemoveGate(name string) bool {
+	gatesLock.Lock()
+	defer gatesLock.Unlock()
+	_, found := gates[name]
+	if found {
+		delete(gates, name)
+	}
+	return found
 }
 
 type Wire struct {
-	Gate            Gate
+	Gate            *Gate
 	Inputs          []*Wire // if there are no Inputs, the wire is assumed an input wire
 	nbUniqueOutputs int     // number of other wires using it as input, not counting duplicates (i.e. providing two inputs to the same gate counts as one)
 }
@@ -690,12 +913,13 @@ func Verify(c Circuit, assignment WireAssignment, proof Proof, transcriptSetting
 
 // outputsList also sets the nbUniqueOutputs fields. It also sets the wire metadata.
 func outputsList(c Circuit, indexes map[*Wire]int) [][]int {
+	idGate := GetGate("identity")
 	res := make([][]int, len(c))
 	for i := range c {
 		res[i] = make([]int, 0)
 		c[i].nbUniqueOutputs = 0
 		if c[i].IsInput() {
-			c[i].Gate = IdentityGate{}
+			c[i].Gate = idGate
 		}
 	}
 	ins := make(map[int]struct{}, len(c))
@@ -845,136 +1069,44 @@ func frToBigInts(dst []*big.Int, src []small_rational.SmallRational) {
 	}
 }
 
-// Gates defined by name
-var Gates = map[string]Gate{
-	"identity": IdentityGate{},
-	"add":      AddGate{},
-	"sub":      SubGate{},
-	"neg":      NegGate{},
-	"mul":      MulGate(2),
-}
+func init() {
+	// register some basic gates
 
-type IdentityGate struct{}
-type AddGate struct{}
-type MulGate int
-type SubGate struct{}
-type NegGate struct{}
+	if err := RegisterGate("identity", func(x ...small_rational.SmallRational) small_rational.SmallRational {
+		return x[0]
+	}, 1); err != nil {
+		panic(err)
+	}
 
-func (IdentityGate) Evaluate(input ...small_rational.SmallRational) small_rational.SmallRational {
-	return input[0]
-}
-
-func (IdentityGate) Degree() int {
-	return 1
-}
-
-func (g AddGate) Evaluate(x ...small_rational.SmallRational) (res small_rational.SmallRational) {
-	switch len(x) {
-	case 0:
-	// set zero
-	case 1:
-		res.Set(&x[0])
-	default:
+	if err := RegisterGate("add2", func(x ...small_rational.SmallRational) small_rational.SmallRational {
+		var res small_rational.SmallRational
 		res.Add(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Add(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
 
-func (g AddGate) Degree() int {
-	return 1
-}
-
-func (g MulGate) Evaluate(x ...small_rational.SmallRational) (res small_rational.SmallRational) {
-	if len(x) != int(g) {
-		panic("wrong input count")
+	if err := RegisterGate("sub2", func(x ...small_rational.SmallRational) small_rational.SmallRational {
+		var res small_rational.SmallRational
+		res.Sub(&x[0], &x[1])
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	switch len(x) {
-	case 0:
-		res.SetOne()
-	case 1:
-		res.Set(&x[0])
-	default:
+
+	if err := RegisterGate("neg", func(x ...small_rational.SmallRational) small_rational.SmallRational {
+		var res small_rational.SmallRational
+		res.Neg(&x[0])
+		return res
+	}, 1); err != nil {
+		panic(err)
+	}
+
+	if err := RegisterGate("mul2", func(x ...small_rational.SmallRational) small_rational.SmallRational {
+		var res small_rational.SmallRational
 		res.Mul(&x[0], &x[1])
-		for i := 2; i < len(x); i++ {
-			res.Mul(&res, &x[i])
-		}
+		return res
+	}, 2); err != nil {
+		panic(err)
 	}
-	return
-}
-
-func (g MulGate) Degree() int {
-	return int(g)
-}
-
-func (g SubGate) Evaluate(element ...small_rational.SmallRational) (diff small_rational.SmallRational) {
-	if len(element) > 2 {
-		panic("not implemented") //TODO
-	}
-	diff.Sub(&element[0], &element[1])
-	return
-}
-
-func (g SubGate) Degree() int {
-	return 1
-}
-
-func (g NegGate) Evaluate(element ...small_rational.SmallRational) (neg small_rational.SmallRational) {
-	if len(element) != 1 {
-		panic("univariate gate")
-	}
-	neg.Neg(&element[0])
-	return
-}
-
-func (g NegGate) Degree() int {
-	return 1
-}
-
-// TestGateDegree checks if deg(g) = g.Degree()
-func TestGateDegree(g Gate, nbIn int) error {
-	// TODO when Gate is a struct, turn this into a method
-	if nbIn < 1 {
-		return errors.New("at least one input required")
-	}
-
-	d := g.Degree()
-	// evaluate g at 0 .. d
-	var one, _x small_rational.SmallRational
-	one.SetOne()
-	x := make([]small_rational.SmallRational, nbIn)
-	y := make([]small_rational.SmallRational, d+1)
-	for i := range y {
-		y[i] = g.Evaluate(x...)
-		_x.Add(&_x, &one)
-		for j := range x {
-			x[j] = _x
-		}
-	}
-
-	p := polynomial.InterpolateOnRange(y)
-	// test if p matches g
-	if _, err := _x.SetRandom(); err != nil {
-		return err
-	}
-	for j := range x {
-		x[j] = _x
-	}
-
-	if expected, encountered := p.Eval(&x[0]), g.Evaluate(x...); !expected.Equal(&encountered) {
-		return fmt.Errorf("interpolation failed: not a polynomial of degree %d or lower", d)
-	}
-
-	// check if the degree is LESS than d
-	degP := d
-	for degP >= 0 && p[degP].IsZero() {
-		degP--
-	}
-	if degP != d {
-		return fmt.Errorf("expected polynomial of degree %d, interpolation yielded %d", d, degP)
-	}
-
-	return nil
 }

--- a/internal/generator/test_vector_utils/small_rational/polynomial/polynomial.go
+++ b/internal/generator/test_vector_utils/small_rational/polynomial/polynomial.go
@@ -6,6 +6,7 @@
 package polynomial
 
 import (
+	"errors"
 	"github.com/consensys/gnark-crypto/internal/generator/test_vector_utils/small_rational"
 	"github.com/consensys/gnark-crypto/utils"
 	"strconv"
@@ -306,4 +307,87 @@ func computeLagrangeBasis(domainSize uint8) []Polynomial {
 	}
 
 	return res
+}
+
+// Interpolate fits a polynomial of degree len(X) - 1 = len(Y) - 1 to the points (X[i], Y[i])
+// Note that the runtime is O(len(X)³)
+func Interpolate(X, Y []small_rational.SmallRational) (Polynomial, error) {
+	if len(X) != len(Y) {
+		return nil, errors.New("X and Y must have the same length")
+	}
+
+	// solve the system of equations by Gaussian elimination
+	augmentedRows := make([][]small_rational.SmallRational, len(X)) // the last column is the Y values
+	for i := range augmentedRows {
+		augmentedRows[i] = make([]small_rational.SmallRational, len(X)+1)
+		augmentedRows[i][0].SetOne()
+		augmentedRows[i][1].Set(&X[i])
+		for j := 2; j < len(augmentedRows[i])-1; j++ {
+			augmentedRows[i][j].Mul(&augmentedRows[i][j-1], &X[i])
+		}
+		augmentedRows[i][len(augmentedRows[i])-1].Set(&Y[i])
+	}
+
+	// make the upper triangle
+	for i := range len(augmentedRows) - 1 {
+		// use row i to eliminate the ith element in all rows below
+		var negInv small_rational.SmallRational
+		if augmentedRows[i][i].IsZero() {
+			return nil, errors.New("singular matrix")
+		}
+		negInv.Inverse(&augmentedRows[i][i])
+		negInv.Neg(&negInv)
+		for j := i + 1; j < len(augmentedRows); j++ {
+			var c small_rational.SmallRational
+			c.Mul(&augmentedRows[j][i], &negInv)
+			// augmentedRows[j][i].SetZero() omitted
+			for k := i + 1; k < len(augmentedRows[i]); k++ {
+				var t small_rational.SmallRational
+				t.Mul(&augmentedRows[i][k], &c)
+				augmentedRows[j][k].Add(&augmentedRows[j][k], &t)
+			}
+		}
+	}
+
+	// back substitution
+	res := make(Polynomial, len(X))
+	for i := len(augmentedRows) - 1; i >= 0; i-- {
+		res[i] = augmentedRows[i][len(augmentedRows[i])-1]
+		for j := i + 1; j < len(augmentedRows[i])-1; j++ {
+			var t small_rational.SmallRational
+			t.Mul(&res[j], &augmentedRows[i][j])
+			res[i].Sub(&res[i], &t)
+		}
+		res[i].Div(&res[i], &augmentedRows[i][i])
+	}
+
+	return res, nil
+}
+
+// setRandom panics if SetRandom returns an error
+func setRandom(x *small_rational.SmallRational) {
+	if _, err := x.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// isLinear returns whether f is linear in its i-th variable
+func isLinear(f func(...small_rational.SmallRational) small_rational.SmallRational, i, fanIn int) bool {
+	// fix all variables except the i-th one at random points
+	// pick random values x0, x1 for the i-th variable
+	// check if f(-, x0, -) + f(-, x1, -) = 2*f(-, (x0 + x1)/2, -)
+	x := make([]small_rational.SmallRational, fanIn)
+	for i := range x {
+		setRandom(&x[i])
+	}
+	y0 := f(x...)
+	x0 := x[i]
+
+	setRandom(&x[i])
+	y1 := f(x...)
+
+	x[i].Add(&x[i], &x0).Halve()
+	y2 := f(x...)
+
+	return y2.Double(&y2).Sub(&y2, &y1).Equal(&y0)
 }

--- a/internal/generator/test_vector_utils/small_rational/small-rational.go
+++ b/internal/generator/test_vector_utils/small_rational/small-rational.go
@@ -220,6 +220,32 @@ func (z *SmallRational) Mul(x, y *SmallRational) *SmallRational {
 	return z
 }
 
+func (z *SmallRational) Div(x, y *SmallRational) *SmallRational {
+	var num, den big.Int
+
+	num.Mul(&x.numerator, &y.denominator)
+	den.Mul(&x.denominator, &y.numerator)
+
+	z.numerator = num
+	z.denominator = den
+
+	z.simplify()
+	z.UpdateText()
+	return z
+}
+
+func (z *SmallRational) Halve() *SmallRational {
+	if z.numerator.Bit(0) == 0 {
+		z.numerator.Rsh(&z.numerator, 1)
+	} else {
+		z.denominator.Lsh(&z.denominator, 1)
+	}
+
+	z.simplify()
+	z.UpdateText()
+	return z
+}
+
 func (z *SmallRational) SetOne() *SmallRational {
 	return z.SetInt64(1)
 }


### PR DESCRIPTION
1. Change `Gate` from an interface to a concrete type, containing its fan-in, function reference, degree, and whether there is a variable of degree 1 (will be useful in later optims)
2. A thread-safe gate registry as the sole way to create gates
3. Options for automatic detection or verification of the total degree and 1-degree var index
4. Remove the unsound function `TestGateDegree`.