### PR TITLE
perf: remove useless copies in e4 mul by elem

### DIFF
--- a/field/babybear/extensions/e2.go
+++ b/field/babybear/extensions/e2.go
@@ -127,10 +127,8 @@ func (z *E2) String() string {
 
 // MulByElement multiplies an element in E2 by an element in fr
 func (z *E2) MulByElement(x *E2, y *fr.Element) *E2 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.A0.Mul(&x.A0, &yCopy)
-	z.A1.Mul(&x.A1, &yCopy)
+	z.A0.Mul(&x.A0, y)
+	z.A1.Mul(&x.A1, y)
 	return z
 }
 

--- a/field/babybear/extensions/e4.go
+++ b/field/babybear/extensions/e4.go
@@ -78,10 +78,8 @@ func (z *E4) SetOne() *E4 {
 
 // MulByElement multiplies an element in E4 by an element in fr
 func (z *E4) MulByElement(x *E4, y *fr.Element) *E4 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.B0.MulByElement(&x.B0, &yCopy)
-	z.B1.MulByElement(&x.B1, &yCopy)
+	z.B0.MulByElement(&x.B0, y)
+	z.B1.MulByElement(&x.B1, y)
 	return z
 }
 

--- a/field/babybear/extensions/e4_test.go
+++ b/field/babybear/extensions/e4_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+
+	fr "github.com/consensys/gnark-crypto/field/babybear"
 )
 
 // ------------------------------------------------------------
@@ -256,6 +258,17 @@ func BenchmarkE4Mul(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
+	}
+}
+
+func BenchmarkE4MulByElement(b *testing.B) {
+	var a E4
+	var c fr.Element
+	_, _ = a.SetRandom()
+	_, _ = c.SetRandom()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.MulByElement(&a, &c)
 	}
 }
 

--- a/field/generator/internal/templates/extensions/e2.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2.go.tmpl
@@ -120,10 +120,8 @@ func (z *E2) String() string {
 
 // MulByElement multiplies an element in E2 by an element in fr
 func (z *E2) MulByElement(x *E2, y *fr.Element) *E2 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.A0.Mul(&x.A0, &yCopy)
-	z.A1.Mul(&x.A1, &yCopy)
+	z.A0.Mul(&x.A0, y)
+	z.A1.Mul(&x.A1, y)
 	return z
 }
 

--- a/field/generator/internal/templates/extensions/e4.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4.go.tmpl
@@ -71,10 +71,8 @@ func (z *E4) SetOne() *E4 {
 
 // MulByElement multiplies an element in E4 by an element in fr
 func (z *E4) MulByElement(x *E4, y *fr.Element) *E4 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.B0.MulByElement(&x.B0, &yCopy)
-	z.B1.MulByElement(&x.B1, &yCopy)
+	z.B0.MulByElement(&x.B0, y)
+	z.B1.MulByElement(&x.B1, y)
 	return z
 }
 

--- a/field/generator/internal/templates/extensions/e4_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4_test.go.tmpl
@@ -3,6 +3,8 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+
+	fr "{{ .FieldPackagePath }}"
 )
 
 // ------------------------------------------------------------
@@ -249,6 +251,17 @@ func BenchmarkE4Mul(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
+	}
+}
+
+func BenchmarkE4MulByElement(b *testing.B) {
+	var a E4
+	var c fr.Element
+	_, _ = a.SetRandom()
+	_, _ = c.SetRandom()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.MulByElement(&a, &c)
 	}
 }
 

--- a/field/goldilocks/extensions/e2.go
+++ b/field/goldilocks/extensions/e2.go
@@ -127,10 +127,8 @@ func (z *E2) String() string {
 
 // MulByElement multiplies an element in E2 by an element in fr
 func (z *E2) MulByElement(x *E2, y *fr.Element) *E2 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.A0.Mul(&x.A0, &yCopy)
-	z.A1.Mul(&x.A1, &yCopy)
+	z.A0.Mul(&x.A0, y)
+	z.A1.Mul(&x.A1, y)
 	return z
 }
 

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -127,10 +127,8 @@ func (z *E2) String() string {
 
 // MulByElement multiplies an element in E2 by an element in fr
 func (z *E2) MulByElement(x *E2, y *fr.Element) *E2 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.A0.Mul(&x.A0, &yCopy)
-	z.A1.Mul(&x.A1, &yCopy)
+	z.A0.Mul(&x.A0, y)
+	z.A1.Mul(&x.A1, y)
 	return z
 }
 

--- a/field/koalabear/extensions/e4.go
+++ b/field/koalabear/extensions/e4.go
@@ -78,10 +78,8 @@ func (z *E4) SetOne() *E4 {
 
 // MulByElement multiplies an element in E4 by an element in fr
 func (z *E4) MulByElement(x *E4, y *fr.Element) *E4 {
-	var yCopy fr.Element
-	yCopy.Set(y)
-	z.B0.MulByElement(&x.B0, &yCopy)
-	z.B1.MulByElement(&x.B1, &yCopy)
+	z.B0.MulByElement(&x.B0, y)
+	z.B1.MulByElement(&x.B1, y)
 	return z
 }
 

--- a/field/koalabear/extensions/e4_test.go
+++ b/field/koalabear/extensions/e4_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+
+	fr "github.com/consensys/gnark-crypto/field/koalabear"
 )
 
 // ------------------------------------------------------------
@@ -256,6 +258,17 @@ func BenchmarkE4Mul(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Mul(&a, &c)
+	}
+}
+
+func BenchmarkE4MulByElement(b *testing.B) {
+	var a E4
+	var c fr.Element
+	_, _ = a.SetRandom()
+	_, _ = c.SetRandom()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.MulByElement(&a, &c)
 	}
 }
 


### PR DESCRIPTION
# Description

At least for small fields, the copy is useless / hurts perf. Likely same for other towers?

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkE4MulByElement-16     6.74          5.95          -11.79%
BenchmarkE4MulByElement-16     6.76          5.86          -13.29%
```

