### PR TITLE
feat(glv): split scalar strict bounds

### DIFF
--- a/ecc/utils.go
+++ b/ecc/utils.go
@@ -155,6 +155,21 @@ func SplitScalar(s *big.Int, l *Lattice) [2]big.Int {
 	return v
 }
 
+// SplitScalarStrict similar to SplitScalar but does not increase bounds on k1
+// and k2
+func SplitScalarStrict(s *big.Int, l *Lattice) [2]big.Int {
+
+	var k1, k2 big.Int
+	k1.Mul(s, &l.V2[1])
+	k2.Mul(s, &l.V1[1]).Neg(&k2)
+	rounding(&k1, &l.Det, &k1)
+	rounding(&k2, &l.Det, &k2)
+	v := getVector(l, &k1, &k2)
+	v[0].Sub(s, &v[0])
+	v[1].Neg(&v[1])
+	return v
+}
+
 // sets res to the closest integer from n/d
 func rounding(n, d, res *big.Int) {
 	var dshift, r, one big.Int

--- a/ecc/utils_test.go
+++ b/ecc/utils_test.go
@@ -78,7 +78,7 @@ func TestNafDecomposition(t *testing.T) {
 func TestSplitting(t *testing.T) {
 	t.Parallel()
 
-	var lambda, r, s, _s, zero big.Int
+	var lambda, r, s, _s1, _s2, zero big.Int
 	var l Lattice
 
 	r.SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
@@ -88,10 +88,13 @@ func TestSplitting(t *testing.T) {
 
 	s.SetString("183927522224640574525727508854836440041603434369820418657580", 10)
 
-	v := SplitScalar(&s, &l)
-	_s.Mul(&v[1], &lambda).Add(&_s, &v[0]).Sub(&_s, &s)
-	_s.Mod(&_s, &r)
-	if _s.Cmp(&zero) != 0 {
+	v1 := SplitScalar(&s, &l)
+	v2 := SplitScalarStrict(&s, &l)
+	_s1.Mul(&v1[1], &lambda).Add(&_s1, &v1[0]).Sub(&_s1, &s)
+	_s1.Mod(&_s1, &r)
+	_s2.Mul(&v2[1], &lambda).Add(&_s2, &v2[0]).Sub(&_s2, &s)
+	_s2.Mod(&_s2, &r)
+	if _s1.Cmp(&zero) != 0 || _s2.Cmp(&zero) != 0 {
 		t.Fatal("Error split scalar")
 	}
 }
@@ -108,5 +111,20 @@ func BenchmarkSplitting256(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		SplitScalar(&s, &l)
+	}
+}
+
+func BenchmarkSplittingStrict256(b *testing.B) {
+	var lambda, r, s big.Int
+	var l Lattice
+
+	r.SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
+	lambda.SetString("4407920970296243842393367215006156084916469457145843978461", 10)
+	PrecomputeLattice(&r, &lambda, &l)
+	s.SetString("183927522224640574525727508854836440041603434369820418657580", 10)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SplitScalarStrict(&s, &l)
 	}
 }


### PR DESCRIPTION
# Description

We re-introduce the original `SplitScalar()` removed in #213 (now renamed `SplitScalarStrict()`). For gnark-crypto we continue to use the current `SplitScalar()` which replaces divisions by right-shifts but we need `SplitScalarStrict()` for gnark circuits.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

`TestSplitting` in `utils_test.go` tests both `SplitScalar()` and `SplitScalarStrict()`.

# How has this been benchmarked?

```
goos: darwin
goarch: arm64
pkg: github.com/consensys/gnark-crypto/ecc
cpu: Apple M1
BenchmarkSplitting256
BenchmarkSplitting256-8                  4004929               253.8 ns/op
BenchmarkSplittingStrict256
BenchmarkSplittingStrict256-8            1352343               884.2 ns/op
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

