### PR TITLE
perf: parallelize batch subgroup on bls12377 and better randomness re…

### DIFF
--- a/ecc/bls12-377/batch_subgroup_membership.go
+++ b/ecc/bls12-377/batch_subgroup_membership.go
@@ -3,6 +3,9 @@ package bls12377
 import (
 	"crypto/rand"
 	"math/big"
+	"sync/atomic"
+
+	"github.com/consensys/gnark-crypto/internal/parallel"
 )
 
 // IsInSubGroupBatchNaive checks if a batch of points P_i are in G1.
@@ -11,12 +14,16 @@ import (
 //
 // [Scott21]: https://eprint.iacr.org/2021/1130.pdf
 func IsInSubGroupBatchNaive(points []G1Affine) bool {
-	for i := range points {
-		if !points[i].IsInSubGroup() {
-			return false
+	var nbErrors int64
+	parallel.Execute(len(points), func(start, end int) {
+		for i := start; i < end; i++ {
+			if !points[i].IsInSubGroup() {
+				atomic.AddInt64(&nbErrors, 1)
+				return
+			}
 		}
-	}
-	return true
+	})
+	return nbErrors == 0
 }
 
 // IsInSubGroupBatch checks if a batch of points P_i are in G1.
@@ -26,22 +33,45 @@ func IsInSubGroupBatchNaive(points []G1Affine) bool {
 //
 // [Scott21]: https://eprint.iacr.org/2021/1130.pdf
 func IsInSubGroupBatch(points []G1Affine, bound *big.Int, rounds int) bool {
+	// ensure bound is 2 for now.
+	if !bound.IsUint64() && bound.Uint64() != 2 {
+		panic("IsInSubGroupBatch only supports bound=2 for now")
+	}
+	// ensure rounds == 64
+	const nbRounds = 64
+	if rounds != nbRounds {
+		panic("IsInSubGroupBatch only supports rounds=64 for now")
+	}
 
-	// Check Sj are on E[r]
-	for i := 0; i < rounds; i++ {
+	var nbErrors int64
+	parallel.Execute(rounds, func(start, end int) {
 		var sum G1Jac
-		for j := range len(points) {
-			b, err := rand.Int(rand.Reader, bound)
-			if err != nil {
-				panic(err)
-			}
-			if b.Cmp(big.NewInt(0)) != 0 {
-				sum.AddMixed(&points[j])
+
+		const windowSize = 64
+		var br [windowSize / 8]byte
+
+		// Check Sj are on E[r]
+		for i := start; i < end; i++ {
+			for j := range len(points) {
+				pos := j % windowSize
+				if pos == 0 {
+					// re sample the random bytes every windowSize points
+					// as per the doc:
+					// Read fills b with cryptographically secure random bytes. It never returns an error, and always fills b entirely.
+					rand.Read(br[:])
+				}
+				// check if the bit is set
+				if br[pos/8]&(1<<(pos%8)) != 0 {
+					// add the point to the sum
+					sum.AddMixed(&points[j])
+				}
 			}
 		}
 		if !sum.IsInSubGroup() {
-			return false
+			atomic.AddInt64(&nbErrors, 1)
 		}
-	}
-	return true
+	})
+
+	return nbErrors == 0
+
 }


### PR DESCRIPTION
This pull request refactors and optimizes the batch subgroup membership checks in the `ecc/bls12-377` package. The changes improve performance by introducing parallel execution and adding validations for input parameters. Below are the most important changes:

### Performance Improvements:
* Replaced the sequential loop in `IsInSubGroupBatchNaive` with a parallel execution model using the `parallel.Execute` utility, enabling concurrent validation of points in the batch. Atomic counters are used to track errors during the parallel execution. (`ecc/bls12-377/batch_subgroup_membership.go`, [ecc/bls12-377/batch_subgroup_membership.goL14-R26](diffhunk://#diff-2e650bc236839750887b16e5705a081f93f169da7acbeeae6ff5321e51ce9892L14-R26))

* Optimized the `IsInSubGroupBatch` function by introducing a window-based random sampling approach for points and parallelizing the subgroup checks across multiple rounds. This ensures better performance for large batches. (`ecc/bls12-377/batch_subgroup_membership.go`, [ecc/bls12-377/batch_subgroup_membership.goR36-R76](diffhunk://#diff-2e650bc236839750887b16e5705a081f93f169da7acbeeae6ff5321e51ce9892R36-R76))

