### PR TITLE
ci: add noavx build tag tests to ensure full code path coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,7 @@ jobs:
         set -euo pipefail
         go test -json -v -short -timeout=30m ./... 2>&1 | gotestfmt -hide=all |  tee /tmp/gotest.log 
         go test -json -v -tags=purego -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log 
+        go test -json -v -tags=noavx -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
         go test -json -v -race -timeout=30m ./ecc/bn254/... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log 
         GOARCH=386 go test -json -short -v -timeout=30m ./ecc/bn254/... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
         GOARCH=386 go test -json -short -v -timeout=30m ./field/goldilocks 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,6 +71,7 @@ jobs:
         set -euo pipefail
         go test -json -v -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee /tmp/gotest.log
         go test -json -v -tags=purego -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
+        go test -json -v -tags=noavx -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
         go test -json -v -race -timeout=30m ./ecc/bn254/... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
         GOARCH=386 go test -json -short -v -timeout=30m ./ecc/bn254/... 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log
         GOARCH=386 go test -json -short -v -timeout=30m ./field/goldilocks 2>&1 | gotestfmt -hide=all | tee -a /tmp/gotest.log


### PR DESCRIPTION
# Description

This PR adds explicit test paths for non-AVX512 code in the CI workflows. The CI environment now tests both AVX512 and non-AVX512 code paths by adding test runs with the noavx build tag. This ensures complete code coverage for environments both with and without AVX512 instruction support.
Previously, the CI did not explicitly test the non-AVX512 code paths, leading to uncovered code paths in the test suite.

Fixes #613

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

- [x] Verified that the modified CI workflow YAML files are syntactically correct
- [x] Confirmed that the new test command correctly uses the -tags=noavx flag

# How has this been benchmarked?


Not applicable as this is a CI configuration change.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

