### PR TITLE
Remove Unused Imports and Duplicate FRI Generation Call

### DIFF
--- a/field/goff/cmd/root.go
+++ b/field/goff/cmd/root.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/field/generator"
 	"github.com/consensys/gnark-crypto/field/generator/config"
-	field "github.com/consensys/gnark-crypto/field/generator/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -175,9 +175,6 @@ func main() {
 			// generate permutation on fr
 			assertNoError(permutation.Generate(conf, filepath.Join(curveDir, "fr", "permutation"), bgen))
 
-			// generate eddsa on companion curves
-			assertNoError(fri.Generate(conf, filepath.Join(curveDir, "fr", "fri"), bgen))
-
 			// generate iop functions
 			assertNoError(iop.Generate(conf, filepath.Join(curveDir, "fr", "iop"), bgen))
 


### PR DESCRIPTION
### Changes:  
- Removed unused import alias (`field` in `root.go`).  
- Deleted duplicate `fri.Generate` call in the `eddsa` section of `main.go`.  

These changes improve code clarity and avoid unnecessary function calls.  

## Type of change  
- [x] Code cleanup (removing unused imports and redundant calls)  

## How has this been tested?  
- [x] Code compiles without errors  
- [x] Existing unit tests pass  

## How has this been benchmarked?  
- No performance impact expected  

## Checklist:  
- [x] I have performed a self-review of my code  
- [x] I have removed unnecessary code without affecting functionality  
- [x] Existing tests pass locally  
