### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/field/generator/config/extension.go
+++ b/field/generator/config/extension.go
@@ -38,13 +38,6 @@ func (f *Extension) Neg(x Element) Element {
 	return z
 }
 
-func max(x int, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 func (f *Extension) Add(x Element, y Element) Element {
 	z := make(Element, f.Degree)
 

--- a/field/hash/hashutils.go
+++ b/field/hash/hashutils.go
@@ -85,10 +85,3 @@ func ExpandMsgXmd(msg, dst []byte, lenInBytes int) ([]byte, error) {
 	}
 	return res, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
# Description

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

