### PR TITLE
fix: MerkleDamgardHasher IV

### DIFF
--- a/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
@@ -108,24 +108,4 @@ func TestHashReset(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, res, h.Sum(nil))
-
-}
-
-func TestHashSingleNonZeroIV(t *testing.T) {
-	// hash a single element using Merkle-Damgard, with a nonzero IV
-	const lastByteMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure it's smaller than the modulus
-	var iv, b [fr.Bytes]byte
-	iv[0] = 1
-	_, err := rand.Read(b[:])
-	require.NoError(t, err)
-	b[0] &= lastByteMask
-	p := Permutation{GetDefaultParameters()}
-	res, err := p.Compress(iv[:], b[:])
-	require.NoError(t, err)
-
-	h := hash.NewMerkleDamgardHasher(&p, iv[:])
-	_, err = h.Write(b[:])
-	require.NoError(t, err)
-
-	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls12-377/fr/poseidon2/poseidon2_test.go
@@ -68,15 +68,16 @@ func BenchmarkPoseidon2(b *testing.B) {
 	}
 }
 
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
 func TestHashSmall(t *testing.T) {
 	// hash two elements using Merkle-Damgard
-	const lastByteMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure it's smaller than the modulus
 	var b [2][fr.Bytes]byte
 	h := NewMerkleDamgardHasher()
 	for i := range b {
 		_, err := rand.Read(b[i][:])
 		require.NoError(t, err)
-		b[i][0] &= lastByteMask
+		b[i][0] &= msbMask
 		_, err = h.Write(b[i][:])
 		require.NoError(t, err)
 	}
@@ -91,12 +92,11 @@ func TestHashSmall(t *testing.T) {
 
 func TestHashReset(t *testing.T) {
 	// hash a single element using Merkle-Damgard and a nonzero IV, twice
-	const lastByteMask = 0xff >> (9 - (fr.Bits % 8))
 	var iv, b [fr.Bytes]byte
 	iv[0] = 1
 	_, err := rand.Read(b[:])
 	require.NoError(t, err)
-	b[0] &= lastByteMask
+	b[0] &= msbMask
 	p := Permutation{GetDefaultParameters()}
 	h := hash.NewMerkleDamgardHasher(&p, iv[:])
 	_, err = h.Write(b[:])

--- a/ecc/bls12-381/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls12-381/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bls24-315/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls24-315/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bls24-317/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bls24-317/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bn254/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bn254/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bw6-633/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bw6-633/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/bw6-761/fr/poseidon2/poseidon2_test.go
+++ b/ecc/bw6-761/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/ecc/grumpkin/fr/poseidon2/poseidon2_test.go
+++ b/ecc/grumpkin/fr/poseidon2/poseidon2_test.go
@@ -6,9 +6,12 @@
 package poseidon2
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/grumpkin/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -63,4 +66,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }

--- a/hash/merkle-damgard.go
+++ b/hash/merkle-damgard.go
@@ -1,10 +1,9 @@
 package hash
 
 import (
-	"errors"
+	"bytes"
+	"fmt"
 )
-
-var errStateOverflow = errors.New("the size of the state should not exceed the block size")
 
 type merkleDamgardHasher struct {
 	state []byte
@@ -17,7 +16,9 @@ func (h *merkleDamgardHasher) Write(p []byte) (n int, err error) {
 	blockSize := h.f.BlockSize()
 	for len(p) != 0 {
 		if len(p) < blockSize {
-			p = append(make([]byte, blockSize-len(p), blockSize), p...)
+			if p, err = cloneLeftPadded(p, blockSize); err != nil {
+				panic(err) // this should not be possible
+			}
 		}
 		if h.state, err = h.f.Compress(h.state, p[:blockSize]); err != nil {
 			return
@@ -36,7 +37,7 @@ func (h *merkleDamgardHasher) Sum(b []byte) []byte {
 }
 
 func (h *merkleDamgardHasher) Reset() {
-	h.state = h.iv
+	h.state = bytes.Clone(h.iv)
 }
 
 func (h *merkleDamgardHasher) Size() int {
@@ -52,16 +53,12 @@ func (h *merkleDamgardHasher) State() []byte {
 }
 
 // SetState sets h's state to state. If len(state) > BlockSize, an error is thrown.
-// if len(state) < BlockSize, h's state is set to state, and left padded with zeroes.
+// If len(state) < BlockSize, h's state is set to state, and left padded with zeroes.
+// len(state) > BlockSize will result in an error.
 func (h *merkleDamgardHasher) SetState(state []byte) error {
-	bs := h.BlockSize()
-	if len(state) > bs {
-		return errStateOverflow
-	}
-	h.state = make([]byte, bs)
-	ss := len(state)
-	copy(h.state[bs-ss:], state)
-	return nil
+	var err error
+	h.state, err = cloneLeftPadded(state, h.BlockSize())
+	return err
 }
 
 // NewMerkleDamgardHasher transforms a 2-1 one-way compression function into a
@@ -75,22 +72,31 @@ func (h *merkleDamgardHasher) SetState(state []byte) error {
 // blocks) is same. For collision resistance the caller should perform explicit
 // padding on the input data.
 //
-// The value initialState is provided as initial input to the compression
+// - initialState is provided as initial input to the compression
 // function. Its preimage should not be known and thus it should be generated
 // using a deterministic method.
+// If the given initialState is shorter than the hash block size, it will be zero-padded
+// on the left. An oversized initialState will cause a panic.
 func NewMerkleDamgardHasher(f Compressor, initialState []byte) StateStorer {
-	h := merkleDamgardHasher{
-		f: f,
+	iv, err := cloneLeftPadded(initialState, f.BlockSize())
+	if err != nil {
+		panic(err)
 	}
-	bs := h.BlockSize()
-	h.state = make([]byte, bs)
-	if len(initialState) > len(h.state) {
-		copy(h.iv, initialState)
-		copy(h.state, initialState)
-	} else { // in that case, we left pad with zeroes
-		is := len(initialState)
-		copy(h.iv[bs-is:], initialState)
-		copy(h.state[bs-is:], initialState)
+	return &merkleDamgardHasher{
+		f:     f,
+		iv:    iv,
+		state: bytes.Clone(iv),
 	}
-	return &h
+}
+
+// cloneLeftPadded copies b into a new byte slice of size n.
+// If len(b) < n, it will be padded on the left.
+// len(b) > n will result in an error.
+func cloneLeftPadded(b []byte, n int) ([]byte, error) {
+	if len(b) > n {
+		return nil, fmt.Errorf("buffer too large: %d > %d", len(b), n)
+	}
+	res := make([]byte, n)
+	copy(res[n-len(b):], b)
+	return res, nil
 }

--- a/internal/generator/crypto/hash/poseidon2/template/poseidon2.test.go.tmpl
+++ b/internal/generator/crypto/hash/poseidon2/template/poseidon2.test.go.tmpl
@@ -1,7 +1,10 @@
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
+	"github.com/consensys/gnark-crypto/hash"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalMatrix(t *testing.T) {
@@ -57,4 +60,46 @@ func BenchmarkPoseidon2(b *testing.B) {
 	for i := 0; i<b.N; i++ {
 		h.Permutation(tmp[:])
 	}
+}
+
+const msbMask = 0xff >> (9 - (fr.Bits % 8)) // to make sure randomized buffers are smaller than the modulus
+
+func TestHashSmall(t *testing.T) {
+	// hash two elements using Merkle-Damgard
+	var b [2][fr.Bytes]byte
+	h := NewMerkleDamgardHasher()
+	for i := range b {
+		_, err := rand.Read(b[i][:])
+		require.NoError(t, err)
+		b[i][0] &= msbMask
+		_, err = h.Write(b[i][:])
+		require.NoError(t, err)
+	}
+	p := Permutation{GetDefaultParameters()}
+	res, err := p.Compress(make([]byte, fr.Bytes), b[0][:])
+	require.NoError(t, err)
+	res, err = p.Compress(res, b[1][:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
+}
+
+func TestHashReset(t *testing.T) {
+	// hash a single element using Merkle-Damgard and a nonzero IV, twice
+	var iv, b [fr.Bytes]byte
+	iv[0] = 1
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	b[0] &= msbMask
+	p := Permutation{GetDefaultParameters()}
+	h := hash.NewMerkleDamgardHasher(&p, iv[:])
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+	res := h.Sum(nil)
+
+	h.Reset()
+	_, err = h.Write(b[:])
+	require.NoError(t, err)
+
+	require.Equal(t, res, h.Sum(nil))
 }


### PR DESCRIPTION
Fixes an incorrect IV initialization that would make the hash fail after a `Reset`.