### PR TITLE
feat: half-GCD in ℤ [ √- 2 ]

### DIFF
--- a/field/zz2/doc.go
+++ b/field/zz2/doc.go
@@ -1,0 +1,6 @@
+// Package zz2 provides arithmetic in Z[√−2].
+//
+// Z[√−2] form a commutative ring of algebraic integers in the algebraic number
+// field Q(j).  These are of the form z = a + bj, where a and b are integers
+// and j²+2=0.
+package zz2

--- a/field/zz2/zz2.go
+++ b/field/zz2/zz2.go
@@ -1,0 +1,231 @@
+package zz2
+
+import (
+	"math/big"
+)
+
+// A ComplexNumber represents an arbitrary-precision Z[√−2] integer.
+type ComplexNumber struct {
+	A0, A1 *big.Int
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// helpers – hex-lattice geometry & symmetric rounding
+// ──────────────────────────────────────────────────────────────────────────────
+
+// six axial directions of the hexagonal lattice
+var neighbours = [][2]int64{
+	{1, 0}, {0, 1}, {-1, 1}, {-1, 0}, {0, -1}, {1, -1},
+}
+
+// roundNearest returns ⌊(z + d/2) / d⌋  for *any* sign of z, d>0
+func roundNearest(z, d *big.Int) *big.Int {
+	half := new(big.Int).Rsh(d, 1) // d / 2
+	if z.Sign() >= 0 {
+		return new(big.Int).Div(new(big.Int).Add(z, half), d)
+	}
+	tmp := new(big.Int).Neg(z)
+	tmp.Add(tmp, half)
+	tmp.Div(tmp, d)
+	return tmp.Neg(tmp)
+}
+
+func (z *ComplexNumber) init() {
+	if z.A0 == nil {
+		z.A0 = new(big.Int)
+
+	}
+	if z.A1 == nil {
+		z.A1 = new(big.Int)
+
+	}
+}
+
+// String implements Stringer interface for fancy printing
+func (z *ComplexNumber) String() string {
+	return z.A0.String() + "+(" + z.A1.String() + "*j)"
+}
+
+// Equal returns true if z equals x, false otherwise
+func (z *ComplexNumber) Equal(x *ComplexNumber) bool {
+	return z.A0.Cmp(x.A0) == 0 && z.A1.Cmp(x.A1) == 0
+}
+
+// Set sets z to x, and returns z.
+func (z *ComplexNumber) Set(x *ComplexNumber) *ComplexNumber {
+	z.init()
+	z.A0.Set(x.A0)
+	z.A1.Set(x.A1)
+	return z
+}
+
+// SetZero sets z to 0, and returns z.
+func (z *ComplexNumber) SetZero() *ComplexNumber {
+	z.A0 = big.NewInt(0)
+	z.A1 = big.NewInt(0)
+	return z
+}
+
+// SetOne sets z to 1, and returns z.
+func (z *ComplexNumber) SetOne() *ComplexNumber {
+	z.A0 = big.NewInt(1)
+	z.A1 = big.NewInt(0)
+	return z
+}
+
+// Neg sets z to the negative of x, and returns z.
+func (z *ComplexNumber) Neg(x *ComplexNumber) *ComplexNumber {
+	z.init()
+	z.A0.Neg(x.A0)
+	z.A1.Neg(x.A1)
+	return z
+}
+
+// Conjugate sets z to the conjugate of x, and returns z.
+func (z *ComplexNumber) Conjugate(x *ComplexNumber) *ComplexNumber {
+	z.init()
+	z.A0.Set(x.A0)
+	z.A1.Neg(x.A1)
+	return z
+}
+
+// Add sets z to the sum of x and y, and returns z.
+func (z *ComplexNumber) Add(x, y *ComplexNumber) *ComplexNumber {
+	z.init()
+	z.A0.Add(x.A0, y.A0)
+	z.A1.Add(x.A1, y.A1)
+	return z
+}
+
+// Sub sets z to the difference of x and y, and returns z.
+func (z *ComplexNumber) Sub(x, y *ComplexNumber) *ComplexNumber {
+	z.init()
+	z.A0.Sub(x.A0, y.A0)
+	z.A1.Sub(x.A1, y.A1)
+	return z
+}
+
+// Mul sets z to the product of x and y, and returns z.
+//
+// Given that j²+2=0, the explicit formula is:
+//
+//	(x0+x1j)(y0+y1j) = (x0y0-2x1y1) + (x0y1+x1y0)j
+func (z *ComplexNumber) Mul(x, y *ComplexNumber) *ComplexNumber {
+	z.init()
+	var t [3]big.Int
+	var z0, z1 big.Int
+	t[0].Mul(x.A0, y.A0)
+	t[1].Mul(x.A1, y.A1)
+	z0.Sub(&t[0], &t[1])
+	z0.Sub(&z0, &t[1])
+	t[0].Mul(x.A0, y.A1)
+	t[2].Mul(x.A1, y.A0)
+	z1.Add(&t[0], &t[2])
+	z.A0.Set(&z0)
+	z.A1.Set(&z1)
+	return z
+}
+
+// Norm returns the norm of z.
+//
+// The explicit formula is:
+//
+//	N(x0+x1j) = x0² + 2x1²
+func (z *ComplexNumber) Norm() *big.Int {
+	norm := new(big.Int)
+	temp := new(big.Int)
+	norm.Add(
+		norm.Mul(z.A0, z.A0),
+		temp.Mul(z.A1, z.A1),
+	)
+	norm.Add(
+		norm,
+		temp.Mul(z.A1, z.A1),
+	)
+	return norm
+}
+
+// QuoRem sets z to the Euclidean quotient of x / y, r to the remainder,
+// and guarantees ‖r‖ < ‖y‖ (true Euclidean division in ℤ[j]).
+func (z *ComplexNumber) QuoRem(x, y, r *ComplexNumber) (*ComplexNumber, *ComplexNumber) {
+
+	norm := y.Norm() // > 0  (Z[√−2] norm is always non-neg)
+	if norm.Sign() == 0 {
+		panic("division by zero")
+	}
+
+	// num = x * ȳ   (ȳ computed in a fresh variable → y unchanged)
+	var yConj, num ComplexNumber
+	yConj.Conjugate(y)
+	num.Mul(x, &yConj)
+
+	// first guess by *symmetric* rounding of both coordinates
+	q0 := roundNearest(num.A0, norm)
+	q1 := roundNearest(num.A1, norm)
+	z.A0, z.A1 = q0, q1
+
+	// r = x – q*y
+	r.Mul(y, z)
+	r.Sub(x, r)
+
+	// If Euclidean inequality already holds we're done.
+	// Otherwise walk ≤2 unit steps in the hex lattice until N(r) < N(y).
+	if r.Norm().Cmp(norm) >= 0 {
+		bestQ0, bestQ1 := new(big.Int).Set(z.A0), new(big.Int).Set(z.A1)
+		bestR := new(ComplexNumber).Set(r)
+		bestN2 := bestR.Norm()
+
+		for _, dir := range neighbours {
+			candQ0 := new(big.Int).Add(z.A0, big.NewInt(dir[0]))
+			candQ1 := new(big.Int).Add(z.A1, big.NewInt(dir[1]))
+			var candQ ComplexNumber
+			candQ.A0, candQ.A1 = candQ0, candQ1
+
+			var candR ComplexNumber
+			candR.Mul(y, &candQ)
+			candR.Sub(x, &candR)
+
+			if candR.Norm().Cmp(bestN2) < 0 {
+				bestQ0, bestQ1 = candQ0, candQ1
+				bestR.Set(&candR)
+				bestN2 = bestR.Norm()
+			}
+		}
+		z.A0, z.A1 = bestQ0, bestQ1
+		r.Set(bestR) // update remainder and retry; Euclidean property ⇒ ≤ 2 loops
+	}
+	return z, r
+}
+
+// HalfGCD returns the rational reconstruction of a, b.
+// This outputs w, v, u s.t. w = a*u + b*v.
+func HalfGCD(a, b *ComplexNumber) [3]*ComplexNumber {
+
+	var aRun, bRun, u, v, u_, v_, quotient, remainder, t, t1, t2 ComplexNumber
+	var sqrt big.Int
+
+	aRun.Set(a)
+	bRun.Set(b)
+	u.SetOne()
+	v.SetZero()
+	u_.SetZero()
+	v_.SetOne()
+
+	// Z[√−2] integers form an Euclidean domain for the norm
+	sqrt.Sqrt(a.Norm())
+	for bRun.Norm().Cmp(&sqrt) >= 0 {
+		quotient.QuoRem(&aRun, &bRun, &remainder)
+		t.Mul(&u_, &quotient)
+		t1.Sub(&u, &t)
+		t.Mul(&v_, &quotient)
+		t2.Sub(&v, &t)
+		aRun.Set(&bRun)
+		u.Set(&u_)
+		v.Set(&v_)
+		bRun.Set(&remainder)
+		u_.Set(&t1)
+		v_.Set(&t2)
+	}
+
+	return [3]*ComplexNumber{&bRun, &v_, &u_}
+}

--- a/field/zz2/zz2_test.go
+++ b/field/zz2/zz2_test.go
@@ -1,0 +1,315 @@
+package zz2
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/prop"
+)
+
+const (
+	nbFuzzShort = 10
+	nbFuzz      = 50
+	boundSize   = 128
+)
+
+func TestZZ2ReceiverIsOperand(t *testing.T) {
+
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genE := GenComplexNumber(boundSize)
+
+	properties.Property("Having the receiver as operand (addition) should output the same result", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c, d ComplexNumber
+			d.Set(a)
+			c.Add(a, b)
+			a.Add(a, b)
+			b.Add(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("Having the receiver as operand (sub) should output the same result", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c, d ComplexNumber
+			d.Set(a)
+			c.Sub(a, b)
+			a.Sub(a, b)
+			b.Sub(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("Having the receiver as operand (mul) should output the same result", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c, d ComplexNumber
+			d.Set(a)
+			c.Mul(a, b)
+			a.Mul(a, b)
+			b.Mul(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("Having the receiver as operand (neg) should output the same result", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b ComplexNumber
+			b.Neg(a)
+			a.Neg(a)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.Property("Having the receiver as operand (conjugate) should output the same result", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b ComplexNumber
+			b.Conjugate(a)
+			a.Conjugate(a)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestZZ2Arithmetic(t *testing.T) {
+
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genE := GenComplexNumber(boundSize)
+
+	properties.Property("sub & add should leave an element invariant", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c ComplexNumber
+			c.Set(a)
+			c.Add(&c, b).Sub(&c, b)
+			return c.Equal(a)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("neg twice should leave an element invariant", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b ComplexNumber
+			b.Neg(a).Neg(&b)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.Property("conj twice should leave an element invariant", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b ComplexNumber
+			b.Conjugate(a).Conjugate(&b)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.Property("add zero should leave element invariant", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b, zero ComplexNumber
+			zero.SetZero()
+			b.Add(a, &zero)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.Property("mul by one should leave element invariant", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			var b, one ComplexNumber
+			one.SetOne()
+			b.Mul(a, &one)
+			return a.Equal(&b)
+		},
+		genE,
+	))
+
+	properties.Property("add should be commutative", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c, d ComplexNumber
+			c.Add(a, b)
+			d.Add(b, a)
+			return c.Equal(&d)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("add should be assiocative", prop.ForAll(
+		func(a, b, c *ComplexNumber) bool {
+			var d, e ComplexNumber
+			d.Add(a, b).Add(&d, c)
+			e.Add(c, b).Add(&e, a)
+			return e.Equal(&d)
+		},
+		genE,
+		genE,
+		genE,
+	))
+
+	properties.Property("mul should be commutative", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var c, d ComplexNumber
+			c.Mul(a, b)
+			d.Mul(b, a)
+			return c.Equal(&d)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("mul should be assiocative", prop.ForAll(
+		func(a, b, c *ComplexNumber) bool {
+			var d, e ComplexNumber
+			d.Mul(a, b).Mul(&d, c)
+			e.Mul(c, b).Mul(&e, a)
+			return e.Equal(&d)
+		},
+		genE,
+		genE,
+		genE,
+	))
+
+	properties.Property("norm should always be positive", prop.ForAll(
+		func(a *ComplexNumber) bool {
+			return a.Norm().Sign() >= 0
+		},
+		genE,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestZZ2HalfGCD(t *testing.T) {
+
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genE := GenComplexNumber(boundSize)
+
+	properties.Property("half-GCD", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			res := HalfGCD(a, b)
+			var c, d ComplexNumber
+			c.Mul(b, res[1])
+			d.Mul(a, res[2])
+			d.Add(&c, &d)
+			return d.Equal(res[0])
+		},
+		genE,
+		genE,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestZZ2QuoRem(t *testing.T) {
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+	genE := GenComplexNumber(boundSize)
+
+	properties.Property("QuoRem should be correct", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var z, rem ComplexNumber
+			z.QuoRem(a, b, &rem)
+			var res ComplexNumber
+			res.Mul(b, &z)
+			res.Add(&res, &rem)
+			return res.Equal(a)
+		},
+		genE,
+		genE,
+	))
+
+	properties.Property("QuoRem remainder should be smaller than divisor", prop.ForAll(
+		func(a, b *ComplexNumber) bool {
+			var z, rem ComplexNumber
+			z.QuoRem(a, b, &rem)
+			return rem.Norm().Cmp(b.Norm()) == -1
+		},
+		genE,
+		genE,
+	))
+}
+
+// GenNumber generates a random integer
+func GenNumber(boundSize int64) gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		var bound big.Int
+		bound.Exp(big.NewInt(2), big.NewInt(boundSize), nil)
+		elmt, _ := rand.Int(genParams.Rng, &bound)
+		genResult := gopter.NewGenResult(elmt, gopter.NoShrinker)
+		return genResult
+	}
+}
+
+// GenComplexNumber generates a random integer
+func GenComplexNumber(boundSize int64) gopter.Gen {
+	return gopter.CombineGens(
+		GenNumber(boundSize),
+		GenNumber(boundSize),
+	).Map(func(values []interface{}) *ComplexNumber {
+		return &ComplexNumber{A0: values[0].(*big.Int), A1: values[1].(*big.Int)}
+	})
+}
+
+// bench
+var benchRes [3]*ComplexNumber
+
+func BenchmarkHalfGCD(b *testing.B) {
+	var n, _ = new(big.Int).SetString("100000000000000000000000000000000", 16) // 2^128
+	a0, _ := rand.Int(rand.Reader, n)
+	a1, _ := rand.Int(rand.Reader, n)
+	c0, _ := rand.Int(rand.Reader, n)
+	c1, _ := rand.Int(rand.Reader, n)
+	a := ComplexNumber{A0: a0, A1: a1}
+	c := ComplexNumber{A0: c0, A1: c1}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchRes = HalfGCD(&a, &c)
+	}
+}


### PR DESCRIPTION
# Description

This PR provides arithmetic in ℤ[√−2], particularly the half-GCD needed in https://github.com/Consensys/gnark/pull/1499.

This code can probably be refactored with `eisenstein/` but this PR is unlikely to be merged. So I'm keeping it as is for demonstration purposes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tests implemented in  `zz2_test.go`.

# How has this been benchmarked?

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules