### PR TITLE
505 feat add mustsetrandom methods

### DIFF
--- a/ecc/bls12-377/fflonk/fflonk_test.go
+++ b/ecc/bls12-377/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -363,6 +363,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -367,8 +367,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -258,8 +258,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -298,7 +298,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls12-377/fp/element_test.go
+++ b/ecc/bls12-377/fp/element_test.go
@@ -2377,7 +2377,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2422,8 +2422,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2441,7 +2441,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2492,7 +2492,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls12-377/fp/vector.go
+++ b/ecc/bls12-377/fp/vector.go
@@ -190,6 +190,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls12-377/fp/vector_test.go
+++ b/ecc/bls12-377/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls12-377/fr/element_test.go
+++ b/ecc/bls12-377/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls12-377/fr/fft/bitreverse_test.go
+++ b/ecc/bls12-377/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bls12-377/fr/fft/fft_test.go
+++ b/ecc/bls12-377/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bls12-377/fr/fri/fri_test.go
+++ b/ecc/bls12-377/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bls12-377/fr/gkr/gkr_test.go
+++ b/ecc/bls12-377/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-377/fr/iop/polynomial_test.go
+++ b/ecc/bls12-377/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bls12-377/fr/iop/quotient_test.go
+++ b/ecc/bls12-377/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bls12-377/fr/iop/ratios_test.go
+++ b/ecc/bls12-377/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bls12-377/fr/mimc/mimc_test.go
+++ b/ecc/bls12-377/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bls12-377/fr/pedersen/example_test.go
+++ b/ecc/bls12-377/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bls12-377/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-377/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bls12-377/fr/permutation/permutation_test.go
+++ b/ecc/bls12-377/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls12-377/fr/plookup/plookup_test.go
+++ b/ecc/bls12-377/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls12-377/fr/polynomial/multilin_test.go
+++ b/ecc/bls12-377/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bls12-377/fr/polynomial/polynomial_test.go
+++ b/ecc/bls12-377/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bls12-377/fr/sis/sis_test.go
+++ b/ecc/bls12-377/fr/sis/sis_test.go
@@ -102,7 +102,7 @@ func TestLimbDecomposeBytes(t *testing.T) {
 	nbElmts := 10
 	a := make([]fr.Element, nbElmts)
 	for i := 0; i < nbElmts; i++ {
-		a[i].SetRandom()
+		a[i].MustSetRandom()
 	}
 
 	logTwoBound := 8
@@ -177,7 +177,7 @@ func BenchmarkSIS(b *testing.B) {
 	// accounted for in the benchmark.
 	inputs := make(fr.Vector, nbInputs)
 	for i := 0; i < len(inputs); i++ {
-		inputs[i].SetRandom()
+		inputs[i].MustSetRandom()
 	}
 
 	for _, param := range params128Bits {

--- a/ecc/bls12-377/fr/vector.go
+++ b/ecc/bls12-377/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls12-377/fr/vector_test.go
+++ b/ecc/bls12-377/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -603,9 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -513,12 +513,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BLS12-377] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -603,7 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -505,11 +505,11 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BLS12-377] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fptower.E2
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			}
 
@@ -592,7 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -592,9 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -88,6 +88,14 @@ func (z *E12) SetRandom() (*E12, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E12) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E12) IsZero() bool {
 	return z.C0.IsZero() && z.C1.IsZero()

--- a/ecc/bls12-377/internal/fptower/e12_test.go
+++ b/ecc/bls12-377/internal/fptower/e12_test.go
@@ -444,8 +444,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -454,8 +454,8 @@ func BenchmarkE12Add(b *testing.B) {
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -464,8 +464,8 @@ func BenchmarkE12Sub(b *testing.B) {
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -474,7 +474,7 @@ func BenchmarkE12Mul(b *testing.B) {
 
 func BenchmarkE12Cyclosquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -483,7 +483,7 @@ func BenchmarkE12Cyclosquare(b *testing.B) {
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -492,7 +492,7 @@ func BenchmarkE12Square(b *testing.B) {
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -501,7 +501,7 @@ func BenchmarkE12Inverse(b *testing.B) {
 
 func BenchmarkE12Conjugate(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -510,7 +510,7 @@ func BenchmarkE12Conjugate(b *testing.B) {
 
 func BenchmarkE12Frobenius(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -519,7 +519,7 @@ func BenchmarkE12Frobenius(b *testing.B) {
 
 func BenchmarkE12FrobeniusSquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -528,7 +528,7 @@ func BenchmarkE12FrobeniusSquare(b *testing.B) {
 
 func BenchmarkE12Expt(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/ecc/bls12-377/internal/fptower/e2.go
+++ b/ecc/bls12-377/internal/fptower/e2.go
@@ -90,6 +90,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E2) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/ecc/bls12-377/internal/fptower/e2_test.go
+++ b/ecc/bls12-377/internal/fptower/e2_test.go
@@ -394,8 +394,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -404,8 +404,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -414,8 +414,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -425,8 +425,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -435,7 +435,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -444,7 +444,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -453,7 +453,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -463,7 +463,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -472,7 +472,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -481,7 +481,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -490,7 +490,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls12-377/internal/fptower/e6.go
+++ b/ecc/bls12-377/internal/fptower/e6.go
@@ -52,6 +52,14 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E6) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero() && z.B2.IsZero()

--- a/ecc/bls12-377/internal/fptower/e6_test.go
+++ b/ecc/bls12-377/internal/fptower/e6_test.go
@@ -283,8 +283,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -293,8 +293,8 @@ func BenchmarkE6Add(b *testing.B) {
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -303,8 +303,8 @@ func BenchmarkE6Sub(b *testing.B) {
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -313,7 +313,7 @@ func BenchmarkE6Mul(b *testing.B) {
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -322,7 +322,7 @@ func BenchmarkE6Square(b *testing.B) {
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)

--- a/ecc/bls12-377/internal/fptower/generators_test.go
+++ b/ecc/bls12-377/internal/fptower/generators_test.go
@@ -9,10 +9,8 @@ import (
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bls12-377/kzg/kzg.go
+++ b/ecc/bls12-377/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bls12-377/marshal_test.go
+++ b/ecc/bls12-377/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bls12-377/multiexp_test.go
+++ b/ecc/bls12-377/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bls12-377/pairing_test.go
+++ b/ecc/bls12-377/pairing_test.go
@@ -395,7 +395,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -459,11 +459,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(12)
 	e.Exp(e, k)

--- a/ecc/bls12-377/shplonk/example_test.go
+++ b/ecc/bls12-377/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bls12-377/shplonk/shplonk_test.go
+++ b/ecc/bls12-377/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bls12-377/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls12-377/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bls12-381/bandersnatch/eddsa/eddsa_test.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -773,9 +773,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bls12-381/fflonk/fflonk_test.go
+++ b/ecc/bls12-381/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -363,6 +363,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -367,8 +367,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -258,8 +258,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -298,7 +298,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls12-381/fp/element_test.go
+++ b/ecc/bls12-381/fp/element_test.go
@@ -2377,7 +2377,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2422,8 +2422,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2441,7 +2441,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2492,7 +2492,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls12-381/fp/vector.go
+++ b/ecc/bls12-381/fp/vector.go
@@ -190,6 +190,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls12-381/fp/vector_test.go
+++ b/ecc/bls12-381/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls12-381/fr/element_test.go
+++ b/ecc/bls12-381/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls12-381/fr/fft/bitreverse_test.go
+++ b/ecc/bls12-381/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bls12-381/fr/fft/fft_test.go
+++ b/ecc/bls12-381/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bls12-381/fr/fri/fri_test.go
+++ b/ecc/bls12-381/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bls12-381/fr/gkr/gkr_test.go
+++ b/ecc/bls12-381/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bls12-381/fr/iop/polynomial_test.go
+++ b/ecc/bls12-381/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bls12-381/fr/iop/quotient_test.go
+++ b/ecc/bls12-381/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bls12-381/fr/iop/ratios_test.go
+++ b/ecc/bls12-381/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bls12-381/fr/mimc/mimc_test.go
+++ b/ecc/bls12-381/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bls12-381/fr/pedersen/example_test.go
+++ b/ecc/bls12-381/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bls12-381/fr/pedersen/pedersen_test.go
+++ b/ecc/bls12-381/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bls12-381/fr/permutation/permutation_test.go
+++ b/ecc/bls12-381/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls12-381/fr/plookup/plookup_test.go
+++ b/ecc/bls12-381/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls12-381/fr/polynomial/multilin_test.go
+++ b/ecc/bls12-381/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bls12-381/fr/polynomial/polynomial_test.go
+++ b/ecc/bls12-381/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bls12-381/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls12-381/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bls12-381/fr/vector.go
+++ b/ecc/bls12-381/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls12-381/fr/vector_test.go
+++ b/ecc/bls12-381/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -610,9 +610,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -520,12 +520,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BLS12-381] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -610,7 +610,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -599,9 +599,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -512,11 +512,11 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BLS12-381] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fptower.E2
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			}
 
@@ -599,7 +599,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -88,6 +88,14 @@ func (z *E12) SetRandom() (*E12, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E12) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E12) IsZero() bool {
 	return z.C0.IsZero() && z.C1.IsZero()

--- a/ecc/bls12-381/internal/fptower/e12_test.go
+++ b/ecc/bls12-381/internal/fptower/e12_test.go
@@ -444,8 +444,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -454,8 +454,8 @@ func BenchmarkE12Add(b *testing.B) {
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -464,8 +464,8 @@ func BenchmarkE12Sub(b *testing.B) {
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -474,7 +474,7 @@ func BenchmarkE12Mul(b *testing.B) {
 
 func BenchmarkE12Cyclosquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -483,7 +483,7 @@ func BenchmarkE12Cyclosquare(b *testing.B) {
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -492,7 +492,7 @@ func BenchmarkE12Square(b *testing.B) {
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -501,7 +501,7 @@ func BenchmarkE12Inverse(b *testing.B) {
 
 func BenchmarkE12Conjugate(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -510,7 +510,7 @@ func BenchmarkE12Conjugate(b *testing.B) {
 
 func BenchmarkE12Frobenius(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -519,7 +519,7 @@ func BenchmarkE12Frobenius(b *testing.B) {
 
 func BenchmarkE12FrobeniusSquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -528,7 +528,7 @@ func BenchmarkE12FrobeniusSquare(b *testing.B) {
 
 func BenchmarkE12Expt(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/ecc/bls12-381/internal/fptower/e2.go
+++ b/ecc/bls12-381/internal/fptower/e2.go
@@ -90,6 +90,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E2) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/ecc/bls12-381/internal/fptower/e2_test.go
+++ b/ecc/bls12-381/internal/fptower/e2_test.go
@@ -405,8 +405,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -415,8 +415,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -425,8 +425,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -436,8 +436,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -446,7 +446,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -455,7 +455,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -464,7 +464,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -474,7 +474,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -483,7 +483,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -492,7 +492,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -501,7 +501,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls12-381/internal/fptower/e6.go
+++ b/ecc/bls12-381/internal/fptower/e6.go
@@ -52,6 +52,14 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E6) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero() && z.B2.IsZero()

--- a/ecc/bls12-381/internal/fptower/e6_test.go
+++ b/ecc/bls12-381/internal/fptower/e6_test.go
@@ -283,8 +283,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -293,8 +293,8 @@ func BenchmarkE6Add(b *testing.B) {
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -303,8 +303,8 @@ func BenchmarkE6Sub(b *testing.B) {
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -313,7 +313,7 @@ func BenchmarkE6Mul(b *testing.B) {
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -322,7 +322,7 @@ func BenchmarkE6Square(b *testing.B) {
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)

--- a/ecc/bls12-381/internal/fptower/generators_test.go
+++ b/ecc/bls12-381/internal/fptower/generators_test.go
@@ -12,10 +12,8 @@ import (
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bls12-381/kzg/kzg.go
+++ b/ecc/bls12-381/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bls12-381/marshal_test.go
+++ b/ecc/bls12-381/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bls12-381/multiexp_test.go
+++ b/ecc/bls12-381/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bls12-381/pairing_test.go
+++ b/ecc/bls12-381/pairing_test.go
@@ -395,7 +395,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -459,11 +459,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(12)
 	e.Exp(e, k)

--- a/ecc/bls12-381/shplonk/example_test.go
+++ b/ecc/bls12-381/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bls12-381/shplonk/shplonk_test.go
+++ b/ecc/bls12-381/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bls12-381/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls12-381/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bls24-315/fflonk/fflonk_test.go
+++ b/ecc/bls24-315/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -355,8 +355,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -351,6 +351,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -2370,7 +2370,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2414,8 +2414,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2433,7 +2433,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls24-315/fp/element_test.go
+++ b/ecc/bls24-315/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -256,8 +256,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -296,7 +296,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls24-315/fp/vector.go
+++ b/ecc/bls24-315/fp/vector.go
@@ -189,6 +189,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls24-315/fp/vector_test.go
+++ b/ecc/bls24-315/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls24-315/fr/element_test.go
+++ b/ecc/bls24-315/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls24-315/fr/fft/bitreverse_test.go
+++ b/ecc/bls24-315/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bls24-315/fr/fft/fft_test.go
+++ b/ecc/bls24-315/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bls24-315/fr/fri/fri_test.go
+++ b/ecc/bls24-315/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bls24-315/fr/gkr/gkr_test.go
+++ b/ecc/bls24-315/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-315/fr/iop/polynomial_test.go
+++ b/ecc/bls24-315/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bls24-315/fr/iop/quotient_test.go
+++ b/ecc/bls24-315/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bls24-315/fr/iop/ratios_test.go
+++ b/ecc/bls24-315/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bls24-315/fr/mimc/mimc_test.go
+++ b/ecc/bls24-315/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bls24-315/fr/pedersen/example_test.go
+++ b/ecc/bls24-315/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bls24-315/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-315/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bls24-315/fr/permutation/permutation_test.go
+++ b/ecc/bls24-315/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls24-315/fr/plookup/plookup_test.go
+++ b/ecc/bls24-315/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls24-315/fr/polynomial/multilin_test.go
+++ b/ecc/bls24-315/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bls24-315/fr/polynomial/polynomial_test.go
+++ b/ecc/bls24-315/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bls24-315/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls24-315/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bls24-315/fr/vector.go
+++ b/ecc/bls24-315/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls24-315/fr/vector_test.go
+++ b/ecc/bls24-315/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -603,9 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -513,12 +513,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BLS24-315] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -603,7 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -505,11 +505,11 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BLS24-315] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fptower.E4
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			}
 
@@ -592,7 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E4
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -592,9 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E4
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bls24-315/internal/fptower/e12.go
+++ b/ecc/bls24-315/internal/fptower/e12.go
@@ -45,7 +45,7 @@ func (z *E12) SetOne() *E12 {
 	return z
 }
 
-// SetRandom set z to a random elmt
+// SetRandom set z to a random value
 func (z *E12) SetRandom() (*E12, error) {
 	if _, err := z.C0.SetRandom(); err != nil {
 		return nil, err
@@ -57,6 +57,15 @@ func (z *E12) SetRandom() (*E12, error) {
 		return nil, err
 	}
 	return z, nil
+}
+
+// MustSetRandom sets z to a random value/
+// It panics if reading from crypto/rand fails
+func (z *E12) MustSetRandom() *E12 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/ecc/bls24-315/internal/fptower/e12_test.go
+++ b/ecc/bls24-315/internal/fptower/e12_test.go
@@ -185,8 +185,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -195,8 +195,8 @@ func BenchmarkE12Add(b *testing.B) {
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -205,8 +205,8 @@ func BenchmarkE12Sub(b *testing.B) {
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -215,7 +215,7 @@ func BenchmarkE12Mul(b *testing.B) {
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -224,7 +224,7 @@ func BenchmarkE12Square(b *testing.B) {
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -235,7 +235,7 @@ func BenchmarkE12ExpBySeed(b *testing.B) {
 	var a E12
 	var seed big.Int
 	seed.SetString("3218079743", 10)
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Exp(a, &seed).Conjugate(&a)

--- a/ecc/bls24-315/internal/fptower/e2.go
+++ b/ecc/bls24-315/internal/fptower/e2.go
@@ -80,6 +80,15 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a random value.
+// It panics if reading from crypto/rand fails
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/ecc/bls24-315/internal/fptower/e24.go
+++ b/ecc/bls24-315/internal/fptower/e24.go
@@ -86,6 +86,15 @@ func (z *E24) SetRandom() (*E24, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a uniform random value.
+// It panics if reading from crypto/rand fails.
+func (z *E24) MustSetRandom() *E24 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E24) IsZero() bool {
 	return z.D0.IsZero() && z.D1.IsZero()

--- a/ecc/bls24-315/internal/fptower/e24_test.go
+++ b/ecc/bls24-315/internal/fptower/e24_test.go
@@ -485,8 +485,8 @@ func TestE24Ops(t *testing.T) {
 
 func BenchmarkE24Add(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -495,8 +495,8 @@ func BenchmarkE24Add(b *testing.B) {
 
 func BenchmarkE24Sub(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -505,8 +505,8 @@ func BenchmarkE24Sub(b *testing.B) {
 
 func BenchmarkE24Mul(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -515,7 +515,7 @@ func BenchmarkE24Mul(b *testing.B) {
 
 func BenchmarkE24Cyclosquare(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -524,7 +524,7 @@ func BenchmarkE24Cyclosquare(b *testing.B) {
 
 func BenchmarkE24Square(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -533,7 +533,7 @@ func BenchmarkE24Square(b *testing.B) {
 
 func BenchmarkE24Inverse(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -542,7 +542,7 @@ func BenchmarkE24Inverse(b *testing.B) {
 
 func BenchmarkE24Conjugate(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -551,7 +551,7 @@ func BenchmarkE24Conjugate(b *testing.B) {
 
 func BenchmarkE24Frobenius(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -560,7 +560,7 @@ func BenchmarkE24Frobenius(b *testing.B) {
 
 func BenchmarkE24FrobeniusSquare(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -569,7 +569,7 @@ func BenchmarkE24FrobeniusSquare(b *testing.B) {
 
 func BenchmarkE24FrobeniusQuad(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusQuad(&a)
@@ -578,7 +578,7 @@ func BenchmarkE24FrobeniusQuad(b *testing.B) {
 
 func BenchmarkE24Expt(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/ecc/bls24-315/internal/fptower/e2_test.go
+++ b/ecc/bls24-315/internal/fptower/e2_test.go
@@ -376,8 +376,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -386,8 +386,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -396,8 +396,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -407,8 +407,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -417,7 +417,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -426,7 +426,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -435,7 +435,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -445,7 +445,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -454,7 +454,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -463,7 +463,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -472,7 +472,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls24-315/internal/fptower/e4.go
+++ b/ecc/bls24-315/internal/fptower/e4.go
@@ -122,6 +122,15 @@ func (z *E4) SetRandom() (*E4, error) {
 	return z, nil
 }
 
+// MustSetRandom sets B0 and B1 to random values.
+// Panics if reading from crypto/rand fails.
+func (z *E4) MustSetRandom() *E4 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E4) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/ecc/bls24-315/internal/fptower/e4_test.go
+++ b/ecc/bls24-315/internal/fptower/e4_test.go
@@ -262,8 +262,8 @@ func TestE4Ops(t *testing.T) {
 
 func BenchmarkE4Add(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -272,8 +272,8 @@ func BenchmarkE4Add(b *testing.B) {
 
 func BenchmarkE4Sub(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -282,8 +282,8 @@ func BenchmarkE4Sub(b *testing.B) {
 
 func BenchmarkE4Mul(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -292,7 +292,7 @@ func BenchmarkE4Mul(b *testing.B) {
 
 func BenchmarkE4Square(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -301,7 +301,7 @@ func BenchmarkE4Square(b *testing.B) {
 
 func BenchmarkE4Sqrt(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -310,7 +310,7 @@ func BenchmarkE4Sqrt(b *testing.B) {
 
 func BenchmarkE4Inverse(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -319,7 +319,7 @@ func BenchmarkE4Inverse(b *testing.B) {
 
 func BenchmarkE4MulNonRes(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -328,7 +328,7 @@ func BenchmarkE4MulNonRes(b *testing.B) {
 
 func BenchmarkE4MulNonResInv(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -336,7 +336,7 @@ func BenchmarkE4MulNonResInv(b *testing.B) {
 }
 func BenchmarkE4Conjugate(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls24-315/internal/fptower/generators_test.go
+++ b/ecc/bls24-315/internal/fptower/generators_test.go
@@ -9,10 +9,8 @@ import (
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bls24-315/kzg/kzg.go
+++ b/ecc/bls24-315/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bls24-315/marshal_test.go
+++ b/ecc/bls24-315/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bls24-315/multiexp_test.go
+++ b/ecc/bls24-315/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bls24-315/pairing_test.go
+++ b/ecc/bls24-315/pairing_test.go
@@ -396,7 +396,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -460,11 +460,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(24)
 

--- a/ecc/bls24-315/shplonk/example_test.go
+++ b/ecc/bls24-315/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bls24-315/shplonk/shplonk_test.go
+++ b/ecc/bls24-315/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bls24-315/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls24-315/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bls24-317/fflonk/fflonk_test.go
+++ b/ecc/bls24-317/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -355,8 +355,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -351,6 +351,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls24-317/fp/element_test.go
+++ b/ecc/bls24-317/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-317/fp/element_test.go
+++ b/ecc/bls24-317/fp/element_test.go
@@ -2370,7 +2370,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2414,8 +2414,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2433,7 +2433,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls24-317/fp/element_test.go
+++ b/ecc/bls24-317/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -256,8 +256,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -296,7 +296,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls24-317/fp/vector.go
+++ b/ecc/bls24-317/fp/vector.go
@@ -189,6 +189,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls24-317/fp/vector_test.go
+++ b/ecc/bls24-317/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bls24-317/fr/element_test.go
+++ b/ecc/bls24-317/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-317/fr/element_test.go
+++ b/ecc/bls24-317/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bls24-317/fr/element_test.go
+++ b/ecc/bls24-317/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bls24-317/fr/fft/bitreverse_test.go
+++ b/ecc/bls24-317/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bls24-317/fr/fft/fft_test.go
+++ b/ecc/bls24-317/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bls24-317/fr/fri/fri_test.go
+++ b/ecc/bls24-317/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bls24-317/fr/gkr/gkr_test.go
+++ b/ecc/bls24-317/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bls24-317/fr/iop/polynomial_test.go
+++ b/ecc/bls24-317/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bls24-317/fr/iop/quotient_test.go
+++ b/ecc/bls24-317/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bls24-317/fr/iop/ratios_test.go
+++ b/ecc/bls24-317/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bls24-317/fr/mimc/mimc_test.go
+++ b/ecc/bls24-317/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bls24-317/fr/pedersen/example_test.go
+++ b/ecc/bls24-317/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bls24-317/fr/pedersen/pedersen_test.go
+++ b/ecc/bls24-317/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bls24-317/fr/permutation/permutation_test.go
+++ b/ecc/bls24-317/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls24-317/fr/plookup/plookup_test.go
+++ b/ecc/bls24-317/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bls24-317/fr/polynomial/multilin_test.go
+++ b/ecc/bls24-317/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bls24-317/fr/polynomial/polynomial_test.go
+++ b/ecc/bls24-317/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bls24-317/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls24-317/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bls24-317/fr/vector.go
+++ b/ecc/bls24-317/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bls24-317/fr/vector_test.go
+++ b/ecc/bls24-317/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -603,9 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -513,12 +513,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BLS24-317] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -603,7 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -505,11 +505,11 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BLS24-317] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fptower.E4
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			}
 
@@ -592,7 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E4
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -592,9 +592,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E4
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bls24-317/internal/fptower/e12.go
+++ b/ecc/bls24-317/internal/fptower/e12.go
@@ -45,7 +45,7 @@ func (z *E12) SetOne() *E12 {
 	return z
 }
 
-// SetRandom sets z to a random elmt
+// SetRandom sets z to a random value
 func (z *E12) SetRandom() (*E12, error) {
 	if _, err := z.C0.SetRandom(); err != nil {
 		return nil, err
@@ -57,6 +57,15 @@ func (z *E12) SetRandom() (*E12, error) {
 		return nil, err
 	}
 	return z, nil
+}
+
+// MustSetRandom sets z to a random value
+// Panics if reading from crypto/rand fails
+func (z *E12) MustSetRandom() *E12 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/ecc/bls24-317/internal/fptower/e12_test.go
+++ b/ecc/bls24-317/internal/fptower/e12_test.go
@@ -184,8 +184,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -194,8 +194,8 @@ func BenchmarkE12Add(b *testing.B) {
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -204,8 +204,8 @@ func BenchmarkE12Sub(b *testing.B) {
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -214,7 +214,7 @@ func BenchmarkE12Mul(b *testing.B) {
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -223,7 +223,7 @@ func BenchmarkE12Square(b *testing.B) {
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -234,7 +234,7 @@ func BenchmarkE12ExpBySeed(b *testing.B) {
 	var a E12
 	var seed big.Int
 	seed.SetString("3218079743", 10)
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Exp(a, &seed).Conjugate(&a)

--- a/ecc/bls24-317/internal/fptower/e2.go
+++ b/ecc/bls24-317/internal/fptower/e2.go
@@ -80,6 +80,15 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/ecc/bls24-317/internal/fptower/e24.go
+++ b/ecc/bls24-317/internal/fptower/e24.go
@@ -86,6 +86,15 @@ func (z *E24) SetRandom() (*E24, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a uniform random value.
+// It panics if reading from crypto/rand fails.
+func (z *E24) MustSetRandom() *E24 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E24) IsZero() bool {
 	return z.D0.IsZero() && z.D1.IsZero()

--- a/ecc/bls24-317/internal/fptower/e24_test.go
+++ b/ecc/bls24-317/internal/fptower/e24_test.go
@@ -465,8 +465,8 @@ func TestE24Ops(t *testing.T) {
 
 func BenchmarkE24Add(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -475,8 +475,8 @@ func BenchmarkE24Add(b *testing.B) {
 
 func BenchmarkE24Sub(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -485,8 +485,8 @@ func BenchmarkE24Sub(b *testing.B) {
 
 func BenchmarkE24Mul(b *testing.B) {
 	var a, c E24
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -495,7 +495,7 @@ func BenchmarkE24Mul(b *testing.B) {
 
 func BenchmarkE24Cyclosquare(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -504,7 +504,7 @@ func BenchmarkE24Cyclosquare(b *testing.B) {
 
 func BenchmarkE24Square(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -513,7 +513,7 @@ func BenchmarkE24Square(b *testing.B) {
 
 func BenchmarkE24Inverse(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -522,7 +522,7 @@ func BenchmarkE24Inverse(b *testing.B) {
 
 func BenchmarkE24Conjugate(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -531,7 +531,7 @@ func BenchmarkE24Conjugate(b *testing.B) {
 
 func BenchmarkE24Frobenius(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -540,7 +540,7 @@ func BenchmarkE24Frobenius(b *testing.B) {
 
 func BenchmarkE24FrobeniusSquare(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -549,7 +549,7 @@ func BenchmarkE24FrobeniusSquare(b *testing.B) {
 
 func BenchmarkE24FrobeniusQuad(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusQuad(&a)
@@ -558,7 +558,7 @@ func BenchmarkE24FrobeniusQuad(b *testing.B) {
 
 func BenchmarkE24Expt(b *testing.B) {
 	var a E24
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/ecc/bls24-317/internal/fptower/e2_test.go
+++ b/ecc/bls24-317/internal/fptower/e2_test.go
@@ -377,8 +377,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -387,8 +387,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -397,8 +397,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -408,8 +408,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-	c.SetRandom()
-	a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -418,7 +418,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -427,7 +427,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -436,7 +436,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -446,7 +446,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -455,7 +455,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -464,7 +464,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -473,7 +473,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls24-317/internal/fptower/e4.go
+++ b/ecc/bls24-317/internal/fptower/e4.go
@@ -122,6 +122,15 @@ func (z *E4) SetRandom() (*E4, error) {
 	return z, nil
 }
 
+// MustSetRandom sets B0 and B1 to random values.
+// Panics if reading from crypto/rand fails.
+func (z *E4) MustSetRandom() *E4 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E4) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/ecc/bls24-317/internal/fptower/e4_test.go
+++ b/ecc/bls24-317/internal/fptower/e4_test.go
@@ -260,8 +260,8 @@ func TestE4Ops(t *testing.T) {
 
 func BenchmarkE4Add(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -270,8 +270,8 @@ func BenchmarkE4Add(b *testing.B) {
 
 func BenchmarkE4Sub(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -280,8 +280,8 @@ func BenchmarkE4Sub(b *testing.B) {
 
 func BenchmarkE4Mul(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -290,7 +290,7 @@ func BenchmarkE4Mul(b *testing.B) {
 
 func BenchmarkE4Square(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -299,7 +299,7 @@ func BenchmarkE4Square(b *testing.B) {
 
 func BenchmarkE4Sqrt(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -308,7 +308,7 @@ func BenchmarkE4Sqrt(b *testing.B) {
 
 func BenchmarkE4Inverse(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -317,7 +317,7 @@ func BenchmarkE4Inverse(b *testing.B) {
 
 func BenchmarkE4MulNonRes(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -326,7 +326,7 @@ func BenchmarkE4MulNonRes(b *testing.B) {
 
 func BenchmarkE4MulNonResInv(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -334,7 +334,7 @@ func BenchmarkE4MulNonResInv(b *testing.B) {
 }
 func BenchmarkE4Conjugate(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bls24-317/internal/fptower/generators_test.go
+++ b/ecc/bls24-317/internal/fptower/generators_test.go
@@ -9,10 +9,8 @@ import (
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bls24-317/kzg/kzg.go
+++ b/ecc/bls24-317/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bls24-317/marshal_test.go
+++ b/ecc/bls24-317/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bls24-317/multiexp_test.go
+++ b/ecc/bls24-317/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bls24-317/pairing_test.go
+++ b/ecc/bls24-317/pairing_test.go
@@ -396,7 +396,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -460,11 +460,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(12)
 	e.Exp(e, k)

--- a/ecc/bls24-317/shplonk/example_test.go
+++ b/ecc/bls24-317/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bls24-317/shplonk/shplonk_test.go
+++ b/ecc/bls24-317/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bls24-317/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls24-317/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bn254/fflonk/fflonk_test.go
+++ b/ecc/bn254/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bn254/fp/element_test.go
+++ b/ecc/bn254/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bn254/fp/vector.go
+++ b/ecc/bn254/fp/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bn254/fp/vector_test.go
+++ b/ecc/bn254/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bn254/fr/element_test.go
+++ b/ecc/bn254/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bn254/fr/fft/bitreverse_test.go
+++ b/ecc/bn254/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bn254/fr/fft/fft_test.go
+++ b/ecc/bn254/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bn254/fr/fri/fri_test.go
+++ b/ecc/bn254/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bn254/fr/gkr/gkr_test.go
+++ b/ecc/bn254/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bn254/fr/iop/polynomial_test.go
+++ b/ecc/bn254/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bn254/fr/iop/quotient_test.go
+++ b/ecc/bn254/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bn254/fr/iop/ratios_test.go
+++ b/ecc/bn254/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bn254/fr/mimc/mimc_test.go
+++ b/ecc/bn254/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bn254/fr/pedersen/example_test.go
+++ b/ecc/bn254/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bn254/fr/pedersen/pedersen_test.go
+++ b/ecc/bn254/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bn254/fr/permutation/permutation_test.go
+++ b/ecc/bn254/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bn254/fr/plookup/plookup_test.go
+++ b/ecc/bn254/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bn254/fr/polynomial/multilin_test.go
+++ b/ecc/bn254/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bn254/fr/polynomial/polynomial_test.go
+++ b/ecc/bn254/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bn254/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bn254/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bn254/fr/vector.go
+++ b/ecc/bn254/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bn254/fr/vector_test.go
+++ b/ecc/bn254/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -564,7 +564,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -564,9 +564,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -598,9 +598,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -511,11 +511,11 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BN254] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fptower.E2
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 			}
 
@@ -598,7 +598,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fptower.E2
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bn254/internal/fptower/e12.go
+++ b/ecc/bn254/internal/fptower/e12.go
@@ -88,6 +88,14 @@ func (z *E12) SetRandom() (*E12, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E12) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E12) IsZero() bool {
 	return z.C0.IsZero() && z.C1.IsZero()

--- a/ecc/bn254/internal/fptower/e12_test.go
+++ b/ecc/bn254/internal/fptower/e12_test.go
@@ -444,8 +444,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -454,8 +454,8 @@ func BenchmarkE12Add(b *testing.B) {
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -464,8 +464,8 @@ func BenchmarkE12Sub(b *testing.B) {
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -474,7 +474,7 @@ func BenchmarkE12Mul(b *testing.B) {
 
 func BenchmarkE12Cyclosquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -483,7 +483,7 @@ func BenchmarkE12Cyclosquare(b *testing.B) {
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -492,7 +492,7 @@ func BenchmarkE12Square(b *testing.B) {
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -501,7 +501,7 @@ func BenchmarkE12Inverse(b *testing.B) {
 
 func BenchmarkE12Conjugate(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -510,7 +510,7 @@ func BenchmarkE12Conjugate(b *testing.B) {
 
 func BenchmarkE12Frobenius(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -519,7 +519,7 @@ func BenchmarkE12Frobenius(b *testing.B) {
 
 func BenchmarkE12FrobeniusSquare(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -528,7 +528,7 @@ func BenchmarkE12FrobeniusSquare(b *testing.B) {
 
 func BenchmarkE12Expt(b *testing.B) {
 	var a E12
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/ecc/bn254/internal/fptower/e2.go
+++ b/ecc/bn254/internal/fptower/e2.go
@@ -90,6 +90,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E2) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/ecc/bn254/internal/fptower/e2_test.go
+++ b/ecc/bn254/internal/fptower/e2_test.go
@@ -403,8 +403,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -413,8 +413,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -423,8 +423,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -434,8 +434,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -444,7 +444,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -453,7 +453,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -462,7 +462,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -472,7 +472,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -481,7 +481,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -490,7 +490,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -499,7 +499,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/ecc/bn254/internal/fptower/e6.go
+++ b/ecc/bn254/internal/fptower/e6.go
@@ -52,6 +52,14 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E6) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero() && z.B2.IsZero()

--- a/ecc/bn254/internal/fptower/e6_test.go
+++ b/ecc/bn254/internal/fptower/e6_test.go
@@ -283,8 +283,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -293,8 +293,8 @@ func BenchmarkE6Add(b *testing.B) {
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -303,8 +303,8 @@ func BenchmarkE6Sub(b *testing.B) {
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -313,7 +313,7 @@ func BenchmarkE6Mul(b *testing.B) {
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -322,7 +322,7 @@ func BenchmarkE6Square(b *testing.B) {
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)

--- a/ecc/bn254/internal/fptower/generators_test.go
+++ b/ecc/bn254/internal/fptower/generators_test.go
@@ -5,14 +5,12 @@ import (
 	"github.com/leanovate/gopter"
 )
 
-// GenFp generates an Fp element
+// Fp generates an Fp element
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bn254/kzg/kzg.go
+++ b/ecc/bn254/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -240,8 +239,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -258,8 +257,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -333,8 +332,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -351,8 +350,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -425,10 +424,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -438,10 +434,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bn254/multiexp_test.go
+++ b/ecc/bn254/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bn254/pairing_test.go
+++ b/ecc/bn254/pairing_test.go
@@ -395,7 +395,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -459,11 +459,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(12)
 	e.Exp(e, k)

--- a/ecc/bn254/shplonk/example_test.go
+++ b/ecc/bn254/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bn254/shplonk/shplonk_test.go
+++ b/ecc/bn254/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bn254/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bn254/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bw6-633/fflonk/fflonk_test.go
+++ b/ecc/bw6-633/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -411,6 +411,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -415,8 +415,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -2405,7 +2405,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2454,8 +2454,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2473,7 +2473,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2519,7 +2519,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2528,7 +2528,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bw6-633/fp/element_test.go
+++ b/ecc/bw6-633/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -266,8 +266,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -306,7 +306,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bw6-633/fp/vector.go
+++ b/ecc/bw6-633/fp/vector.go
@@ -194,6 +194,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bw6-633/fp/vector_test.go
+++ b/ecc/bw6-633/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -355,8 +355,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -351,6 +351,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -2370,7 +2370,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2414,8 +2414,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2433,7 +2433,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bw6-633/fr/element_test.go
+++ b/ecc/bw6-633/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -256,8 +256,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -296,7 +296,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bw6-633/fr/fft/bitreverse_test.go
+++ b/ecc/bw6-633/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bw6-633/fr/fft/fft_test.go
+++ b/ecc/bw6-633/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bw6-633/fr/fri/fri_test.go
+++ b/ecc/bw6-633/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bw6-633/fr/gkr/gkr_test.go
+++ b/ecc/bw6-633/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-633/fr/iop/polynomial_test.go
+++ b/ecc/bw6-633/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bw6-633/fr/iop/quotient_test.go
+++ b/ecc/bw6-633/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bw6-633/fr/iop/ratios_test.go
+++ b/ecc/bw6-633/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bw6-633/fr/mimc/mimc_test.go
+++ b/ecc/bw6-633/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bw6-633/fr/pedersen/example_test.go
+++ b/ecc/bw6-633/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bw6-633/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-633/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bw6-633/fr/permutation/permutation_test.go
+++ b/ecc/bw6-633/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bw6-633/fr/plookup/plookup_test.go
+++ b/ecc/bw6-633/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bw6-633/fr/polynomial/multilin_test.go
+++ b/ecc/bw6-633/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bw6-633/fr/polynomial/polynomial_test.go
+++ b/ecc/bw6-633/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bw6-633/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bw6-633/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bw6-633/fr/vector.go
+++ b/ecc/bw6-633/fr/vector.go
@@ -189,6 +189,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bw6-633/fr/vector_test.go
+++ b/ecc/bw6-633/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -513,12 +513,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BW6-633] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -603,7 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -603,9 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -483,12 +483,12 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BW6-633] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 
@@ -573,7 +573,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -573,9 +573,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bw6-633/internal/fptower/e3.go
+++ b/ecc/bw6-633/internal/fptower/e3.go
@@ -59,7 +59,7 @@ func (z *E3) SetOne() *E3 {
 	return z
 }
 
-// SetRandom sets z to a random elmt
+// SetRandom sets z to a uniform random value
 func (z *E3) SetRandom() (*E3, error) {
 	if _, err := z.A0.SetRandom(); err != nil {
 		return nil, err
@@ -71,6 +71,15 @@ func (z *E3) SetRandom() (*E3, error) {
 		return nil, err
 	}
 	return z, nil
+}
+
+// MustSetRandom sets z to a uniform random value.
+// Panics if reading from crypto/rand fails.
+func (z *E3) MustSetRandom() *E3 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise
@@ -131,31 +140,31 @@ func (z *E3) MulByElement(x *E3, y *fp.Element) *E3 {
 }
 
 // MulBy12 multiplication by sparse element (0,b1,b2)
-func (x *E3) MulBy12(b1, b2 *fp.Element) *E3 {
+func (z *E3) MulBy12(b1, b2 *fp.Element) *E3 {
 	var t1, t2, c0, tmp, c1, c2 fp.Element
-	t1.Mul(&x.A1, b1)
-	t2.Mul(&x.A2, b2)
-	c0.Add(&x.A1, &x.A2)
+	t1.Mul(&z.A1, b1)
+	t2.Mul(&z.A2, b2)
+	c0.Add(&z.A1, &z.A2)
 	tmp.Add(b1, b2)
 	c0.Mul(&c0, &tmp)
 	c0.Sub(&c0, &t1)
 	c0.Sub(&c0, &t2)
 	c0.MulByNonResidue(&c0)
-	c1.Add(&x.A0, &x.A1)
+	c1.Add(&z.A0, &z.A1)
 	c1.Mul(&c1, b1)
 	c1.Sub(&c1, &t1)
 	tmp.MulByNonResidue(&t2)
 	c1.Add(&c1, &tmp)
-	tmp.Add(&x.A0, &x.A2)
+	tmp.Add(&z.A0, &z.A2)
 	c2.Mul(b2, &tmp)
 	c2.Sub(&c2, &t2)
 	c2.Add(&c2, &t1)
 
-	x.A0 = c0
-	x.A1 = c1
-	x.A2 = c2
+	z.A0 = c0
+	z.A1 = c1
+	z.A2 = c2
 
-	return x
+	return z
 }
 
 // MulBy01 multiplication by sparse element (c0,c1,0)

--- a/ecc/bw6-633/internal/fptower/e3_test.go
+++ b/ecc/bw6-633/internal/fptower/e3_test.go
@@ -244,8 +244,8 @@ func TestE3Ops(t *testing.T) {
 
 func BenchmarkE3Add(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -254,8 +254,8 @@ func BenchmarkE3Add(b *testing.B) {
 
 func BenchmarkE3Sub(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -264,8 +264,8 @@ func BenchmarkE3Sub(b *testing.B) {
 
 func BenchmarkE3Mul(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -275,8 +275,8 @@ func BenchmarkE3Mul(b *testing.B) {
 func BenchmarkE3MulByElement(b *testing.B) {
 	var a E3
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -285,7 +285,7 @@ func BenchmarkE3MulByElement(b *testing.B) {
 
 func BenchmarkE3Square(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -294,7 +294,7 @@ func BenchmarkE3Square(b *testing.B) {
 
 func BenchmarkE3Inverse(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -303,7 +303,7 @@ func BenchmarkE3Inverse(b *testing.B) {
 
 func BenchmarkE3MulNonRes(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)

--- a/ecc/bw6-633/internal/fptower/e6.go
+++ b/ecc/bw6-633/internal/fptower/e6.go
@@ -87,6 +87,15 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a uniform random value.
+// It panics if reading from crypto/rand fails.
+func (z *E6) MustSetRandom() *E6 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/ecc/bw6-633/internal/fptower/e6_test.go
+++ b/ecc/bw6-633/internal/fptower/e6_test.go
@@ -378,8 +378,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -388,8 +388,8 @@ func BenchmarkE6Add(b *testing.B) {
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -398,8 +398,8 @@ func BenchmarkE6Sub(b *testing.B) {
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -408,7 +408,7 @@ func BenchmarkE6Mul(b *testing.B) {
 
 func BenchmarkE6Cyclosquare(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -417,7 +417,7 @@ func BenchmarkE6Cyclosquare(b *testing.B) {
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -426,7 +426,7 @@ func BenchmarkE6Square(b *testing.B) {
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -435,7 +435,7 @@ func BenchmarkE6Inverse(b *testing.B) {
 
 func BenchmarkE6Conjugate(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -444,7 +444,7 @@ func BenchmarkE6Conjugate(b *testing.B) {
 
 func BenchmarkE6Frobenius(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -453,7 +453,7 @@ func BenchmarkE6Frobenius(b *testing.B) {
 
 func BenchmarkE6Expt(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	c.Conjugate(&a)
 	a.Inverse(&a)

--- a/ecc/bw6-633/internal/fptower/generators_test.go
+++ b/ecc/bw6-633/internal/fptower/generators_test.go
@@ -11,10 +11,8 @@ import (
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bw6-633/kzg/kzg.go
+++ b/ecc/bw6-633/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bw6-633/marshal_test.go
+++ b/ecc/bw6-633/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bw6-633/multiexp_test.go
+++ b/ecc/bw6-633/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bw6-633/pairing_test.go
+++ b/ecc/bw6-633/pairing_test.go
@@ -396,7 +396,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -460,11 +460,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(6)
 

--- a/ecc/bw6-633/shplonk/example_test.go
+++ b/ecc/bw6-633/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bw6-633/shplonk/shplonk_test.go
+++ b/ecc/bw6-633/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bw6-633/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bw6-633/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/bw6-761/fflonk/fflonk_test.go
+++ b/ecc/bw6-761/fflonk/fflonk_test.go
@@ -40,7 +40,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -73,7 +73,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -89,13 +89,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -439,8 +439,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -435,6 +435,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -270,8 +270,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -310,7 +310,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bw6-761/fp/element_test.go
+++ b/ecc/bw6-761/fp/element_test.go
@@ -2419,7 +2419,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2470,8 +2470,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2489,7 +2489,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2537,7 +2537,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2546,7 +2546,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bw6-761/fp/vector.go
+++ b/ecc/bw6-761/fp/vector.go
@@ -196,6 +196,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bw6-761/fp/vector_test.go
+++ b/ecc/bw6-761/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -363,6 +363,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -367,8 +367,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -258,8 +258,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -298,7 +298,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/bw6-761/fr/element_test.go
+++ b/ecc/bw6-761/fr/element_test.go
@@ -2377,7 +2377,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2422,8 +2422,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2441,7 +2441,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2483,7 +2483,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2492,7 +2492,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/bw6-761/fr/fft/bitreverse_test.go
+++ b/ecc/bw6-761/fr/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []fr.Element array of size 2**20
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []fr.Element array of size 2**22
 	pol := make([]fr.Element, maxSizeBitReverse)
 	one := fr.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/ecc/bw6-761/fr/fft/fft_test.go
+++ b/ecc/bw6-761/fr/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]fr.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]fr.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]fr.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/ecc/bw6-761/fr/fri/fri_test.go
+++ b/ecc/bw6-761/fr/fri/fri_test.go
@@ -210,10 +210,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/ecc/bw6-761/fr/gkr/gkr_test.go
+++ b/ecc/bw6-761/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/bw6-761/fr/iop/polynomial_test.go
+++ b/ecc/bw6-761/fr/iop/polynomial_test.go
@@ -52,7 +52,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -107,11 +107,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/ecc/bw6-761/fr/iop/quotient_test.go
+++ b/ecc/bw6-761/fr/iop/quotient_test.go
@@ -56,8 +56,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -108,7 +108,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/ecc/bw6-761/fr/iop/ratios_test.go
+++ b/ecc/bw6-761/fr/iop/ratios_test.go
@@ -78,7 +78,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -190,7 +190,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -221,8 +221,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/ecc/bw6-761/fr/mimc/mimc_test.go
+++ b/ecc/bw6-761/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/bw6-761/fr/pedersen/example_test.go
+++ b/ecc/bw6-761/fr/pedersen/example_test.go
@@ -43,7 +43,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -95,7 +95,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -108,7 +108,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -167,7 +167,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -190,7 +190,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/ecc/bw6-761/fr/pedersen/pedersen_test.go
+++ b/ecc/bw6-761/fr/pedersen/pedersen_test.go
@@ -25,13 +25,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -81,9 +79,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -151,11 +149,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -196,13 +194,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -215,8 +210,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/ecc/bw6-761/fr/permutation/permutation_test.go
+++ b/ecc/bw6-761/fr/permutation/permutation_test.go
@@ -45,7 +45,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bw6-761/fr/plookup/plookup_test.go
+++ b/ecc/bw6-761/fr/plookup/plookup_test.go
@@ -44,7 +44,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -94,7 +94,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/ecc/bw6-761/fr/polynomial/multilin_test.go
+++ b/ecc/bw6-761/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/bw6-761/fr/polynomial/polynomial_test.go
+++ b/ecc/bw6-761/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/bw6-761/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bw6-761/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/bw6-761/fr/vector.go
+++ b/ecc/bw6-761/fr/vector.go
@@ -190,6 +190,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/bw6-761/fr/vector_test.go
+++ b/ecc/bw6-761/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -603,9 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -513,12 +513,12 @@ func TestG1CofactorClearing(t *testing.T) {
 	properties.Property("[BW6-761] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 
@@ -603,7 +603,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -483,12 +483,12 @@ func TestG2CofactorClearing(t *testing.T) {
 	properties.Property("[BW6-761] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b fp.Element
-			a.SetRandom()
+			a.MustSetRandom()
 
 			x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 
 			for x.Legendre() != 1 {
-				a.SetRandom()
+				a.MustSetRandom()
 
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 
@@ -573,7 +573,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -573,9 +573,7 @@ func BenchmarkG2JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG2JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G2Jac
 	a.ScalarMultiplication(&g2Gen, big.NewInt(42))

--- a/ecc/bw6-761/internal/fptower/e3.go
+++ b/ecc/bw6-761/internal/fptower/e3.go
@@ -55,7 +55,7 @@ func (z *E3) SetOne() *E3 {
 	return z
 }
 
-// SetRandom sets z to a random elmt
+// SetRandom sets z to a random value
 func (z *E3) SetRandom() (*E3, error) {
 	if _, err := z.A0.SetRandom(); err != nil {
 		return nil, err
@@ -67,6 +67,15 @@ func (z *E3) SetRandom() (*E3, error) {
 		return nil, err
 	}
 	return z, nil
+}
+
+// MustSetRandom sets z to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E3) MustSetRandom() *E3 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/ecc/bw6-761/internal/fptower/e3_test.go
+++ b/ecc/bw6-761/internal/fptower/e3_test.go
@@ -244,8 +244,8 @@ func TestE3Ops(t *testing.T) {
 
 func BenchmarkE3Add(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -254,8 +254,8 @@ func BenchmarkE3Add(b *testing.B) {
 
 func BenchmarkE3Sub(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -264,8 +264,8 @@ func BenchmarkE3Sub(b *testing.B) {
 
 func BenchmarkE3Mul(b *testing.B) {
 	var a, c E3
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -275,8 +275,8 @@ func BenchmarkE3Mul(b *testing.B) {
 func BenchmarkE3MulByElement(b *testing.B) {
 	var a E3
 	var c fp.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -285,7 +285,7 @@ func BenchmarkE3MulByElement(b *testing.B) {
 
 func BenchmarkE3Square(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -294,7 +294,7 @@ func BenchmarkE3Square(b *testing.B) {
 
 func BenchmarkE3Inverse(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -303,7 +303,7 @@ func BenchmarkE3Inverse(b *testing.B) {
 
 func BenchmarkE3MulNonRes(b *testing.B) {
 	var a E3
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)

--- a/ecc/bw6-761/internal/fptower/e6.go
+++ b/ecc/bw6-761/internal/fptower/e6.go
@@ -86,6 +86,15 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a uniform random value.
+// It panics if reading from crypto/rand fails.
+func (z *E6) MustSetRandom() *E6 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/ecc/bw6-761/internal/fptower/e6_direct.go
+++ b/ecc/bw6-761/internal/fptower/e6_direct.go
@@ -111,6 +111,15 @@ func (z *E6D) SetRandom() (*E6D, error) {
 	return z, nil
 }
 
+// MustSetRandom sets z to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E6D) MustSetRandom() *E6D {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6D) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero() && z.A2.IsZero() && z.A3.IsZero() && z.A4.IsZero() && z.A5.IsZero()

--- a/ecc/bw6-761/internal/fptower/e6_direct_test.go
+++ b/ecc/bw6-761/internal/fptower/e6_direct_test.go
@@ -200,8 +200,8 @@ func TestE6DOps(t *testing.T) {
 // bench
 func BenchmarkE6DMulTower(b *testing.B) {
 	var a, c E6D
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.mulTower(&a, &c)
@@ -210,8 +210,8 @@ func BenchmarkE6DMulTower(b *testing.B) {
 
 func BenchmarkE6DMulMontgomery6(b *testing.B) {
 	var a, c E6D
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.mulMontgomery6(&a, &c)

--- a/ecc/bw6-761/internal/fptower/e6_test.go
+++ b/ecc/bw6-761/internal/fptower/e6_test.go
@@ -360,8 +360,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -370,8 +370,8 @@ func BenchmarkE6Add(b *testing.B) {
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -380,8 +380,8 @@ func BenchmarkE6Sub(b *testing.B) {
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
-	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -390,7 +390,7 @@ func BenchmarkE6Mul(b *testing.B) {
 
 func BenchmarkE6Cyclosquare(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -399,7 +399,7 @@ func BenchmarkE6Cyclosquare(b *testing.B) {
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -408,7 +408,7 @@ func BenchmarkE6Square(b *testing.B) {
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -417,7 +417,7 @@ func BenchmarkE6Inverse(b *testing.B) {
 
 func BenchmarkE6Conjugate(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -426,7 +426,7 @@ func BenchmarkE6Conjugate(b *testing.B) {
 
 func BenchmarkE6Frobenius(b *testing.B) {
 	var a E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -435,7 +435,7 @@ func BenchmarkE6Frobenius(b *testing.B) {
 
 func BenchmarkE6Expt(b *testing.B) {
 	var a, c E6
-	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	c.Conjugate(&a)
 	a.Inverse(&a)

--- a/ecc/bw6-761/internal/fptower/generators_test.go
+++ b/ecc/bw6-761/internal/fptower/generators_test.go
@@ -7,14 +7,12 @@ import (
 
 // TODO all gopter.Gen are incorrect, use same model as goff
 
-// GenFp generates an Fp element
+// Fp generates an Fp element
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/ecc/bw6-761/kzg/kzg.go
+++ b/ecc/bw6-761/kzg/kzg.go
@@ -423,8 +423,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -121,9 +121,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -160,19 +160,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -211,7 +211,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -306,12 +306,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -328,7 +328,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -367,7 +367,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -439,9 +439,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -578,13 +578,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -601,7 +601,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -616,7 +616,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -652,7 +652,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -682,7 +682,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -698,7 +698,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/ecc/bw6-761/marshal_test.go
+++ b/ecc/bw6-761/marshal_test.go
@@ -48,8 +48,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -67,10 +67,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -260,8 +259,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -278,8 +277,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -373,8 +372,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -391,8 +390,8 @@ func TestG2AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G2Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -465,10 +464,7 @@ func TestG2AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -478,10 +474,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/bw6-761/multiexp_test.go
+++ b/ecc/bw6-761/multiexp_test.go
@@ -847,6 +847,6 @@ func fillBenchBasesG2(samplePoints []G2Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/bw6-761/pairing_test.go
+++ b/ecc/bw6-761/pairing_test.go
@@ -424,7 +424,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -488,11 +488,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
 
 	k := new(big.Int).SetUint64(6)
 

--- a/ecc/bw6-761/shplonk/example_test.go
+++ b/ecc/bw6-761/shplonk/example_test.go
@@ -27,14 +27,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/ecc/bw6-761/shplonk/shplonk_test.go
+++ b/ecc/bw6-761/shplonk/shplonk_test.go
@@ -26,7 +26,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -46,9 +46,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -66,9 +64,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -79,9 +75,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -93,7 +87,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -109,9 +103,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -144,10 +136,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -162,9 +153,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -183,7 +173,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -195,9 +185,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -214,7 +203,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -225,18 +214,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -248,15 +235,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -272,7 +255,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -285,18 +268,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -318,7 +299,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/ecc/bw6-761/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bw6-761/twistededwards/eddsa/eddsa_test.go
@@ -31,7 +31,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -741,9 +741,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/ecc/grumpkin/fp/element.go
+++ b/ecc/grumpkin/fp/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/grumpkin/fp/element.go
+++ b/ecc/grumpkin/fp/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/grumpkin/fp/element_test.go
+++ b/ecc/grumpkin/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/grumpkin/fp/element_test.go
+++ b/ecc/grumpkin/fp/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/grumpkin/fp/element_test.go
+++ b/ecc/grumpkin/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/grumpkin/fp/vector.go
+++ b/ecc/grumpkin/fp/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/grumpkin/fp/vector_test.go
+++ b/ecc/grumpkin/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/grumpkin/fr/element.go
+++ b/ecc/grumpkin/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/grumpkin/fr/element.go
+++ b/ecc/grumpkin/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/grumpkin/fr/element_test.go
+++ b/ecc/grumpkin/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/grumpkin/fr/element_test.go
+++ b/ecc/grumpkin/fr/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/grumpkin/fr/element_test.go
+++ b/ecc/grumpkin/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/grumpkin/fr/gkr/gkr_test.go
+++ b/ecc/grumpkin/fr/gkr/gkr_test.go
@@ -372,7 +372,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]fr.El
 
 func setRandom(slice []fr.Element) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/ecc/grumpkin/fr/mimc/mimc_test.go
+++ b/ecc/grumpkin/fr/mimc/mimc_test.go
@@ -86,10 +86,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/ecc/grumpkin/fr/polynomial/multilin_test.go
+++ b/ecc/grumpkin/fr/polynomial/multilin_test.go
@@ -18,16 +18,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]fr.Element
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r fr.Element
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/ecc/grumpkin/fr/polynomial/polynomial_test.go
+++ b/ecc/grumpkin/fr/polynomial/polynomial_test.go
@@ -25,7 +25,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den fr.Element
@@ -56,7 +56,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -82,7 +82,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -108,7 +108,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c fr.Element
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/ecc/grumpkin/fr/poseidon2/poseidon2_test.go
+++ b/ecc/grumpkin/fr/poseidon2/poseidon2_test.go
@@ -58,9 +58,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])

--- a/ecc/grumpkin/fr/vector.go
+++ b/ecc/grumpkin/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/grumpkin/fr/vector_test.go
+++ b/ecc/grumpkin/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/grumpkin/g1_test.go
+++ b/ecc/grumpkin/g1_test.go
@@ -564,7 +564,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 

--- a/ecc/grumpkin/g1_test.go
+++ b/ecc/grumpkin/g1_test.go
@@ -564,9 +564,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))

--- a/ecc/grumpkin/marshal_test.go
+++ b/ecc/grumpkin/marshal_test.go
@@ -45,8 +45,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inG = make([]G1Affine, 2)
@@ -63,9 +63,7 @@ func TestEncoder(t *testing.T) {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
 			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			fr.Vector(inN[i][j]).MustSetRandom()
 		}
 	}
 
@@ -197,8 +195,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -215,8 +213,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -289,10 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -302,10 +297,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/grumpkin/multiexp_test.go
+++ b/ecc/grumpkin/multiexp_test.go
@@ -437,6 +437,6 @@ func fillBenchBasesG1(samplePoints []G1Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/secp256k1/fp/element_test.go
+++ b/ecc/secp256k1/fp/element_test.go
@@ -30,8 +30,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -41,17 +41,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -63,21 +63,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -87,8 +87,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -99,8 +99,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -109,8 +109,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -119,7 +119,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -128,8 +128,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -138,8 +138,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -147,7 +147,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -156,8 +156,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -165,7 +165,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -173,7 +173,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -252,8 +252,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -292,7 +292,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/secp256k1/fp/element_test.go
+++ b/ecc/secp256k1/fp/element_test.go
@@ -45,7 +45,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/secp256k1/fp/vector.go
+++ b/ecc/secp256k1/fp/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/secp256k1/fp/vector_test.go
+++ b/ecc/secp256k1/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/secp256k1/fr/element_test.go
+++ b/ecc/secp256k1/fr/element_test.go
@@ -30,8 +30,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -41,17 +41,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -63,21 +63,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -87,8 +87,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -99,8 +99,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -109,8 +109,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -119,7 +119,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -128,8 +128,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -138,8 +138,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -147,7 +147,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -156,8 +156,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -165,7 +165,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -173,7 +173,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -252,8 +252,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -292,7 +292,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/secp256k1/fr/element_test.go
+++ b/ecc/secp256k1/fr/element_test.go
@@ -45,7 +45,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/secp256k1/fr/vector.go
+++ b/ecc/secp256k1/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/secp256k1/fr/vector_test.go
+++ b/ecc/secp256k1/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -566,7 +566,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 
@@ -840,7 +840,7 @@ func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
 
-		if _, err := elmt.SetRandom(); err != nil {
+		if _, err := elmt.MustSetRandom(); err != nil {
 			panic(err)
 		}
 
@@ -853,7 +853,7 @@ func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
 
-		if _, err := elmt.SetRandom(); err != nil {
+		if _, err := elmt.MustSetRandom(); err != nil {
 			panic(err)
 		}
 

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -566,9 +566,7 @@ func BenchmarkG1JacIsInSubGroup(b *testing.B) {
 
 func BenchmarkG1JacEqual(b *testing.B) {
 	var scalar fp.Element
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a G1Jac
 	a.ScalarMultiplication(&g1Gen, big.NewInt(42))
@@ -839,10 +837,7 @@ const (
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.MustSetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -852,10 +847,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.MustSetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/secp256k1/marshal_test.go
+++ b/ecc/secp256k1/marshal_test.go
@@ -22,8 +22,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {

--- a/ecc/secp256k1/multiexp_test.go
+++ b/ecc/secp256k1/multiexp_test.go
@@ -437,6 +437,6 @@ func fillBenchBasesG1(samplePoints []G1Affine) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/stark-curve/fp/element_test.go
+++ b/ecc/stark-curve/fp/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/stark-curve/fp/element_test.go
+++ b/ecc/stark-curve/fp/element_test.go
@@ -2363,7 +2363,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2406,8 +2406,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2425,7 +2425,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2465,7 +2465,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2474,7 +2474,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/stark-curve/fp/element_test.go
+++ b/ecc/stark-curve/fp/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/stark-curve/fp/vector.go
+++ b/ecc/stark-curve/fp/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/stark-curve/fp/vector_test.go
+++ b/ecc/stark-curve/fp/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -346,8 +346,7 @@ func (z *Element) SetRandom() (*Element, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *Element) MustSetRandom() *Element {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -342,6 +342,17 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/ecc/stark-curve/fr/element_test.go
+++ b/ecc/stark-curve/fr/element_test.go
@@ -47,7 +47,7 @@ func BenchmarkElementSetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/ecc/stark-curve/fr/element_test.go
+++ b/ecc/stark-curve/fr/element_test.go
@@ -2315,7 +2315,7 @@ func bigIntMatchUint64Slice(aInt *big.Int, a []uint64) error {
 func TestElementInversionApproximation(t *testing.T) {
 	var x Element
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -2358,8 +2358,8 @@ func TestElementLinearComb(t *testing.T) {
 	var y Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -2377,7 +2377,7 @@ func TestElementInversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x Element
 		var xInv Element
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -2417,7 +2417,7 @@ func TestElementBigNumWMul(t *testing.T) {
 	var x Element
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -2426,7 +2426,7 @@ func TestElementBigNumWMul(t *testing.T) {
 func TestElementVeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/ecc/stark-curve/fr/element_test.go
+++ b/ecc/stark-curve/fr/element_test.go
@@ -32,8 +32,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,17 +43,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -65,21 +65,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -89,8 +89,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -101,8 +101,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -111,8 +111,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -130,8 +130,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -140,8 +140,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -149,7 +149,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -158,8 +158,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -167,7 +167,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -175,7 +175,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -254,8 +254,8 @@ func TestElementCmp(t *testing.T) {
 func TestElementIsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y Element
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -294,7 +294,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/ecc/stark-curve/fr/vector.go
+++ b/ecc/stark-curve/fr/vector.go
@@ -188,6 +188,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/ecc/stark-curve/fr/vector_test.go
+++ b/ecc/stark-curve/fr/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/ecc/stark-curve/g1_test.go
+++ b/ecc/stark-curve/g1_test.go
@@ -28,10 +28,7 @@ const (
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -41,10 +38,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/ecc/stark-curve/marshal_test.go
+++ b/ecc/stark-curve/marshal_test.go
@@ -1,8 +1,6 @@
 // Copyright 2020-2025 Consensys Software Inc.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file for details.
 
-// FOO
-
 package starkcurve
 
 import (
@@ -34,8 +32,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inG = make([]G1Affine, 2)
@@ -156,8 +154,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -174,8 +172,8 @@ func TestG1AffineSerialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 G1Affine
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {

--- a/ecc/stark-curve/pedersen-hash/pedersen_hash_test.go
+++ b/ecc/stark-curve/pedersen-hash/pedersen_hash_test.go
@@ -120,13 +120,9 @@ var feltBench fp.Element
 func BenchmarkPedersenArray(b *testing.B) {
 	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
 	createRandomFelts := func(n int) []*fp.Element {
-		var felts []*fp.Element
-		for i := 0; i < n; i++ {
-			f, err := new(fp.Element).SetRandom()
-			if err != nil {
-				b.Fatalf("error while generating random felt: %x", err)
-			}
-			felts = append(felts, f)
+		felts := make([]*fp.Element, n)
+		for i := range felts {
+			felts[i] = new(fp.Element).MustSetRandom()
 		}
 		return felts
 	}

--- a/field/babybear/element.go
+++ b/field/babybear/element.go
@@ -302,6 +302,16 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/field/babybear/element_test.go
+++ b/field/babybear/element_test.go
@@ -30,8 +30,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -41,17 +41,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -63,21 +63,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -87,8 +87,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -99,8 +99,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -109,8 +109,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -119,7 +119,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -128,8 +128,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -138,8 +138,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -147,7 +147,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -156,8 +156,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -165,7 +165,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -173,7 +173,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -248,7 +248,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/field/babybear/extensions/e2.go
+++ b/field/babybear/extensions/e2.go
@@ -88,6 +88,7 @@ func (z *E2) MustSetRandom() *E2 {
 	if _, err := z.A0.SetRandom(); err != nil {
 		panic(err)
 	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/field/babybear/extensions/e2.go
+++ b/field/babybear/extensions/e2.go
@@ -82,6 +82,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading from crypto/rand fails.
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.A0.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/field/babybear/extensions/e2_test.go
+++ b/field/babybear/extensions/e2_test.go
@@ -389,8 +389,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -399,8 +399,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -409,8 +409,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -420,8 +420,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fr.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -430,7 +430,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -439,7 +439,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -448,7 +448,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fr.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -458,7 +458,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -467,7 +467,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -476,7 +476,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -485,7 +485,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/babybear/extensions/e4.go
+++ b/field/babybear/extensions/e4.go
@@ -133,6 +133,15 @@ func (z *E4) SetRandom() (*E4, error) {
 	return z, nil
 }
 
+// MustSetRandom sets the element to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E4) MustSetRandom() *E4 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E4) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/field/babybear/extensions/e4_test.go
+++ b/field/babybear/extensions/e4_test.go
@@ -231,8 +231,8 @@ func TestE4Ops(t *testing.T) {
 
 func BenchmarkE4Add(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -241,8 +241,8 @@ func BenchmarkE4Add(b *testing.B) {
 
 func BenchmarkE4Sub(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -251,8 +251,8 @@ func BenchmarkE4Sub(b *testing.B) {
 
 func BenchmarkE4Mul(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -261,7 +261,7 @@ func BenchmarkE4Mul(b *testing.B) {
 
 func BenchmarkE4Square(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -270,7 +270,7 @@ func BenchmarkE4Square(b *testing.B) {
 
 func BenchmarkE4Sqrt(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -279,7 +279,7 @@ func BenchmarkE4Sqrt(b *testing.B) {
 
 func BenchmarkE4Inverse(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -288,7 +288,7 @@ func BenchmarkE4Inverse(b *testing.B) {
 
 func BenchmarkE4MulNonRes(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -297,7 +297,7 @@ func BenchmarkE4MulNonRes(b *testing.B) {
 
 func BenchmarkE4Conjugate(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/babybear/extensions/utils.go
+++ b/field/babybear/extensions/utils.go
@@ -23,10 +23,8 @@ var bigIntPool = sync.Pool{
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/field/babybear/fft/bitreverse_test.go
+++ b/field/babybear/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []babybear.Element array of size 2**20
 	pol := make([]babybear.Element, maxSizeBitReverse)
 	one := babybear.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []babybear.Element array of size 2**22
 	pol := make([]babybear.Element, maxSizeBitReverse)
 	one := babybear.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/field/babybear/fft/fft_test.go
+++ b/field/babybear/fft/fft_test.go
@@ -47,7 +47,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -74,7 +74,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -102,7 +102,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -128,7 +128,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -154,7 +154,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]babybear.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -185,7 +185,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -208,7 +208,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]babybear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -294,7 +294,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]babybear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -323,7 +323,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]babybear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -340,7 +340,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]babybear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -357,7 +357,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]babybear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -374,7 +374,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]babybear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/field/babybear/poseidon2/poseidon2_test.go
+++ b/field/babybear/poseidon2/poseidon2_test.go
@@ -14,7 +14,7 @@ import (
 func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 	var input, expected [16]fr.Element
 	for i := 0; i < 16; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -38,7 +38,7 @@ func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 func TestMulMulInternalInPlaceWidth24(t *testing.T) {
 	var input, expected [24]fr.Element
 	for i := 0; i < 24; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -173,7 +173,7 @@ func BenchmarkPoseidon2Width16(b *testing.B) {
 
 	var tmp [16]fr.Element
 	for i := 0; i < 16; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -185,7 +185,7 @@ func BenchmarkPoseidon2Width24(b *testing.B) {
 	h := NewPermutation(24, 6, 19)
 	var tmp [24]fr.Element
 	for i := 0; i < 24; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/field/babybear/sis/sis_test.go
+++ b/field/babybear/sis/sis_test.go
@@ -104,7 +104,7 @@ func TestLimbDecomposeBytes(t *testing.T) {
 	nbElmts := 10
 	a := make([]babybear.Element, nbElmts)
 	for i := 0; i < nbElmts; i++ {
-		a[i].SetRandom()
+		a[i].MustSetRandom()
 	}
 
 	logTwoBound := 8
@@ -187,7 +187,7 @@ func BenchmarkSIS(b *testing.B) {
 	// accounted for in the benchmark.
 	inputs := make(babybear.Vector, nbInputs)
 	for i := 0; i < len(inputs); i++ {
-		inputs[i].SetRandom()
+		inputs[i].MustSetRandom()
 	}
 
 	for _, param := range params128Bits {

--- a/field/babybear/vector.go
+++ b/field/babybear/vector.go
@@ -185,6 +185,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/field/babybear/vector_test.go
+++ b/field/babybear/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/field/generator/internal/templates/element/base.go
+++ b/field/generator/internal/templates/element/base.go
@@ -355,6 +355,17 @@ func (z *{{.ElementName}}) SetRandom() (*{{.ElementName}}, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *{{.ElementName}}) MustSetRandom() *{{.ElementName}} {
+	_, err := z.SetRandom()
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *{{.ElementName}}) smallerThanModulus() bool {

--- a/field/generator/internal/templates/element/base.go
+++ b/field/generator/internal/templates/element/base.go
@@ -359,8 +359,7 @@ func (z *{{.ElementName}}) SetRandom() (*{{.ElementName}}, error) {
 //
 // It panics if reading from crypto/rand.Reader errors.
 func (z *{{.ElementName}}) MustSetRandom() *{{.ElementName}} {
-	_, err := z.SetRandom()
-	if err != nil {
+	if _, err := z.SetRandom(); err != nil {
 		panic(err)
 	}
 	return z

--- a/field/generator/internal/templates/element/inverse_tests.go
+++ b/field/generator/internal/templates/element/inverse_tests.go
@@ -7,7 +7,7 @@ const InverseTests = `
 func Test{{toTitle .ElementName}}InversionApproximation(t *testing.T) {
 	var x {{.ElementName}}
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 
 		// Normally small elements are unlikely. Here we give them a higher chance
 		xZeros := mrand.Int() % Limbs //#nosec G404 weak rng is fine here
@@ -49,8 +49,8 @@ func Test{{toTitle .ElementName}}LinearComb(t *testing.T) {
 	var y {{.ElementName}}
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		testLinearComb(t, &x, mrand.Int63(), &y, mrand.Int63()) //#nosec G404 weak rng is fine here
 	}
 }
@@ -68,7 +68,7 @@ func Test{{toTitle .ElementName}}InversionCorrectionFactor(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		var x {{.ElementName}}
 		var xInv {{.ElementName}}
-		x.SetRandom()
+		x.MustSetRandom()
 		xInv.Inverse(&x)
 
 		x.Mul(&x, &xInv)
@@ -107,7 +107,7 @@ func Test{{toTitle .ElementName}}BigNumWMul(t *testing.T) {
 	var x {{.ElementName}}
 
 	for i := 0; i < 1000; i++ {
-		x.SetRandom()
+		x.MustSetRandom()
 		w := mrand.Int63() //#nosec G404 weak rng is fine here
 		testBigNumWMul(t, &x, w)
 	}
@@ -116,7 +116,7 @@ func Test{{toTitle .ElementName}}BigNumWMul(t *testing.T) {
 func Test{{toTitle .ElementName}}VeryBigIntConversion(t *testing.T) {
 	xHi := mrand.Uint64() //#nosec G404 weak rng is fine here
 	var x {{.ElementName}}
-	x.SetRandom()
+	x.MustSetRandom()
 	var xInt big.Int
 	x.toVeryBigIntSigned(&xInt, xHi)
 	x.assertMatchVeryBigInt(t, xHi, &xInt)

--- a/field/generator/internal/templates/element/tests.go
+++ b/field/generator/internal/templates/element/tests.go
@@ -31,8 +31,8 @@ var benchRes{{.ElementName}} {{.ElementName}}
 
 func Benchmark{{toTitle .ElementName}}Select(b *testing.B) {
 	var x, y {{.ElementName}}
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -42,17 +42,17 @@ func Benchmark{{toTitle .ElementName}}Select(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}SetRandom(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		_, _ = x.MustSetRandom()
 	}
 }
 
 func Benchmark{{toTitle .ElementName}}SetBytes(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -64,21 +64,21 @@ func Benchmark{{toTitle .ElementName}}SetBytes(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}MulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B){
-		benchRes{{.ElementName}}.SetRandom()
+		benchRes{{.ElementName}}.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchRes{{.ElementName}})
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B){
-		benchRes{{.ElementName}}.SetRandom()
+		benchRes{{.ElementName}}.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchRes{{.ElementName}})
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B){
-		benchRes{{.ElementName}}.SetRandom()
+		benchRes{{.ElementName}}.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchRes{{.ElementName}})
@@ -88,8 +88,8 @@ func Benchmark{{toTitle .ElementName}}MulByConstants(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Inverse(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -100,8 +100,8 @@ func Benchmark{{toTitle .ElementName}}Inverse(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Butterfly(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchRes{{.ElementName}})
@@ -111,8 +111,8 @@ func Benchmark{{toTitle .ElementName}}Butterfly(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Exp(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -122,7 +122,7 @@ func Benchmark{{toTitle .ElementName}}Exp(b *testing.B) {
 
 
 func Benchmark{{toTitle .ElementName}}Double(b *testing.B) {
-	benchRes{{.ElementName}}.SetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Double(&benchRes{{.ElementName}})
@@ -132,8 +132,8 @@ func Benchmark{{toTitle .ElementName}}Double(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Add(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Add(&x, &benchRes{{.ElementName}})
@@ -142,8 +142,8 @@ func Benchmark{{toTitle .ElementName}}Add(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Sub(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Sub(&x, &benchRes{{.ElementName}})
@@ -151,7 +151,7 @@ func Benchmark{{toTitle .ElementName}}Sub(b *testing.B) {
 }
 
 func Benchmark{{toTitle .ElementName}}Neg(b *testing.B) {
-	benchRes{{.ElementName}}.SetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Neg(&benchRes{{.ElementName}})
@@ -160,8 +160,8 @@ func Benchmark{{toTitle .ElementName}}Neg(b *testing.B) {
 
 func Benchmark{{toTitle .ElementName}}Div(b *testing.B) {
 	var x {{.ElementName}}
-	x.SetRandom()
-	benchRes{{.ElementName}}.SetRandom()
+	x.MustSetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Div(&x, &benchRes{{.ElementName}})
@@ -170,7 +170,7 @@ func Benchmark{{toTitle .ElementName}}Div(b *testing.B) {
 
 
 func Benchmark{{toTitle .ElementName}}FromMont(b *testing.B) {
-	benchRes{{.ElementName}}.SetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.fromMont()
@@ -178,7 +178,7 @@ func Benchmark{{toTitle .ElementName}}FromMont(b *testing.B) {
 }
 
 func Benchmark{{toTitle .ElementName}}Square(b *testing.B) {
-	benchRes{{.ElementName}}.SetRandom()
+	benchRes{{.ElementName}}.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchRes{{.ElementName}}.Square(&benchRes{{.ElementName}})
@@ -256,8 +256,8 @@ func Test{{toTitle .ElementName}}Cmp(t *testing.T) {
 func Test{{toTitle .ElementName}}IsRandom(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var x, y {{.ElementName}}
-		x.SetRandom()
-		y.SetRandom()
+		x.MustSetRandom()
+		y.MustSetRandom()
 		if x.Equal(&y) {
 			t.Fatal("2 random numbers are unlikely to be equal")
 		}
@@ -299,7 +299,7 @@ func Test{{toTitle .ElementName}}NegZero(t *testing.T) {
 	var a, b {{.ElementName}}
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/field/generator/internal/templates/element/tests.go
+++ b/field/generator/internal/templates/element/tests.go
@@ -46,7 +46,7 @@ func Benchmark{{toTitle .ElementName}}SetRandom(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.MustSetRandom()
+		x.MustSetRandom()
 	}
 }
 

--- a/field/generator/internal/templates/element/tests_vector.go
+++ b/field/generator/internal/templates/element/tests_vector.go
@@ -235,7 +235,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer {{.ElementName}}
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -190,6 +190,29 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
 
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {

--- a/field/generator/internal/templates/extensions/e2.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2.go.tmpl
@@ -75,6 +75,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading from crypto/rand fails.
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.A0.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/field/generator/internal/templates/extensions/e2.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2.go.tmpl
@@ -81,6 +81,7 @@ func (z *E2) MustSetRandom() *E2 {
 	if _, err := z.A0.SetRandom(); err != nil {
 		panic(err)
 	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/field/generator/internal/templates/extensions/e2_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2_test.go.tmpl
@@ -388,8 +388,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -398,8 +398,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -408,8 +408,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -419,8 +419,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fr.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -429,7 +429,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -438,7 +438,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -447,7 +447,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fr.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -457,7 +457,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -466,7 +466,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -475,7 +475,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -484,7 +484,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/generator/internal/templates/extensions/e4.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4.go.tmpl
@@ -126,6 +126,15 @@ func (z *E4) SetRandom() (*E4, error) {
 	return z, nil
 }
 
+// MustSetRandom sets the element to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E4) MustSetRandom() *E4 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E4) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/field/generator/internal/templates/extensions/e4_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4_test.go.tmpl
@@ -224,8 +224,8 @@ func TestE4Ops(t *testing.T) {
 
 func BenchmarkE4Add(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -234,8 +234,8 @@ func BenchmarkE4Add(b *testing.B) {
 
 func BenchmarkE4Sub(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -244,8 +244,8 @@ func BenchmarkE4Sub(b *testing.B) {
 
 func BenchmarkE4Mul(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -254,7 +254,7 @@ func BenchmarkE4Mul(b *testing.B) {
 
 func BenchmarkE4Square(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -263,7 +263,7 @@ func BenchmarkE4Square(b *testing.B) {
 
 func BenchmarkE4Sqrt(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -272,7 +272,7 @@ func BenchmarkE4Sqrt(b *testing.B) {
 
 func BenchmarkE4Inverse(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -281,7 +281,7 @@ func BenchmarkE4Inverse(b *testing.B) {
 
 func BenchmarkE4MulNonRes(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -290,7 +290,7 @@ func BenchmarkE4MulNonRes(b *testing.B) {
 
 func BenchmarkE4Conjugate(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/generator/internal/templates/extensions/utils.go.tmpl
+++ b/field/generator/internal/templates/extensions/utils.go.tmpl
@@ -16,10 +16,8 @@ var bigIntPool = sync.Pool{
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/field/generator/internal/templates/fft/tests/bitreverse.go.tmpl
+++ b/field/generator/internal/templates/fft/tests/bitreverse.go.tmpl
@@ -27,7 +27,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []{{ .FF }}.Element array of size 2**20
 	pol := make([]{{ .FF }}.Element, maxSizeBitReverse)
 	one := {{ .FF }}.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -74,7 +74,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []{{ .FF }}.Element array of size 2**22
 	pol := make([]{{ .FF }}.Element, maxSizeBitReverse)
 	one := {{ .FF }}.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/field/generator/internal/templates/fft/tests/fft.go.tmpl
+++ b/field/generator/internal/templates/fft/tests/fft.go.tmpl
@@ -43,7 +43,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]{{ .FF }}.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -207,7 +207,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]{{ .FF }}.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -296,7 +296,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]{{ .FF }}.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -325,7 +325,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]{{ .FF }}.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -342,7 +342,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]{{ .FF }}.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -359,7 +359,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]{{ .FF }}.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -376,7 +376,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]{{ .FF }}.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/field/generator/internal/templates/poseidon2/poseidon2_test.go.tmpl
+++ b/field/generator/internal/templates/poseidon2/poseidon2_test.go.tmpl
@@ -8,7 +8,7 @@ import (
 func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 	var input, expected [16]fr.Element
 	for i := 0; i < 16; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -37,7 +37,7 @@ func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 func TestMulMulInternalInPlaceWidth24(t *testing.T) {
 	var input, expected [24]fr.Element
 	for i := 0; i < 24; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -274,7 +274,7 @@ func BenchmarkPoseidon2Width16(b *testing.B) {
 
 	var tmp [16]fr.Element
 	for i := 0; i < 16; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -290,7 +290,7 @@ func BenchmarkPoseidon2Width24(b *testing.B) {
 	{{- end}}
 	var tmp [24]fr.Element
 	for i := 0; i < 24; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -371,7 +371,7 @@ func BenchmarkPoseidon2Width8(b *testing.B) {
 	h := NewPermutation(8, 6, 17)
 	var tmp [8]fr.Element
 	for i := 0; i < 8; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -383,7 +383,7 @@ func BenchmarkPoseidon2Width12(b *testing.B) {
 	h := NewPermutation(12, 6, 17)
 	var tmp [12]fr.Element
 	for i := 0; i < 12; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/field/generator/internal/templates/sis/sis.test.go.tmpl
+++ b/field/generator/internal/templates/sis/sis.test.go.tmpl
@@ -101,7 +101,7 @@ func TestLimbDecomposeBytes(t *testing.T) {
 	nbElmts := 10
 	a := make([]{{ .FF }}.Element, nbElmts)
 	for i := 0; i < nbElmts; i++ {
-		a[i].SetRandom()
+		a[i].MustSetRandom()
 	}
 
 	{{- $f31 := or (eq .FF "babybear") (eq .FF "koalabear")}}
@@ -189,7 +189,7 @@ func BenchmarkSIS(b *testing.B) {
 	// accounted for in the benchmark.
 	inputs := make({{ .FF }}.Vector, nbInputs)
 	for i := 0; i < len(inputs); i++ {
-		inputs[i].SetRandom()
+		inputs[i].MustSetRandom()
 	}
 
 	for _, param := range params128Bits {

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -302,6 +302,16 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/field/goldilocks/element_test.go
+++ b/field/goldilocks/element_test.go
@@ -30,8 +30,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -41,17 +41,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -63,21 +63,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -87,8 +87,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -99,8 +99,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -109,8 +109,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -119,7 +119,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -128,8 +128,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -138,8 +138,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -147,7 +147,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -156,8 +156,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -165,7 +165,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -173,7 +173,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -248,7 +248,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/field/goldilocks/extensions/e2.go
+++ b/field/goldilocks/extensions/e2.go
@@ -88,6 +88,7 @@ func (z *E2) MustSetRandom() *E2 {
 	if _, err := z.A0.SetRandom(); err != nil {
 		panic(err)
 	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/field/goldilocks/extensions/e2.go
+++ b/field/goldilocks/extensions/e2.go
@@ -82,6 +82,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading from crypto/rand fails.
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.A0.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/field/goldilocks/extensions/e2_test.go
+++ b/field/goldilocks/extensions/e2_test.go
@@ -389,8 +389,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -399,8 +399,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -409,8 +409,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -420,8 +420,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fr.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -430,7 +430,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -439,7 +439,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -448,7 +448,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fr.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -458,7 +458,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -467,7 +467,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -476,7 +476,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -485,7 +485,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/goldilocks/extensions/utils.go
+++ b/field/goldilocks/extensions/utils.go
@@ -23,10 +23,8 @@ var bigIntPool = sync.Pool{
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/field/goldilocks/fft/bitreverse_test.go
+++ b/field/goldilocks/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []goldilocks.Element array of size 2**20
 	pol := make([]goldilocks.Element, maxSizeBitReverse)
 	one := goldilocks.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []goldilocks.Element array of size 2**22
 	pol := make([]goldilocks.Element, maxSizeBitReverse)
 	one := goldilocks.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/field/goldilocks/fft/fft_test.go
+++ b/field/goldilocks/fft/fft_test.go
@@ -45,7 +45,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -72,7 +72,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -100,7 +100,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -126,7 +126,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -152,7 +152,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]goldilocks.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -183,7 +183,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -206,7 +206,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]goldilocks.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -246,7 +246,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]goldilocks.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -275,7 +275,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]goldilocks.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -292,7 +292,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]goldilocks.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -309,7 +309,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]goldilocks.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -326,7 +326,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]goldilocks.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/field/goldilocks/poseidon2/poseidon2_test.go
+++ b/field/goldilocks/poseidon2/poseidon2_test.go
@@ -84,7 +84,7 @@ func BenchmarkPoseidon2Width8(b *testing.B) {
 	h := NewPermutation(8, 6, 17)
 	var tmp [8]fr.Element
 	for i := 0; i < 8; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -96,7 +96,7 @@ func BenchmarkPoseidon2Width12(b *testing.B) {
 	h := NewPermutation(12, 6, 17)
 	var tmp [12]fr.Element
 	for i := 0; i < 12; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/field/goldilocks/sis/sis_test.go
+++ b/field/goldilocks/sis/sis_test.go
@@ -102,7 +102,7 @@ func TestLimbDecomposeBytes(t *testing.T) {
 	nbElmts := 10
 	a := make([]goldilocks.Element, nbElmts)
 	for i := 0; i < nbElmts; i++ {
-		a[i].SetRandom()
+		a[i].MustSetRandom()
 	}
 
 	logTwoBound := 8
@@ -177,7 +177,7 @@ func BenchmarkSIS(b *testing.B) {
 	// accounted for in the benchmark.
 	inputs := make(goldilocks.Vector, nbInputs)
 	for i := 0; i < len(inputs); i++ {
-		inputs[i].SetRandom()
+		inputs[i].MustSetRandom()
 	}
 
 	for _, param := range params128Bits {

--- a/field/goldilocks/vector.go
+++ b/field/goldilocks/vector.go
@@ -185,6 +185,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/field/goldilocks/vector_test.go
+++ b/field/goldilocks/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/field/koalabear/element.go
+++ b/field/koalabear/element.go
@@ -302,6 +302,16 @@ func (z *Element) SetRandom() (*Element, error) {
 	}
 }
 
+// MustSetRandom sets z to a uniform random value in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (z *Element) MustSetRandom() *Element {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // smallerThanModulus returns true if z < q
 // This is not constant time
 func (z *Element) smallerThanModulus() bool {

--- a/field/koalabear/element_test.go
+++ b/field/koalabear/element_test.go
@@ -30,8 +30,8 @@ var benchResElement Element
 
 func BenchmarkElementSelect(b *testing.B) {
 	var x, y Element
-	x.SetRandom()
-	y.SetRandom()
+	x.MustSetRandom()
+	y.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -41,17 +41,17 @@ func BenchmarkElementSelect(b *testing.B) {
 
 func BenchmarkElementSetRandom(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = x.SetRandom()
+		x.MustSetRandom()
 	}
 }
 
 func BenchmarkElementSetBytes(b *testing.B) {
 	var x Element
-	x.SetRandom()
+	x.MustSetRandom()
 	bb := x.Bytes()
 	b.ResetTimer()
 
@@ -63,21 +63,21 @@ func BenchmarkElementSetBytes(b *testing.B) {
 
 func BenchmarkElementMulByConstants(b *testing.B) {
 	b.Run("mulBy3", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy3(&benchResElement)
 		}
 	})
 	b.Run("mulBy5", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy5(&benchResElement)
 		}
 	})
 	b.Run("mulBy13", func(b *testing.B) {
-		benchResElement.SetRandom()
+		benchResElement.MustSetRandom()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			MulBy13(&benchResElement)
@@ -87,8 +87,8 @@ func BenchmarkElementMulByConstants(b *testing.B) {
 
 func BenchmarkElementInverse(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -99,8 +99,8 @@ func BenchmarkElementInverse(b *testing.B) {
 
 func BenchmarkElementButterfly(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Butterfly(&x, &benchResElement)
@@ -109,8 +109,8 @@ func BenchmarkElementButterfly(b *testing.B) {
 
 func BenchmarkElementExp(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -119,7 +119,7 @@ func BenchmarkElementExp(b *testing.B) {
 }
 
 func BenchmarkElementDouble(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Double(&benchResElement)
@@ -128,8 +128,8 @@ func BenchmarkElementDouble(b *testing.B) {
 
 func BenchmarkElementAdd(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Add(&x, &benchResElement)
@@ -138,8 +138,8 @@ func BenchmarkElementAdd(b *testing.B) {
 
 func BenchmarkElementSub(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Sub(&x, &benchResElement)
@@ -147,7 +147,7 @@ func BenchmarkElementSub(b *testing.B) {
 }
 
 func BenchmarkElementNeg(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Neg(&benchResElement)
@@ -156,8 +156,8 @@ func BenchmarkElementNeg(b *testing.B) {
 
 func BenchmarkElementDiv(b *testing.B) {
 	var x Element
-	x.SetRandom()
-	benchResElement.SetRandom()
+	x.MustSetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Div(&x, &benchResElement)
@@ -165,7 +165,7 @@ func BenchmarkElementDiv(b *testing.B) {
 }
 
 func BenchmarkElementFromMont(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.fromMont()
@@ -173,7 +173,7 @@ func BenchmarkElementFromMont(b *testing.B) {
 }
 
 func BenchmarkElementSquare(b *testing.B) {
-	benchResElement.SetRandom()
+	benchResElement.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		benchResElement.Square(&benchResElement)
@@ -248,7 +248,7 @@ func TestElementNegZero(t *testing.T) {
 	var a, b Element
 	b.SetZero()
 	for a.IsZero() {
-		a.SetRandom()
+		a.MustSetRandom()
 	}
 	a.Neg(&b)
 	if !a.IsZero() {

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -88,6 +88,7 @@ func (z *E2) MustSetRandom() *E2 {
 	if _, err := z.A0.SetRandom(); err != nil {
 		panic(err)
 	}
+	return z
 }
 
 // IsZero returns true if z is zero, false otherwise

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -82,6 +82,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading from crypto/rand fails.
+func (z *E2) MustSetRandom() *E2 {
+	if _, err := z.A0.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/field/koalabear/extensions/e2_test.go
+++ b/field/koalabear/extensions/e2_test.go
@@ -389,8 +389,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -399,8 +399,8 @@ func BenchmarkE2Add(b *testing.B) {
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -409,8 +409,8 @@ func BenchmarkE2Sub(b *testing.B) {
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -420,8 +420,8 @@ func BenchmarkE2Mul(b *testing.B) {
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fr.Element
-	_, _ = c.SetRandom()
-	_, _ = a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -430,7 +430,7 @@ func BenchmarkE2MulByElement(b *testing.B) {
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -439,7 +439,7 @@ func BenchmarkE2Square(b *testing.B) {
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -448,7 +448,7 @@ func BenchmarkE2Sqrt(b *testing.B) {
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-	_, _ = x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fr.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -458,7 +458,7 @@ func BenchmarkE2Exp(b *testing.B) {
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -467,7 +467,7 @@ func BenchmarkE2Inverse(b *testing.B) {
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -476,7 +476,7 @@ func BenchmarkE2MulNonRes(b *testing.B) {
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -485,7 +485,7 @@ func BenchmarkE2MulNonResInv(b *testing.B) {
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/koalabear/extensions/e4.go
+++ b/field/koalabear/extensions/e4.go
@@ -133,6 +133,15 @@ func (z *E4) SetRandom() (*E4, error) {
 	return z, nil
 }
 
+// MustSetRandom sets the element to a random value.
+// It panics if reading from crypto/rand fails.
+func (z *E4) MustSetRandom() *E4 {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+	return z
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E4) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero()

--- a/field/koalabear/extensions/e4_test.go
+++ b/field/koalabear/extensions/e4_test.go
@@ -231,8 +231,8 @@ func TestE4Ops(t *testing.T) {
 
 func BenchmarkE4Add(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -241,8 +241,8 @@ func BenchmarkE4Add(b *testing.B) {
 
 func BenchmarkE4Sub(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -251,8 +251,8 @@ func BenchmarkE4Sub(b *testing.B) {
 
 func BenchmarkE4Mul(b *testing.B) {
 	var a, c E4
-	_, _ = a.SetRandom()
-	_, _ = c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -261,7 +261,7 @@ func BenchmarkE4Mul(b *testing.B) {
 
 func BenchmarkE4Square(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -270,7 +270,7 @@ func BenchmarkE4Square(b *testing.B) {
 
 func BenchmarkE4Sqrt(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -279,7 +279,7 @@ func BenchmarkE4Sqrt(b *testing.B) {
 
 func BenchmarkE4Inverse(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -288,7 +288,7 @@ func BenchmarkE4Inverse(b *testing.B) {
 
 func BenchmarkE4MulNonRes(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -297,7 +297,7 @@ func BenchmarkE4MulNonRes(b *testing.B) {
 
 func BenchmarkE4Conjugate(b *testing.B) {
 	var a E4
-	_, _ = a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/field/koalabear/extensions/utils.go
+++ b/field/koalabear/extensions/utils.go
@@ -23,10 +23,8 @@ var bigIntPool = sync.Pool{
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
+		elmt.MustSetRandom()
 
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
 		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
 		return genResult
 	}

--- a/field/koalabear/fft/bitreverse_test.go
+++ b/field/koalabear/fft/bitreverse_test.go
@@ -31,7 +31,7 @@ func TestBitReverse(t *testing.T) {
 	// generate a random []koalabear.Element array of size 2**20
 	pol := make([]koalabear.Element, maxSizeBitReverse)
 	one := koalabear.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}
@@ -78,7 +78,7 @@ func BenchmarkBitReverse(b *testing.B) {
 	// generate a random []koalabear.Element array of size 2**22
 	pol := make([]koalabear.Element, maxSizeBitReverse)
 	one := koalabear.One()
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSizeBitReverse; i++ {
 		pol[i].Add(&pol[i-1], &one)
 	}

--- a/field/koalabear/fft/fft_test.go
+++ b/field/koalabear/fft/fft_test.go
@@ -47,7 +47,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -74,7 +74,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -102,7 +102,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -128,7 +128,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -154,7 +154,7 @@ func TestFFT(t *testing.T) {
 						backupPol := make([]koalabear.Element, maxSize)
 
 						for i := 0; i < maxSize; i++ {
-							pol[i].SetRandom()
+							pol[i].MustSetRandom()
 						}
 						copy(backupPol, pol)
 
@@ -185,7 +185,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -208,7 +208,7 @@ func TestFFT(t *testing.T) {
 					backupPol := make([]koalabear.Element, maxSize)
 
 					for i := 0; i < maxSize; i++ {
-						pol[i].SetRandom()
+						pol[i].MustSetRandom()
 					}
 					copy(backupPol, pol)
 
@@ -294,7 +294,7 @@ func BenchmarkFFT(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]koalabear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -323,7 +323,7 @@ func BenchmarkFFTDITCosetReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]koalabear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -340,7 +340,7 @@ func BenchmarkFFTDITReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]koalabear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -357,7 +357,7 @@ func BenchmarkFFTDIFReference(b *testing.B) {
 	const maxSize = 1 << 20
 
 	pol := make([]koalabear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}
@@ -374,7 +374,7 @@ func BenchmarkFFTDIFReferenceSmall(b *testing.B) {
 	const maxSize = 1 << 9
 
 	pol := make([]koalabear.Element, maxSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < maxSize; i++ {
 		pol[i] = pol[i-1]
 	}

--- a/field/koalabear/poseidon2/poseidon2_test.go
+++ b/field/koalabear/poseidon2/poseidon2_test.go
@@ -14,7 +14,7 @@ import (
 func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 	var input, expected [16]fr.Element
 	for i := 0; i < 16; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -38,7 +38,7 @@ func TestMulMulInternalInPlaceWidth16(t *testing.T) {
 func TestMulMulInternalInPlaceWidth24(t *testing.T) {
 	var input, expected [24]fr.Element
 	for i := 0; i < 24; i++ {
-		input[i].SetRandom()
+		input[i].MustSetRandom()
 	}
 
 	expected = input
@@ -173,7 +173,7 @@ func BenchmarkPoseidon2Width16(b *testing.B) {
 
 	var tmp [16]fr.Element
 	for i := 0; i < 16; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -185,7 +185,7 @@ func BenchmarkPoseidon2Width24(b *testing.B) {
 	h := NewPermutation(24, 6, 21)
 	var tmp [24]fr.Element
 	for i := 0; i < 24; i++ {
-		tmp[i].SetRandom()
+		tmp[i].MustSetRandom()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/field/koalabear/sis/sis_test.go
+++ b/field/koalabear/sis/sis_test.go
@@ -104,7 +104,7 @@ func TestLimbDecomposeBytes(t *testing.T) {
 	nbElmts := 10
 	a := make([]koalabear.Element, nbElmts)
 	for i := 0; i < nbElmts; i++ {
-		a[i].SetRandom()
+		a[i].MustSetRandom()
 	}
 
 	logTwoBound := 8
@@ -187,7 +187,7 @@ func BenchmarkSIS(b *testing.B) {
 	// accounted for in the benchmark.
 	inputs := make(koalabear.Vector, nbInputs)
 	for i := 0; i < len(inputs); i++ {
-		inputs[i].SetRandom()
+		inputs[i].MustSetRandom()
 	}
 
 	for _, param := range params128Bits {

--- a/field/koalabear/vector.go
+++ b/field/koalabear/vector.go
@@ -185,6 +185,30 @@ func (vector Vector) Swap(i, j int) {
 	vector[i], vector[j] = vector[j], vector[i]
 }
 
+// SetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// This might error only if reading from crypto/rand.Reader errors,
+// in which case the values in vector are undefined.
+func (vector Vector) SetRandom() error {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustSetRandom sets the elements in vector to independent uniform random values in [0, q).
+//
+// It panics if reading from crypto/rand.Reader errors.
+func (vector Vector) MustSetRandom() {
+	for i := range vector {
+		if _, err := vector[i].SetRandom(); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func addVecGeneric(res, a, b Vector) {
 	if len(a) != len(b) || len(a) != len(res) {
 		panic("vector.Add: vectors don't have the same length")

--- a/field/koalabear/vector_test.go
+++ b/field/koalabear/vector_test.go
@@ -234,7 +234,7 @@ func BenchmarkVectorOps(b *testing.B) {
 	b1 := make(Vector, N)
 	c1 := make(Vector, N)
 	var mixer Element
-	mixer.SetRandom()
+	mixer.MustSetRandom()
 	for i := 1; i < N; i++ {
 		a1[i-1].SetUint64(uint64(i)).
 			Mul(&a1[i-1], &mixer)

--- a/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
@@ -79,10 +79,8 @@ func TestSetState(t *testing.T) {
 	// we use for restoring from state
 	h3 := mimc.NewMiMC()
 
-	randInputs := make([]fr.Element, 10)
-	for i := range randInputs {
-		randInputs[i].SetRandom()
-	}
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
 
 	storedStates := make([][]byte, len(randInputs))
 

--- a/internal/generator/crypto/hash/poseidon2/template/poseidon2.test.go.tmpl
+++ b/internal/generator/crypto/hash/poseidon2/template/poseidon2.test.go.tmpl
@@ -52,9 +52,7 @@ func TestExternalMatrix(t *testing.T) {
 func BenchmarkPoseidon2(b *testing.B) {
 	h := NewPermutation(3, 8, 56)
 	var tmp [3]fr.Element
-	tmp[0].SetRandom()
-	tmp[1].SetRandom()
-	tmp[2].SetRandom()
+	fr.Vector(tmp[:]).MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i<b.N; i++ {
 		h.Permutation(tmp[:])

--- a/internal/generator/ecc/template/tests/marshal.go.tmpl
+++ b/internal/generator/ecc/template/tests/marshal.go.tmpl
@@ -49,8 +49,8 @@ func TestEncoder(t *testing.T) {
 
 	// set values of inputs
 	inA = rand.Uint64() //#nosec G404 weak rng is fine here
-	inB.SetRandom()
-	inC.SetRandom()
+	inB.MustSetRandom()
+	inC.MustSetRandom()
 	inD.ScalarMultiplication(&g1GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
 	// inE --> infinity
 	inF.ScalarMultiplication(&g2GenAff, new(big.Int).SetUint64(rand.Uint64())) //#nosec G404 weak rng is fine here
@@ -68,10 +68,9 @@ func TestEncoder(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		inN[i] = make([][]fr.Element, i+2)
 		for j := 0; j < i+2; j++ {
-			inN[i][j] = make([]fr.Element, j+3)
-			for k := 0; k < j+3; k++ {
-				inN[i][j][k].SetRandom()
-			}
+			inNIJ := make(fr.Vector, j+3)
+			inNIJ.MustSetRandom()
+			inN[i][j] = inNIJ
 		}
 	}
 
@@ -281,8 +280,8 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 		// compressed
 		{
 			var p1, p2 {{ $.TAffine }}
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.Bytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -299,8 +298,8 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 		// uncompressed
 		{
 			var p1, p2 {{ $.TAffine }}
-			p2.X.SetRandom()
-			p2.Y.SetRandom()
+			p2.X.MustSetRandom()
+			p2.Y.MustSetRandom()
 			buf := p1.RawBytes()
 			n, err := p2.SetBytes(buf[:])
 			if err != nil {
@@ -379,10 +378,7 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -392,10 +388,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.SetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/internal/generator/ecc/template/tests/multiexp.go.tmpl
+++ b/internal/generator/ecc/template/tests/multiexp.go.tmpl
@@ -484,6 +484,6 @@ func fillBenchBases{{ $.UPointName }}(samplePoints []{{ $.TAffine }}) {
 func fillBenchScalars(sampleScalars []fr.Element) {
 	// ensure every words of the scalars are filled
 	for i := 0; i < len(sampleScalars); i++ {
-		sampleScalars[i].SetRandom()
+		sampleScalars[i].MustSetRandom()
 	}
 }

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -593,7 +593,7 @@ func Test{{ toUpper .PointName }}CofactorClearing(t *testing.T) {
 	properties.Property("[{{ toUpper .Name }}] Clearing the cofactor of a random point should set it in the r-torsion", prop.ForAll(
 		func() bool {
 			var a, x, b {{ .CoordType }}
-			a.SetRandom()
+			a.MustSetRandom()
 			{{if eq .CoordType "fp.Element" }}
 				{{if eq .PointName "g2" }}
 					x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
@@ -601,7 +601,7 @@ func Test{{ toUpper .PointName }}CofactorClearing(t *testing.T) {
 					x.Square(&a).Mul(&x, &a).Add(&x, &bCurveCoeff)
 				{{end}}
 				for x.Legendre() != 1 {
-					a.SetRandom()
+					a.MustSetRandom()
 					{{if eq .PointName "g2" }}
 						x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 					{{else}}
@@ -612,7 +612,7 @@ func Test{{ toUpper .PointName }}CofactorClearing(t *testing.T) {
 			{{/* eq .CoordType "fptower.E2" */}}
 				x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 				for x.Legendre() != 1 {
-					a.SetRandom()
+					a.MustSetRandom()
 					x.Square(&a).Mul(&x, &a).Add(&x, &bTwistCurveCoeff)
 				}
 			{{end}}
@@ -696,7 +696,7 @@ func Benchmark{{ $TJacobian }}IsInSubGroup(b *testing.B) {
 
 func Benchmark{{ $TJacobian }}Equal(b *testing.B) {
 	var scalar {{ .CoordType}}
-	if _, err := scalar.SetRandom(); err != nil {
+	if _, err := scalar.MustSetRandom(); err != nil {
 		b.Fatalf("failed to set scalar: %s", err)
 	}
 
@@ -1029,7 +1029,7 @@ func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
 
-		if _, err := elmt.SetRandom(); err != nil {
+		if _, err := elmt.MustSetRandom(); err != nil {
 			panic(err)
 		}
 
@@ -1042,7 +1042,7 @@ func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
 
-		if _, err := elmt.SetRandom(); err != nil {
+		if _, err := elmt.MustSetRandom(); err != nil {
 			panic(err)
 		}
 

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -696,9 +696,7 @@ func Benchmark{{ $TJacobian }}IsInSubGroup(b *testing.B) {
 
 func Benchmark{{ $TJacobian }}Equal(b *testing.B) {
 	var scalar {{ .CoordType}}
-	if _, err := scalar.MustSetRandom(); err != nil {
-		b.Fatalf("failed to set scalar: %s", err)
-	}
+	scalar.MustSetRandom()
 
 	var a {{ $TJacobian }}
 	a.ScalarMultiplication(&{{.PointName}}Gen, big.NewInt(42))
@@ -1028,10 +1026,7 @@ const (
 func GenFr() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fr.Element
-
-		if _, err := elmt.MustSetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}
@@ -1041,10 +1036,7 @@ func GenFr() gopter.Gen {
 func GenFp() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var elmt fp.Element
-
-		if _, err := elmt.MustSetRandom(); err != nil {
-			panic(err)
-		}
+		elmt.MustSetRandom()
 
 		return gopter.NewGenResult(elmt, gopter.NoShrinker)
 	}

--- a/internal/generator/edwards/eddsa/template/eddsa.test.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/eddsa.test.go.tmpl
@@ -25,7 +25,7 @@ func Example() {
 
 	// generate a message (the size must be a multiple of the size of Fr)
 	var _msg fr.Element
-	_msg.SetRandom()
+	_msg.MustSetRandom()
 	msg := _msg.Marshal()
 
 	// sign the message

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -776,9 +776,7 @@ func BenchmarkProjEqual(b *testing.B) {
 	params := GetEdwardsCurve()
 
 	var scalar fr.Element
-	if _, err := scalar.SetRandom(); err != nil {
-		b.Fatalf("error generating random scalar: %v", err)
-	}
+	scalar.MustSetRandom()
 
 	var baseProj PointProj
 	baseProj.FromAffine(&params.Base)

--- a/internal/generator/fflonk/template/fflonk.test.go.tmpl
+++ b/internal/generator/fflonk/template/fflonk.test.go.tmpl
@@ -33,7 +33,7 @@ func TestFflonk(t *testing.T) {
 			curSizePoly := j + 10
 			p[i][j] = make([]fr.Element, curSizePoly)
 			for k := 0; k < curSizePoly; k++ {
-				p[i][j][k].SetRandom()
+				p[i][j][k].MustSetRandom()
 			}
 		}
 	}
@@ -44,7 +44,7 @@ func TestFflonk(t *testing.T) {
 		curSetSize := i + 4
 		x[i] = make([]fr.Element, curSetSize)
 		for j := 0; j < curSetSize; j++ {
-			x[i][j].SetRandom()
+			x[i][j].MustSetRandom()
 		}
 	}
 
@@ -66,7 +66,7 @@ func TestFflonk(t *testing.T) {
 	assert.NoError(err)
 
 	// tamper the proof
-	proof.ClaimedValues[0][0][0].SetRandom()
+	proof.ClaimedValues[0][0][0].MustSetRandom()
 	err = BatchVerify(proof, digests, x, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -82,13 +82,13 @@ func TestCommit(t *testing.T) {
 	for i := 0; i < nbPolys; i++ {
 		p[i] = make([]fr.Element, i+10)
 		for j := 0; j < i+10; j++ {
-			p[i][j].SetRandom()
+			p[i][j].MustSetRandom()
 		}
 	}
 
 	// fflonk commit to them
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	proof, err := kzg.Open(Fold(p), x, testSrs.Pk)
 	assert.NoError(err)
 

--- a/internal/generator/fri/template/fri.test.go.tmpl
+++ b/internal/generator/fri/template/fri.test.go.tmpl
@@ -203,10 +203,8 @@ func BenchmarkProximityVerification(b *testing.B) {
 	for i := 0; i < 10; i++ {
 
 		size := baseSize << i
-		p := make([]fr.Element, size)
-		for k := 0; k < size; k++ {
-			p[k].SetRandom()
-		}
+		p := make(fr.Vector, size)
+		p.MustSetRandom()
 
 		iop := RADIX_2_FRI.New(uint64(size), sha256.New())
 		proof, _ := iop.BuildProofOfProximity(p)

--- a/internal/generator/gkr/template/gkr.test.go.tmpl
+++ b/internal/generator/gkr/template/gkr.test.go.tmpl
@@ -373,7 +373,7 @@ func testATimesBSquared(t *testing.T, numRounds int, inputAssignments ...[]{{.El
 
 func setRandom(slice []{{.ElementType}}) {
 	for i := range slice {
-		slice[i].SetRandom()
+		slice[i].MustSetRandom()
 	}
 }
 

--- a/internal/generator/iop/template/polynomial.test.go.tmpl
+++ b/internal/generator/iop/template/polynomial.test.go.tmpl
@@ -45,7 +45,7 @@ func TestEvaluation(t *testing.T) {
 
 	// get reference values
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	expectedEval := p.ToRegular().Evaluate(x)
 	expectedEvalShifted := ps.ToRegular().Evaluate(x)
 
@@ -100,11 +100,8 @@ func TestEvaluation(t *testing.T) {
 }
 
 func randomVector(size int) *[]fr.Element {
-
 	r := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		r[i].SetRandom()
-	}
+	fr.Vector(r).MustSetRandom()
 	return &r
 }
 

--- a/internal/generator/iop/template/quotient.test.go.tmpl
+++ b/internal/generator/iop/template/quotient.test.go.tmpl
@@ -49,8 +49,8 @@ func TestDivideByXMinusOne(t *testing.T) {
 
 	for i := 0; i < sizeSystem; i++ {
 
-		entries[0].Coefficients()[i].SetRandom()
-		entries[1].Coefficients()[i].SetRandom()
+		entries[0].Coefficients()[i].MustSetRandom()
+		entries[1].Coefficients()[i].MustSetRandom()
 		tmp := computex3(
 			[]fr.Element{entries[0].Coefficients()[i],
 				entries[1].Coefficients()[i]})
@@ -101,7 +101,7 @@ func TestDivideByXMinusOne(t *testing.T) {
 	// evaluate the quotient at a random point and check that
 	// the relation holds.
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 	qx := q.Evaluate(x)
 	entries[0].ToCanonical(domains[1])
 	entries[1].ToCanonical(domains[1])

--- a/internal/generator/iop/template/ratios.test.go.tmpl
+++ b/internal/generator/iop/template/ratios.test.go.tmpl
@@ -71,7 +71,7 @@ func TestBuildRatioShuffledVectors(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta fr.Element
-	beta.SetRandom()
+	beta.MustSetRandom()
 	ratio, err := BuildRatioShuffledVectors(numerator, denominator, beta, expectedForm, domain)
 	if err != nil {
 		t.Fatal()
@@ -183,7 +183,7 @@ func getInvariantEntriesUnderPermutation(sizePolynomials, nbPolynomials int) ([]
 		v := make([]fr.Element, sizePolynomials)
 		res[i] = NewPolynomial(&v, form)
 		for j := 0; j < sizePolynomials/2; j++ {
-			res[i].Coefficients()[2*j].SetRandom()
+			res[i].Coefficients()[2*j].MustSetRandom()
 			res[i].Coefficients()[2*j+1].Set(&res[i].Coefficients()[2*j])
 		}
 	}
@@ -214,8 +214,8 @@ func TestBuildRatioCopyConstraint(t *testing.T) {
 	expectedForm := Form{Basis: Lagrange, Layout: Regular}
 	domain := fft.NewDomain(uint64(sizePolynomials))
 	var beta, gamma fr.Element
-	beta.SetRandom()
-	gamma.SetRandom()
+	beta.MustSetRandom()
+	gamma.MustSetRandom()
 	ratio, err := BuildRatioCopyConstraint(entries, sigma, beta, gamma, expectedForm, domain)
 	if err != nil {
 		t.Fatal()

--- a/internal/generator/kzg/template/kzg.go.tmpl
+++ b/internal/generator/kzg/template/kzg.go.tmpl
@@ -421,8 +421,7 @@ func BatchVerifyMultiPoints(digests []Digest, proofs []OpeningProof, points []fr
 	randomNumbers := make([]fr.Element, len(digests))
 	randomNumbers[0].SetOne()
 	for i := 1; i < len(randomNumbers); i++ {
-		_, err := randomNumbers[i].SetRandom()
-		if err != nil {
+		if _, err := randomNumbers[i].SetRandom(); err != nil {
 			return err
 		}
 	}

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -114,9 +114,9 @@ func TestCommitLagrange(t *testing.T) {
 	// sample a sparse polynomial (here in Lagrange form)
 	size := 64
 	pol := make([]fr.Element, size)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 0; i < size; i = i + 8 {
-		pol[i].SetRandom()
+		pol[i].MustSetRandom()
 	}
 
 	test := func(srs *SRS) func(*testing.T) {
@@ -153,19 +153,19 @@ func TestDividePolyByXminusA(t *testing.T) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 
 	// evaluate the polynomial at a random point
 	var point fr.Element
-	point.SetRandom()
+	point.MustSetRandom()
 	evaluation := eval(pol, point)
 
 	// probabilistic test (using Schwartz Zippel lemma, evaluation at one point is enough)
 	var randPoint, xminusa fr.Element
-	randPoint.SetRandom()
+	randPoint.MustSetRandom()
 	polRandpoint := eval(pol, randPoint)
 	polRandpoint.Sub(&polRandpoint, &evaluation) // f(rand)-f(point)
 
@@ -204,7 +204,7 @@ func TestCommit(t *testing.T) {
 	// create a polynomial
 	f := make([]fr.Element, 60)
 	for i := 0; i < 60; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 
 	// commit using the method from KZG
@@ -299,12 +299,12 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	// random polynomial
 	p := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		p[i].SetRandom()
+		p[i].MustSetRandom()
 	}
 
 	// random value
 	var x fr.Element
-	x.SetRandom()
+	x.MustSetRandom()
 
 	// verify valid proof
 	d, err := Commit(p, srs.Pk)
@@ -321,7 +321,7 @@ func TestVerifySinglePointQuickSRS(t *testing.T) {
 	}
 
 	// verify wrong proof
-	proof.ClaimedValue.SetRandom()
+	proof.ClaimedValue.MustSetRandom()
 	err = Verify(&d, &proof, x, srs.Vk)
 	if err == nil {
 		t.Fatal(err)
@@ -360,7 +360,7 @@ func TestBatchVerifySinglePoint(t *testing.T) {
 			}
 
 			var salt fr.Element
-			salt.SetRandom()
+			salt.MustSetRandom()
 			proofExtendedTranscript, err := BatchOpenSinglePoint(f, digests, point, hf, srs.Pk, salt.Marshal())
 			if err != nil {
 				t.Fatal(err)
@@ -432,9 +432,9 @@ func TestBatchVerifyMultiPoints(t *testing.T) {
 			// compute 2 batch opening proofs at 2 random points
 			points := make([]fr.Element, 2)
 			batchProofs := make([]BatchOpeningProof, 2)
-			points[0].SetRandom()
+			points[0].MustSetRandom()
 			batchProofs[0], _ = BatchOpenSinglePoint(f[:5], digests[:5], points[0], hf, srs.Pk)
-			points[1].SetRandom()
+			points[1].MustSetRandom()
 			batchProofs[1], _ = BatchOpenSinglePoint(f[5:], digests[5:], points[1], hf, srs.Pk)
 
 			// fold the 2 batch opening proofs
@@ -571,13 +571,13 @@ func BenchmarkDivideByXMinusA(b *testing.B) {
 
 	// build random polynomial
 	pol := make([]fr.Element, pSize)
-	pol[0].SetRandom()
+	pol[0].MustSetRandom()
 	for i := 1; i < pSize; i++ {
 		pol[i] = pol[i-1]
 	}
 	var a, fa fr.Element
-	a.SetRandom()
-	fa.SetRandom()
+	a.MustSetRandom()
+	fa.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -594,7 +594,7 @@ func BenchmarkKZGOpen(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -609,7 +609,7 @@ func BenchmarkKZGVerify(b *testing.B) {
 	// random polynomial
 	p := randomPolynomial(benchSize / 2)
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	// commit
 	comm, err := Commit(p, srs.Pk)
@@ -645,7 +645,7 @@ func BenchmarkKZGBatchOpen10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -675,7 +675,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 	hf := sha256.New()
 
 	var r fr.Element
-	r.SetRandom()
+	r.MustSetRandom()
 
 	proof, err := BatchOpenSinglePoint(ps[:], commitments[:], r, hf, srs.Pk)
 	if err != nil {
@@ -691,7 +691,7 @@ func BenchmarkKZGBatchVerify10(b *testing.B) {
 func randomPolynomial(size int) []fr.Element {
 	f := make([]fr.Element, size)
 	for i := 0; i < size; i++ {
-		f[i].SetRandom()
+		f[i].MustSetRandom()
 	}
 	return f
 }

--- a/internal/generator/pairing/template/tests/pairing.go.tmpl
+++ b/internal/generator/pairing/template/tests/pairing.go.tmpl
@@ -455,7 +455,7 @@ func BenchmarkMillerLoop(b *testing.B) {
 func BenchmarkFinalExponentiation(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -519,11 +519,11 @@ func BenchmarkMultiPair(b *testing.B) {
 func BenchmarkExpGT(b *testing.B) {
 
 	var a GT
-	a.SetRandom()
+	a.MustSetRandom()
 	a = FinalExponentiation(&a)
 
 	var e fp.Element
-	e.SetRandom()
+	e.MustSetRandom()
     {{if or (eq .Name "bw6-761") (eq .Name "bw6-633")}}
     k := new(big.Int).SetUint64(6)
     {{else if eq .Name "bls24-315"}}

--- a/internal/generator/pedersen/template/example_test.go.tmpl
+++ b/internal/generator/pedersen/template/example_test.go.tmpl
@@ -36,7 +36,7 @@ func Example_singleProof() {
 	pk := pks[0]
 	toCommit := make([]fr.Element, nbElem)
 	for i := range toCommit {
-		toCommit[i].SetRandom()
+		toCommit[i].MustSetRandom()
 	}
 	// commit to the values
 	commitment, err := pk.Commit(toCommit)
@@ -88,7 +88,7 @@ func ExampleBatchProve() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -101,7 +101,7 @@ func ExampleBatchProve() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	proof, err := BatchProve(pks, toCommit, combinationCoeff)
 	if err != nil {
 		panic(err)
@@ -160,7 +160,7 @@ func ExampleBatchVerifyMultiVk() {
 	for i := range toCommit {
 		toCommit[i] = make([]fr.Element, nbElem)
 		for j := range toCommit[i] {
-			toCommit[i][j].SetRandom()
+			toCommit[i][j].MustSetRandom()
 		}
 	}
 	// commit to the values
@@ -183,7 +183,7 @@ func ExampleBatchVerifyMultiVk() {
 	}
 	// combination coefficient is randomly sampled by the verifier. NB! In non-interactive protocol use Fiat-Shamir!
 	var combinationCoeff fr.Element
-	combinationCoeff.SetRandom()
+	combinationCoeff.MustSetRandom()
 	// batch verify the proofs
 	if err := BatchVerifyMultiVk(vks, commitments, proofs, combinationCoeff); err != nil {
 		panic(err)

--- a/internal/generator/pedersen/template/pedersen.test.go.tmpl
+++ b/internal/generator/pedersen/template/pedersen.test.go.tmpl
@@ -18,13 +18,11 @@ func interfaceSliceToFrSlice(t *testing.T, values ...interface{}) []fr.Element {
 	return res
 }
 
-func randomFrSlice(t *testing.T, size int) []interface{} {
+func randomFrSlice(size int) []interface{} {
 	res := make([]interface{}, size)
-	var err error
 	for i := range res {
 		var v fr.Element
-		res[i], err = v.SetRandom()
-		assert.NoError(t, err)
+		res[i] = v.MustSetRandom()
 	}
 	return res
 }
@@ -74,9 +72,9 @@ func testCommit(t *testing.T, values ...interface{}) {
 func TestFoldProofs(t *testing.T) {
 
 	values := [][]fr.Element{
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
-		interfaceSliceToFrSlice(t, randomFrSlice(t, 5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
+		interfaceSliceToFrSlice(t, randomFrSlice(5)...),
 	}
 
 	bases := make([][]curve.G1Affine, len(values))
@@ -144,11 +142,11 @@ func TestCommitToOne(t *testing.T) {
 }
 
 func TestCommitSingle(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 1)...)
+	testCommit(t, randomFrSlice(1)...)
 }
 
 func TestCommitFiveElements(t *testing.T) {
-	testCommit(t, randomFrSlice(t, 5)...)
+	testCommit(t, randomFrSlice(5)...)
 }
 
 func TestMarshal(t *testing.T) {
@@ -190,13 +188,10 @@ func TestSemiFoldProofs(t *testing.T) {
 		pk[i] = pk0[0]
 	}
 
-	values := make([][]fr.Element, nbCommitments)
+	values := make([]fr.Vector, nbCommitments)
 	for i := range values {
-		values[i] = make([]fr.Element, commitmentLength)
-		for j := range values[i] {
-			_, err = values[i][j].SetRandom()
-			assert.NoError(t, err)
-		}
+		values[i] = make(fr.Vector, commitmentLength)
+		values[i].MustSetRandom()
 	}
 
 	commitments := make([]curve.G1Affine, nbCommitments)
@@ -209,8 +204,7 @@ func TestSemiFoldProofs(t *testing.T) {
 	}
 
 	var challenge fr.Element
-	_, err = challenge.SetRandom()
-	assert.NoError(t, err)
+	challenge.MustSetRandom()
 
 	assert.NoError(t, BatchVerifyMultiVk(vk, commitments, proofs, challenge))
 

--- a/internal/generator/permutation/template/permutation.test.go.tmpl
+++ b/internal/generator/permutation/template/permutation.test.go.tmpl
@@ -38,7 +38,7 @@ func TestProof(t *testing.T) {
 
 	// wrong proof
 	{
-		a[0].SetRandom()
+		a[0].MustSetRandom()
 		proof, err := Prove(kzgSrs.Pk, a, b)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/generator/plookup/template/plookup.test.go.tmpl
+++ b/internal/generator/plookup/template/plookup.test.go.tmpl
@@ -37,7 +37,7 @@ func TestLookupVector(t *testing.T) {
 
 	// wrong proofs vector
 	{
-		fvector[0].SetRandom()
+		fvector[0].MustSetRandom()
 
 		proof, err := ProveLookupVector(kzgSrs.Pk, fvector, lookupVector)
 		if err != nil {
@@ -87,7 +87,7 @@ func TestLookupTable(t *testing.T) {
 
 	// wrong proof
 	{
-		fTable[0][0].SetRandom()
+		fTable[0][0].MustSetRandom()
 		proof, err := ProveLookupTables(kzgSrs.Pk, fTable, lookupTable)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/generator/polynomial/template/multilin.test.go.tmpl
+++ b/internal/generator/polynomial/template/multilin.test.go.tmpl
@@ -11,16 +11,10 @@ func TestFoldBilinear(t *testing.T) {
 
 		// f = c₀ + c₁ X₁ + c₂ X₂ + c₃ X₁ X₂
 		var coefficients [4]{{.ElementType}}
-		for i := 0; i < 4; i++ {
-			if _, err := coefficients[i].SetRandom(); err != nil {
-				t.Error(err)
-			}
-		}
+		fr.Vector(coefficients[:]).MustSetRandom()
 
 		var r {{.ElementType}}
-		if _, err := r.SetRandom(); err != nil {
-			t.Error(err)
-		}
+		r.MustSetRandom()
 
 		// interpolate at {0,1}²:
 		m := make(MultiLin, 4)

--- a/internal/generator/polynomial/template/polynomial.test.go.tmpl
+++ b/internal/generator/polynomial/template/polynomial.test.go.tmpl
@@ -18,7 +18,7 @@ func TestPolynomialEval(t *testing.T) {
 
 	// random value
 	var point {{.ElementType}}
-	point.SetRandom()
+	point.MustSetRandom()
 
 	// compute manually f(val)
 	var expectedEval, one, den {{.ElementType}}
@@ -49,7 +49,7 @@ func TestPolynomialAddConstantInPlace(t *testing.T) {
 
 	// constant to add
 	var c {{.ElementType}}
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// add constant
 	f.AddConstantInPlace(&c)
@@ -75,7 +75,7 @@ func TestPolynomialSubConstantInPlace(t *testing.T) {
 
 	// constant to sub
 	var c {{.ElementType}}
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// sub constant
 	f.SubConstantInPlace(&c)
@@ -101,7 +101,7 @@ func TestPolynomialScaleInPlace(t *testing.T) {
 
 	// constant to scale by
 	var c {{.ElementType}}
-	c.SetRandom()
+	c.MustSetRandom()
 
 	// scale by constant
 	f.ScaleInPlace(&c)

--- a/internal/generator/shplonk/template/example_test.go.tmpl
+++ b/internal/generator/shplonk/template/example_test.go.tmpl
@@ -20,14 +20,10 @@ func Example_batchOpen() {
 	for i := 0; i < nbPolynomials; i++ {
 
 		polynomials[i] = make([]fr.Element, 20+2*i) // random size
-		for j := 0; j < 20+2*i; j++ {
-			polynomials[i][j].SetRandom()
-		}
+		fr.Vector(polynomials[i]).MustSetRandom()
 
-		points[i] = make([]fr.Element, i+1) // random number of point
-		for j := 0; j < i+1; j++ {
-			points[i][j].SetRandom()
-		}
+		points[i] = make([]fr.Element, i+1) // random number of points
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	// Create commitments for each polynomials

--- a/internal/generator/shplonk/template/shplonk.test.go.tmpl
+++ b/internal/generator/shplonk/template/shplonk.test.go.tmpl
@@ -20,7 +20,7 @@ var bAlpha *big.Int
 func init() {
 	const srsSize = 230
 	var frAlpha fr.Element
-	frAlpha.SetRandom()
+	frAlpha.MustSetRandom()
 	bAlpha = big.NewInt(0)
 	frAlpha.BigInt(bAlpha)
 	var err error
@@ -40,9 +40,7 @@ func TestSerialization(t *testing.T) {
 	proof.ClaimedValues = make([][]fr.Element, nbClaimedValues)
 	for i := 0; i < nbClaimedValues; i++ {
 		proof.ClaimedValues[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			proof.ClaimedValues[i][j].SetRandom()
-		}
+		fr.Vector(proof.ClaimedValues[i]).MustSetRandom()
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
@@ -60,9 +58,7 @@ func TestOpening(t *testing.T) {
 	polys := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		polys[i] = make([]fr.Element, sizePoly[i])
-		for j := 0; j < sizePoly[i]; j++ {
-			polys[i][j].SetRandom()
-		}
+		fr.Vector(polys[i]).MustSetRandom()
 	}
 
 	digests := make([]kzg.Digest, nbPolys)
@@ -73,9 +69,7 @@ func TestOpening(t *testing.T) {
 	points := make([][]fr.Element, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		points[i] = make([]fr.Element, i+2)
-		for j := 0; j < i+2; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 
 	hf := sha256.New()
@@ -87,7 +81,7 @@ func TestOpening(t *testing.T) {
 	assert.NoError(err)
 
 	// tampered proof
-	openingProof.ClaimedValues[0][0].SetRandom()
+	openingProof.ClaimedValues[0][0].MustSetRandom()
 	err = BatchVerify(openingProof, digests, points, hf, testSrs.Vk)
 	assert.Error(err)
 
@@ -103,9 +97,7 @@ func TestBuildZtMinusSi(t *testing.T) {
 		sizeSi[i] = 5 + i
 		nbPoints += sizeSi[i]
 		points[i] = make([]fr.Element, sizeSi[i])
-		for j := 0; j < sizeSi[i]; j++ {
-			points[i][j].SetRandom()
-		}
+		fr.Vector(points[i]).MustSetRandom()
 	}
 	for i := 0; i < nbSi; i++ {
 		ztMinusSi := buildZtMinusSi(points, i)
@@ -138,10 +130,9 @@ func TestInterpolate(t *testing.T) {
 	nbPoints := 10
 	x := make([]fr.Element, nbPoints)
 	y := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
-		y[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+	fr.Vector(y).MustSetRandom()
+
 	f := interpolate(x, y)
 	for i := 0; i < nbPoints; i++ {
 		fx := eval(f, x[i])
@@ -156,9 +147,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
+
 	var r fr.Element
 	for i := 0; i < nbPoints; i++ {
 
@@ -177,7 +167,7 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 				}
 			}
 		}
-		r.SetRandom()
+		r.MustSetRandom()
 		y := eval(l, r)
 		if y.IsZero() {
 			t.Fatal("l_{i}(x) should not be zero if x is random")
@@ -189,9 +179,8 @@ func TestBuildLagrangeFromDomain(t *testing.T) {
 func TestBuildVanishingPoly(t *testing.T) {
 	s := 10
 	x := make([]fr.Element, s)
-	for i := 0; i < s; i++ {
-		x[i].SetRandom()
-	}
+	fr.Vector(x).MustSetRandom()
+
 	r := buildVanishingPoly(x)
 
 	if len(r) != s+1 {
@@ -208,7 +197,7 @@ func TestBuildVanishingPoly(t *testing.T) {
 
 	// check that r(y)!=0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(r, a)
 	if y.IsZero() {
 		t.Fatal("πᵢ(X-xᵢ) at r \neq xᵢ should not be zero")
@@ -219,18 +208,16 @@ func TestMultiplyLinearFactor(t *testing.T) {
 
 	s := 10
 	f := make([]fr.Element, s, s+1)
-	for i := 0; i < 10; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	var a, y fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	f = multiplyLinearFactor(f, a)
 	y = eval(f, a)
 	if !y.IsZero() {
 		t.Fatal("(X-a)f(X) should be zero at a")
 	}
-	a.SetRandom()
+	a.MustSetRandom()
 	y = eval(f, a)
 	if y.IsZero() {
 		t.Fatal("(X-1)f(X) at a random point should not be zero")
@@ -242,15 +229,11 @@ func TestNaiveMul(t *testing.T) {
 
 	size := 10
 	f := make([]fr.Element, size)
-	for i := 0; i < size; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	nbPoints := 10
 	points := make([]fr.Element, nbPoints)
-	for i := 0; i < nbPoints; i++ {
-		points[i].SetRandom()
-	}
+	fr.Vector(points).MustSetRandom()
 
 	v := buildVanishingPoly(points)
 	buf := make([]fr.Element, size+nbPoints-1)
@@ -266,7 +249,7 @@ func TestNaiveMul(t *testing.T) {
 
 	// check that g(r) != 0 for a random point
 	var a fr.Element
-	a.SetRandom()
+	a.MustSetRandom()
 	y := eval(g, a)
 	if y.IsZero() {
 		t.Fatal("f(X)(X-x_{1})..(X-x_{n}) at a random point should not be zero")
@@ -279,18 +262,16 @@ func TestDiv(t *testing.T) {
 	nbPoints := 10
 	s := 10
 	f := make([]fr.Element, s, s+nbPoints)
-	for i := 0; i < s; i++ {
-		f[i].SetRandom()
-	}
+	fr.Vector(f).MustSetRandom()
 
 	// backup
 	g := make([]fr.Element, s)
 	copy(g, f)
 
-	// successive divions of linear terms
+	// successive divisions of linear terms
 	x := make([]fr.Element, nbPoints)
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	q := make([][2]fr.Element, nbPoints)
@@ -312,7 +293,7 @@ func TestDiv(t *testing.T) {
 
 	// division by a degree > 1 polynomial
 	for i := 0; i < nbPoints; i++ {
-		x[i].SetRandom()
+		x[i].MustSetRandom()
 		f = multiplyLinearFactor(f, x[i])
 	}
 	r := buildVanishingPoly(x)

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -81,6 +81,14 @@ func (z *E12) SetRandom() (*E12, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E12) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E12) IsZero() bool {
 	return z.C0.IsZero() && z.C1.IsZero()

--- a/internal/generator/tower/template/fq12over6over2/fq2.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq2.go.tmpl
@@ -86,6 +86,14 @@ func (z *E2) SetRandom() (*E2, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E2) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E2) IsZero() bool {
 	return z.A0.IsZero() && z.A1.IsZero()

--- a/internal/generator/tower/template/fq12over6over2/fq6.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq6.go.tmpl
@@ -45,6 +45,14 @@ func (z *E6) SetRandom() (*E6, error) {
 	return z, nil
 }
 
+// MustSetRandom sets a0 and a1 to random values.
+// It panics if reading form crypto/rand fails
+func (z *E6) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
 // IsZero returns true if z is zero, false otherwise
 func (z *E6) IsZero() bool {
 	return z.B0.IsZero() && z.B1.IsZero() && z.B2.IsZero()

--- a/internal/generator/tower/template/fq12over6over2/tests/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/tests/fq12.go.tmpl
@@ -440,8 +440,8 @@ func TestE12Ops(t *testing.T) {
 
 func BenchmarkE12Add(b *testing.B) {
 	var a, c E12
-_,_ =	a.SetRandom()
-_,_ =	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -450,8 +450,8 @@ _,_ =	c.SetRandom()
 
 func BenchmarkE12Sub(b *testing.B) {
 	var a, c E12
-_,_ =	a.SetRandom()
-_,_ =	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -460,8 +460,8 @@ _,_ =	c.SetRandom()
 
 func BenchmarkE12Mul(b *testing.B) {
 	var a, c E12
-_,_ =	a.SetRandom()
-_,_ =	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -470,7 +470,7 @@ _,_ =	c.SetRandom()
 
 func BenchmarkE12Cyclosquare(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.CyclotomicSquare(&a)
@@ -479,7 +479,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12Square(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -488,7 +488,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12Inverse(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -497,7 +497,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12Conjugate(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)
@@ -506,7 +506,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12Frobenius(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Frobenius(&a)
@@ -515,7 +515,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12FrobeniusSquare(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.FrobeniusSquare(&a)
@@ -524,7 +524,7 @@ _,_ =	a.SetRandom()
 
 func BenchmarkE12Expt(b *testing.B) {
 	var a E12
-_,_ =	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Expt(&a)

--- a/internal/generator/tower/template/fq12over6over2/tests/fq2.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/tests/fq2.go.tmpl
@@ -403,8 +403,8 @@ func TestE2Ops(t *testing.T) {
 
 func BenchmarkE2Add(b *testing.B) {
 	var a, c E2
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -413,8 +413,8 @@ _,_=	c.SetRandom()
 
 func BenchmarkE2Sub(b *testing.B) {
 	var a, c E2
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -423,8 +423,8 @@ _,_=	c.SetRandom()
 
 func BenchmarkE2Mul(b *testing.B) {
 	var a, c E2
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -434,8 +434,8 @@ _,_=	c.SetRandom()
 func BenchmarkE2MulByElement(b *testing.B) {
 	var a E2
 	var c fp.Element
-_,_=	c.SetRandom()
-_,_=	a.SetRandom()
+	c.MustSetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByElement(&a, &c)
@@ -444,7 +444,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2Square(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -453,7 +453,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2Sqrt(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sqrt(&a)
@@ -462,7 +462,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2Exp(b *testing.B) {
 	var x E2
-_,_=	x.SetRandom()
+	x.MustSetRandom()
 	b1, _ := rand.Int(rand.Reader, fp.Modulus())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -474,7 +474,7 @@ _,_=	x.SetRandom()
 
 func BenchmarkE2Inverse(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)
@@ -483,7 +483,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2MulNonRes(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidue(&a)
@@ -492,7 +492,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2MulNonResInv(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.MulByNonResidueInv(&a)
@@ -501,7 +501,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE2Conjugate(b *testing.B) {
 	var a E2
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Conjugate(&a)

--- a/internal/generator/tower/template/fq12over6over2/tests/fq6.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/tests/fq6.go.tmpl
@@ -279,8 +279,8 @@ func TestE6Ops(t *testing.T) {
 
 func BenchmarkE6Add(b *testing.B) {
 	var a, c E6
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Add(&a, &c)
@@ -289,8 +289,8 @@ _,_=	c.SetRandom()
 
 func BenchmarkE6Sub(b *testing.B) {
 	var a, c E6
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Sub(&a, &c)
@@ -299,8 +299,8 @@ _,_=	c.SetRandom()
 
 func BenchmarkE6Mul(b *testing.B) {
 	var a, c E6
-_,_=	a.SetRandom()
-_,_=	c.SetRandom()
+	a.MustSetRandom()
+	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
@@ -309,7 +309,7 @@ _,_=	c.SetRandom()
 
 func BenchmarkE6Square(b *testing.B) {
 	var a E6
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Square(&a)
@@ -318,7 +318,7 @@ _,_=	a.SetRandom()
 
 func BenchmarkE6Inverse(b *testing.B) {
 	var a E6
-_,_=	a.SetRandom()
+	a.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Inverse(&a)


### PR DESCRIPTION
Add `MustSetRandom` methods to all field elements and vectors, which panics if there is an error. Prefer it in most tests over `SetRandom` for brevity.

While working on this I noticed that a lot of our curve and field code is not auto generated, involving lots and lots of copy pasting. This not only makes refactoring such as this cumbersome, but is dangerous as well since some bug fix PRs might miss a curve/field or two. We should probably address this in a separate issue.