### PR TITLE
test(bn254, bls12-381): test points intentionally not on sugroups G1/2

### DIFF
--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +538,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -74,7 +74,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -123,7 +123,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -491,7 +491,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -527,7 +527,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -506,6 +506,19 @@ func (p *G1Jac) IsInSubGroup() bool {
 
 }
 
+func GeneratePointNotInG1(f fp.Element) G1Jac {
+	var res, jac G1Jac
+	aff := MapToCurve1(&f)
+	g1Isogeny(&aff)
+	jac.FromAffine(&aff)
+	// p+x²ϕ(p) = [r]p
+	res.phi(&jac).
+		mulBySeed(&res).
+		mulBySeed(&res).
+		AddAssign(&jac)
+	return res
+}
+
 // mulWindowed computes the 2-bits windowed double-and-add scalar
 // multiplication p=[s]q in Jacobian coordinates.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -872,10 +872,6 @@ func fuzzCofactorOfG1(f fp.Element) G1Jac {
 	return res
 }
 
-func GeneratePointNotInG1(f fp.Element) G1Jac {
-	return fuzzCofactorOfG1(f)
-}
-
 func fuzzG1Jac(p *G1Jac, f fp.Element) G1Jac {
 	var res G1Jac
 	res.X.Mul(&p.X, &f).Mul(&res.X, &f)

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -107,7 +107,7 @@ func TestIsOnG1(t *testing.T) {
 	))
 	properties.Property("[BLS12-381] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
 		func(a fp.Element) bool {
-			op := fuzzCofactorOfG1Jac(a)
+			op := fuzzCofactorOfG1(a)
 			return op.IsOnCurve() && !op.IsInSubGroup()
 		},
 		GenFp(),
@@ -859,7 +859,7 @@ func BenchmarkG1AffineDouble(b *testing.B) {
 		a.Double(&a)
 	}
 }
-func fuzzCofactorOfG1Jac(f fp.Element) G1Jac {
+func fuzzCofactorOfG1(f fp.Element) G1Jac {
 	var res, jac G1Jac
 	aff := MapToCurve1(&f)
 	g1Isogeny(&aff)
@@ -870,6 +870,10 @@ func fuzzCofactorOfG1Jac(f fp.Element) G1Jac {
 		mulBySeed(&res).
 		AddAssign(&jac)
 	return res
+}
+
+func GeneratePointNotInG1(f fp.Element) G1Jac {
+	return fuzzCofactorOfG1(f)
 }
 
 func fuzzG1Jac(p *G1Jac, f fp.Element) G1Jac {

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -105,11 +105,18 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 		},
 		GenFp(),
 	))
+	properties.Property("[BLS12-381] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
+		func(a fp.Element) bool {
+			op := fuzzCofactorOfG1Jac(a)
+			return op.IsOnCurve() && !op.IsInSubGroup()
+		},
+		GenFp(),
+	))
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +506,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +545,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -851,6 +858,18 @@ func BenchmarkG1AffineDouble(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		a.Double(&a)
 	}
+}
+func fuzzCofactorOfG1Jac(f fp.Element) G1Jac {
+	var res, jac G1Jac
+	aff := MapToCurve1(&f)
+	g1Isogeny(&aff)
+	jac.FromAffine(&aff)
+	// p+x²ϕ(p) = [r]p
+	res.phi(&jac).
+		mulBySeed(&res).
+		mulBySeed(&res).
+		AddAssign(&jac)
+	return res
 }
 
 func fuzzG1Jac(p *G1Jac, f fp.Element) G1Jac {

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -503,6 +503,18 @@ func (p *G2Jac) IsInSubGroup() bool {
 	return res.Equal(&img)
 }
 
+func GeneratePointNotInG2(f E2) G2Jac {
+	var res, jac G2Jac
+	aff := MapToCurve2(&f)
+	g2Isogeny(&aff)
+	jac.FromAffine(&aff)
+	// ψ(p)-[x₀]P = [r]p
+	res.mulBySeed(&jac)
+	jac.psi(&jac)
+	res.AddAssign(&jac)
+	return res
+}
+
 // mulWindowed computes the 2-bits windowed double-and-add scalar
 // multiplication p=[s]q in Jacobian coordinates.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -121,7 +121,7 @@ func TestIsOnG2(t *testing.T) {
 	))
 	properties.Property("[BLS12-381] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
 		func(a fptower.E2) bool {
-			op := fuzzCofactorOfG2Jac(a)
+			op := fuzzCofactorOfG2(a)
 			return op.IsOnCurve() && !op.IsInSubGroup()
 		},
 		GenE2(),
@@ -848,7 +848,7 @@ func BenchmarkG2AffineDouble(b *testing.B) {
 		a.Double(&a)
 	}
 }
-func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
+func fuzzCofactorOfG2(f fptower.E2) G2Jac {
 	var res, jac G2Jac
 	aff := MapToCurve2(&f)
 	g2Isogeny(&aff)
@@ -858,6 +858,10 @@ func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
 	jac.psi(&jac)
 	res.AddAssign(&jac)
 	return res
+}
+
+func GeneratePointNotInG2(f fptower.E2) G2Jac {
+	return fuzzCofactorOfG2(f)
 }
 
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -74,7 +74,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -119,11 +119,18 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 		},
 		GenE2(),
 	))
+	properties.Property("[BLS12-381] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
+		func(a fptower.E2) bool {
+			op := fuzzCofactorOfG2Jac(a)
+			return op.IsOnCurve() && !op.IsInSubGroup()
+		},
+		GenE2(),
+	))
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -491,7 +498,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -527,7 +534,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -840,6 +847,17 @@ func BenchmarkG2AffineDouble(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		a.Double(&a)
 	}
+}
+func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
+	var res, jac G2Jac
+	aff := MapToCurve2(&f)
+	g2Isogeny(&aff)
+	jac.FromAffine(&aff)
+	// ψ(p)-[x₀]P = [r]p
+	res.mulBySeed(&jac)
+	jac.psi(&jac)
+	res.AddAssign(&jac)
+	return res
 }
 
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -860,10 +860,6 @@ func fuzzCofactorOfG2(f fptower.E2) G2Jac {
 	return res
 }
 
-func GeneratePointNotInG2(f fptower.E2) G2Jac {
-	return fuzzCofactorOfG2(f)
-}
-
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {
 	var res G2Jac
 	res.X.Mul(&p.X, &f).Mul(&res.X, &f)

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +538,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -74,7 +74,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -123,7 +123,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -491,7 +491,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -527,7 +527,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +538,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -74,7 +74,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -123,7 +123,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -491,7 +491,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -527,7 +527,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -516,6 +516,24 @@ func (p *G2Jac) IsInSubGroup() bool {
 	return res.Equal(&c)
 }
 
+func GeneratePointNotInG2(f E2) G2Jac {
+	var res, jac, a, b, c G2Jac
+	aff := MapToCurve2(&f)
+	jac.FromAffine(&aff)
+	// [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) - ψ³([2x₀]P) = [r]P
+	a.mulBySeed(&jac)
+	b.psi(&a)
+	a.AddAssign(&jac)
+	res.psi(&b)
+	c.Set(&res).
+		AddAssign(&b).
+		AddAssign(&a)
+	res.psi(&res).
+		Double(&res).
+		SubAssign(&c)
+	return res
+}
+
 // mulWindowed computes the 2-bits windowed double-and-add scalar
 // multiplication p=[s]q in Jacobian coordinates.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -73,7 +73,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -122,7 +122,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -490,7 +490,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -526,7 +526,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -839,6 +839,23 @@ func BenchmarkG2AffineDouble(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		a.Double(&a)
 	}
+}
+func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
+	var res, jac, a, b, c G2Jac
+	aff := MapToCurve2(&f)
+	jac.FromAffine(&aff)
+	// [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) - ψ³([2x₀]P) = [r]P
+	a.mulBySeed(&jac)
+	b.psi(&a)
+	a.AddAssign(&jac)
+	res.psi(&b)
+	c.Set(&res).
+		AddAssign(&b).
+		AddAssign(&a)
+	res.psi(&res).
+		Double(&res).
+		SubAssign(&c)
+	return res
 }
 
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -120,7 +120,7 @@ func TestIsOnG2(t *testing.T) {
 	))
 	properties.Property("[BN254] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
 		func(a fptower.E2) bool {
-			op := fuzzCofactorOfG2Jac(a)
+			op := fuzzCofactorOfG2(a)
 			return op.IsOnCurve() && !op.IsInSubGroup()
 		},
 		GenE2(),
@@ -847,7 +847,7 @@ func BenchmarkG2AffineDouble(b *testing.B) {
 		a.Double(&a)
 	}
 }
-func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
+func fuzzCofactorOfG2(f fptower.E2) G2Jac {
 	var res, jac, a, b, c G2Jac
 	aff := MapToCurve2(&f)
 	jac.FromAffine(&aff)
@@ -863,6 +863,10 @@ func fuzzCofactorOfG2Jac(f fptower.E2) G2Jac {
 		Double(&res).
 		SubAssign(&c)
 	return res
+}
+
+func GeneratePointNotInG2(f fptower.E2) G2Jac {
+	return fuzzCofactorOfG2(f)
 }
 
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -865,10 +865,6 @@ func fuzzCofactorOfG2(f fptower.E2) G2Jac {
 	return res
 }
 
-func GeneratePointNotInG2(f fptower.E2) G2Jac {
-	return fuzzCofactorOfG2(f)
-}
-
 func fuzzG2Jac(p *G2Jac, f fptower.E2) G2Jac {
 	var res G2Jac
 	res.X.Mul(&p.X, &f).Mul(&res.X, &f)

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -118,6 +118,13 @@ func TestIsOnG2(t *testing.T) {
 		},
 		GenE2(),
 	))
+	properties.Property("[BN254] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
+		func(a fptower.E2) bool {
+			op := fuzzCofactorOfG2Jac(a)
+			return op.IsOnCurve() && !op.IsInSubGroup()
+		},
+		GenE2(),
+	))
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +538,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -469,7 +469,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -508,7 +508,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineCofactorCleaning(t *testing.T) {
+func TestG1CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -538,7 +538,7 @@ func TestG1AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG2AffineEndomorphism(t *testing.T) {
+func TestG2Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG2AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineIsOnCurve(t *testing.T) {
+func TestIsOnG2(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG2AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineConversions(t *testing.T) {
+func TestG2Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -469,7 +469,7 @@ func TestG2AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG2AffineCofactorCleaning(t *testing.T) {
+func TestG2CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -508,7 +508,7 @@ func TestG2AffineCofactorCleaning(t *testing.T) {
 
 }
 
-func TestG2AffineBatchScalarMultiplication(t *testing.T) {
+func TestG2BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/grumpkin/g1_test.go
+++ b/ecc/grumpkin/g1_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -60,7 +60,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -109,7 +109,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -499,7 +499,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestG1AffineEndomorphism(t *testing.T) {
+func TestG1Endomorphism(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -62,7 +62,7 @@ func TestG1AffineEndomorphism(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineIsOnCurve(t *testing.T) {
+func TestIsOnG1(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -111,7 +111,7 @@ func TestG1AffineIsOnCurve(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineConversions(t *testing.T) {
+func TestG1Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -501,7 +501,7 @@ func TestG1AffineOps(t *testing.T) {
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
-func TestG1AffineBatchScalarMultiplication(t *testing.T) {
+func TestG1BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -810,6 +810,51 @@ func (p *{{ $TJacobian }}) IsOnCurve() bool {
 {{- end}}
 
 
+{{- if eq .Name "bls12-381"}}
+    {{- if eq .PointName "g1" }}
+func GeneratePointNotIn{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
+	var res, jac {{ $TJacobian }}
+	aff := MapToCurve1(&f)
+	g1Isogeny(&aff)
+	jac.FromAffine(&aff)
+    // p+x²ϕ(p) = [r]p
+	res.phi(&jac).
+		mulBySeed(&res).
+		mulBySeed(&res).
+		AddAssign(&jac)
+    {{- else}}
+func GeneratePointNotIn{{ toUpper .PointName}}(f E2) {{ $TJacobian }} {
+	var res, jac {{ $TJacobian }}
+	aff := MapToCurve2(&f)
+	g2Isogeny(&aff)
+	jac.FromAffine(&aff)
+    // ψ(p)-[x₀]P = [r]p
+	res.mulBySeed(&jac)
+	jac.psi(&jac)
+    res.AddAssign(&jac)
+    {{- end}}
+	return res
+}
+{{- else if and (eq .Name "bn254") (eq .PointName "g2")}}
+func GeneratePointNotIn{{ toUpper .PointName}}(f E2) {{ $TJacobian }} {
+	var res, jac, a, b, c {{ $TJacobian }}
+   	aff := MapToCurve2(&f)
+	jac.FromAffine(&aff)
+    // [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) - ψ³([2x₀]P) = [r]P
+	a.mulBySeed(&jac)
+	b.psi(&a)
+	a.AddAssign(&jac)
+	res.psi(&b)
+	c.Set(&res).
+		AddAssign(&b).
+		AddAssign(&a)
+	res.psi(&res).
+		Double(&res).
+        SubAssign(&c)
+	return res
+}
+{{- end}}
+
 // mulWindowed computes the 2-bits windowed double-and-add scalar
 // multiplication p=[s]q in Jacobian coordinates.
 func (p *{{ $TJacobian }}) mulWindowed(q *{{ $TJacobian }}, s *big.Int) *{{ $TJacobian }} {

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -993,11 +993,6 @@ func fuzzCofactorOf{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
         SubAssign(&c)
 	return res
 }
-
-func GeneratePointNotIn{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
-	return fuzzCofactorOf{{ toUpper .PointName}}(f)
-}
-
 {{- end}}
 
 func fuzz{{ $TJacobian }}(p *{{ $TJacobian }}, f {{ .CoordType}}) {{ $TJacobian }} {

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -150,7 +150,7 @@ func TestIsOn{{ toUpper .PointName }}(t *testing.T) {
 		{{$fuzzer}},
 	))
 
-    {{- if eq .Name "bls12-381"}}
+    {{- if or (eq .Name "bls12-381") (and (eq .Name "bn254") (eq .PointName "g2"))}}
 	properties.Property("[{{ toUpper .Name }}] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
 		func(a {{ .CoordType}}) bool {
 			op := fuzzCofactorOf{{ $TJacobian }}(a)

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -975,10 +975,6 @@ func fuzzCofactorOf{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
 	return res
 }
 
-func GeneratePointNotIn{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
-	return fuzzCofactorOf{{ toUpper .PointName}}(f)
-}
-
 {{- else if and (eq .Name "bn254") (eq .PointName "g2")}}
 func fuzzCofactorOf{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
 	var res, jac, a, b, c {{ $TJacobian }}

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -36,7 +36,7 @@ import (
 )
 
 {{if .GLV}}
-    func Test{{ $TAffine }}Endomorphism(t *testing.T) {
+    func Test{{ toUpper .PointName }}Endomorphism(t *testing.T) {
 		t.Parallel()
         parameters := gopter.DefaultTestParameters()
         if testing.Short() {
@@ -104,7 +104,7 @@ import (
     }
 {{end}}
 
-func Test{{ $TAffine }}IsOnCurve(t *testing.T) {
+func TestIsOn{{ toUpper .PointName }}(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -150,11 +150,21 @@ func Test{{ $TAffine }}IsOnCurve(t *testing.T) {
 		{{$fuzzer}},
 	))
 
+    {{- if eq .Name "bls12-381"}}
+	properties.Property("[{{ toUpper .Name }}] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
+		func(a {{ .CoordType}}) bool {
+			op := fuzzCofactorOf{{ $TJacobian }}(a)
+			return op.IsOnCurve() && !op.IsInSubGroup()
+		},
+		{{$fuzzer}},
+	))
+    {{- end}}
+
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }
 
 
-func Test{{ $TAffine }}Conversions(t *testing.T) {
+func Test{{ toUpper .PointName }}Conversions(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -569,7 +579,7 @@ func Test{{ $TAffine }}Ops(t *testing.T) {
 
 
 {{if .CofactorCleaning }}
-func Test{{ $TAffine }}CofactorCleaning(t *testing.T) {
+func Test{{ toUpper .PointName }}CofactorClearing(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -621,7 +631,7 @@ func Test{{ $TAffine }}CofactorCleaning(t *testing.T) {
 }
 {{end}}
 
-func Test{{ $TAffine }}BatchScalarMultiplication(t *testing.T) {
+func Test{{ toUpper .PointName }}BatchScalarMultiplication(t *testing.T) {
 
 	parameters := gopter.DefaultTestParameters()
 	if testing.Short() {
@@ -940,6 +950,49 @@ func Benchmark{{ toUpper .PointName}}AffineDouble(b *testing.B) {
 		a.Double(&a)
 	}
 }
+
+{{- if eq .Name "bls12-381"}}
+func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
+	var res, jac {{ $TJacobian }}
+    {{- if eq .PointName "g1" }}
+	aff := MapToCurve1(&f)
+	g1Isogeny(&aff)
+	jac.FromAffine(&aff)
+    // p+x²ϕ(p) = [r]p
+	res.phi(&jac).
+		mulBySeed(&res).
+		mulBySeed(&res).
+		AddAssign(&jac)
+    {{- else}}
+	aff := MapToCurve2(&f)
+	g2Isogeny(&aff)
+	jac.FromAffine(&aff)
+    // ψ(p)-[x₀]P = [r]p
+	res.mulBySeed(&jac)
+	jac.psi(&jac)
+    res.AddAssign(&jac)
+    {{- end}}
+	return res
+}
+{{- else if and (eq .Name "bn254") (eq .PointName "g2")}}
+func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
+	var res, jac, a, b, c {{ $TJacobian }}
+   	aff := MapToCurve2(&f)
+	jac.FromAffine(&aff)
+    // [x₀+1]P + ψ([x₀]P) + ψ²([x₀]P) - ψ³([2x₀]P) = [r]P
+	a.mulBySeed(&jac)
+	b.psi(&a)
+	a.AddAssign(&jac)
+	res.psi(&b)
+	c.Set(&res).
+		AddAssign(&b).
+		AddAssign(&a)
+	res.psi(&res).
+		Double(&res).
+        SubAssign(&c)
+	return res
+}
+{{- end}}
 
 func fuzz{{ $TJacobian }}(p *{{ $TJacobian }}, f {{ .CoordType}}) {{ $TJacobian }} {
 	var res {{ $TJacobian }}

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -153,7 +153,7 @@ func TestIsOn{{ toUpper .PointName }}(t *testing.T) {
     {{- if or (eq .Name "bls12-381") (and (eq .Name "bn254") (eq .PointName "g2"))}}
 	properties.Property("[{{ toUpper .Name }}] IsInSubGroup should return false for a point on the cofactor-torsion", prop.ForAll(
 		func(a {{ .CoordType}}) bool {
-			op := fuzzCofactorOf{{ $TJacobian }}(a)
+			op := fuzzCofactorOf{{ toUpper .PointName}}(a)
 			return op.IsOnCurve() && !op.IsInSubGroup()
 		},
 		{{$fuzzer}},
@@ -952,7 +952,7 @@ func Benchmark{{ toUpper .PointName}}AffineDouble(b *testing.B) {
 }
 
 {{- if eq .Name "bls12-381"}}
-func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
+func fuzzCofactorOf{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
 	var res, jac {{ $TJacobian }}
     {{- if eq .PointName "g1" }}
 	aff := MapToCurve1(&f)
@@ -974,8 +974,13 @@ func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
     {{- end}}
 	return res
 }
+
+func GeneratePointNotIn{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
+	return fuzzCofactorOf{{ toUpper .PointName}}(f)
+}
+
 {{- else if and (eq .Name "bn254") (eq .PointName "g2")}}
-func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
+func fuzzCofactorOf{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
 	var res, jac, a, b, c {{ $TJacobian }}
    	aff := MapToCurve2(&f)
 	jac.FromAffine(&aff)
@@ -992,6 +997,11 @@ func fuzzCofactorOf{{ $TJacobian }}(f {{ .CoordType}}) {{ $TJacobian }} {
         SubAssign(&c)
 	return res
 }
+
+func GeneratePointNotIn{{ toUpper .PointName}}(f {{ .CoordType}}) {{ $TJacobian }} {
+	return fuzzCofactorOf{{ toUpper .PointName}}(f)
+}
+
 {{- end}}
 
 func fuzz{{ $TJacobian }}(p *{{ $TJacobian }}, f {{ .CoordType}}) {{ $TJacobian }} {


### PR DESCRIPTION
# Description

- Generate test points that are intentionally on the G1/2 cofactor-torsions for fuzzing purposes. 
- Renamed some test methods to make more sense.

This is useful for geth fuzzer for bn254 and bls12-381. We could also generify the test for other curves but it's not a priority now IMO.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Last test in `TestIsOnG2` generates points (using `fuzzCofactorOfG*Jac`) that pass the `IsOnCurve` test but not `IsInSubGroup` test.

# How has this been benchmarked?

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

