### PR TITLE
feat: set default size for state

### DIFF
--- a/hash/merkle-damgard.go
+++ b/hash/merkle-damgard.go
@@ -46,7 +46,9 @@ func (h *merkleDamgardHasher) State() []byte {
 }
 
 func (h *merkleDamgardHasher) SetState(state []byte) error {
-	h.state = state
+	bs := h.BlockSize()
+	h.state = make([]byte, bs)
+	copy(h.state, state)
 	return nil
 }
 
@@ -65,9 +67,12 @@ func (h *merkleDamgardHasher) SetState(state []byte) error {
 // function. Its preimage should not be known and thus it should be generated
 // using a deterministic method.
 func NewMerkleDamgardHasher(f Compressor, initialState []byte) StateStorer {
-	return &merkleDamgardHasher{
+	h := merkleDamgardHasher{
 		state: initialState,
-		iv:    initialState,
 		f:     f,
 	}
+	bs := h.BlockSize()
+	h.state = make([]byte, bs)
+	copy(h.state, initialState)
+	return &h
 }

--- a/hash/merkle-damgard.go
+++ b/hash/merkle-damgard.go
@@ -1,5 +1,11 @@
 package hash
 
+import (
+	"errors"
+)
+
+var errStateOverflow = errors.New("the size of the state should not exceed the block size")
+
 type merkleDamgardHasher struct {
 	state []byte
 	iv    []byte
@@ -47,6 +53,9 @@ func (h *merkleDamgardHasher) State() []byte {
 
 func (h *merkleDamgardHasher) SetState(state []byte) error {
 	bs := h.BlockSize()
+	if len(state) > bs {
+		return errStateOverflow
+	}
 	h.state = make([]byte, bs)
 	copy(h.state, state)
 	return nil
@@ -68,8 +77,8 @@ func (h *merkleDamgardHasher) SetState(state []byte) error {
 // using a deterministic method.
 func NewMerkleDamgardHasher(f Compressor, initialState []byte) StateStorer {
 	h := merkleDamgardHasher{
-		state: initialState,
-		f:     f,
+		iv: initialState,
+		f:  f,
 	}
 	bs := h.BlockSize()
 	h.state = make([]byte, bs)


### PR DESCRIPTION
# Description

`SetState` on a StateStorer now ensures that the size of the provided state corresponds to BlockSize.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

