### PR TITLE
perf: small scalarmul

### DIFF
--- a/ecc/bls12-377/bls12-377.go
+++ b/ecc/bls12-377/bls12-377.go
@@ -77,6 +77,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // ψ o π o ψ⁻¹, where ψ:E → E' is the degree 6 iso defined over 𝔽p¹²
 var endo struct {
 	u fptower.E2
@@ -129,6 +135,8 @@ func init() {
 	lambdaGLV.SetString("91893752504881257701523279626832445440", 10) //(x₀²-1)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	endo.u.A0.SetString("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946")
 	endo.v.A0.SetString("216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499")

--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -727,6 +727,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bls12-377/g1_test.go
+++ b/ecc/bls12-377/g1_test.go
@@ -6,6 +6,7 @@
 package bls12377
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -700,29 +701,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -439,13 +447,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -697,19 +697,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -724,11 +724,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bls12-377/g2_test.go
+++ b/ecc/bls12-377/g2_test.go
@@ -716,6 +716,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bls12-381/bls12-381.go
+++ b/ecc/bls12-381/bls12-381.go
@@ -77,6 +77,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // ψ o π o ψ^{-1}, where ψ:E → E' is the degree 6 iso defined over 𝔽p¹²
 var endo struct {
 	u fptower.E2
@@ -128,6 +134,8 @@ func init() {
 	lambdaGLV.SetString("228988810152649578064853576960394133503", 10) //(x₀²-1)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	endo.u.A0.SetString("0")
 	endo.u.A1.SetString("4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939437")

--- a/ecc/bls12-381/g1.go
+++ b/ecc/bls12-381/g1.go
@@ -52,7 +52,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -61,7 +65,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -442,13 +450,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -736,6 +736,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bls12-381/g1_test.go
+++ b/ecc/bls12-381/g1_test.go
@@ -6,6 +6,7 @@
 package bls12381
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -709,29 +710,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -59,7 +59,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -68,7 +72,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -447,13 +455,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -706,19 +706,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -733,11 +733,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -6,6 +6,7 @@
 package bls12381
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -698,29 +699,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls12-381/g2_test.go
+++ b/ecc/bls12-381/g2_test.go
@@ -725,6 +725,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bls24-315/bls24-315.go
+++ b/ecc/bls24-315/bls24-315.go
@@ -78,6 +78,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // ψ o π o ψ⁻¹, where ψ:E → E' is the degree 6 iso defined over 𝔽p¹²
 var endo struct {
 	u fptower.E4
@@ -141,6 +147,8 @@ func init() {
 	lambdaGLV.SetString("11502027791375260645628074404575422496066855707288983427913398978447461580801", 10) // x₀⁸
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	endo.u.B0.A0.SetString("17432737665785421589107433512831558061649422754130449334965277047994983947893909429238815314776")
 	endo.v.B0.A0.SetString("13266452002786802757645810648664867986567631927642464177452792960815113608167203350720036682455")

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -727,6 +727,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bls24-315/g1_test.go
+++ b/ecc/bls24-315/g1_test.go
@@ -6,6 +6,7 @@
 package bls24315
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -700,29 +701,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -439,13 +447,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -697,19 +697,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -724,11 +724,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -6,6 +6,7 @@
 package bls24315
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -689,29 +690,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls24-315/g2_test.go
+++ b/ecc/bls24-315/g2_test.go
@@ -716,6 +716,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bls24-317/bls24-317.go
+++ b/ecc/bls24-317/bls24-317.go
@@ -78,6 +78,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // ψ o π o ψ⁻¹, where ψ:E → E' is the degree 6 iso defined over 𝔽p¹²
 var endo struct {
 	u fptower.E4
@@ -127,6 +133,8 @@ func init() {
 	lambdaGLV.SetString("30869589236456844204538189757527902584770424025911415822847175497150445387776", 10) // x₀⁸
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	endo.u.B0.A0.SetString("100835231576138384070271140557450756773581004948002542492497192760544145876107391019725843007951")
 	endo.u.B0.A1.SetString("100835231576138384070271140557450756773581004948002542492497192760544145876107391019725843007951")

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -727,6 +727,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bls24-317/g1_test.go
+++ b/ecc/bls24-317/g1_test.go
@@ -6,6 +6,7 @@
 package bls24317
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -700,29 +701,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -439,13 +447,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -697,19 +697,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -724,11 +724,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -6,6 +6,7 @@
 package bls24317
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -689,29 +690,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bls24-317/g2_test.go
+++ b/ecc/bls24-317/g2_test.go
@@ -716,6 +716,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bn254/bn254.go
+++ b/ecc/bn254/bn254.go
@@ -80,6 +80,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // ψ o π o ψ⁻¹, where ψ:E → E' is the degree 6 iso defined over 𝔽p¹²
 var endo struct {
 	u fptower.E2
@@ -133,6 +139,8 @@ func init() {
 	lambdaGLV.SetString("4407920970296243842393367215006156084916469457145843978461", 10) // (36x₀³+18x₀²+6x₀+1)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	endo.u.A0.SetString("21575463638280843010398324269430826099269044274347216827212613867836435027261")
 	endo.u.A1.SetString("10307601595873709700152284273816112264069230130616436755625194854815875713954")

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -431,13 +439,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -688,6 +688,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1JacAdd(b *testing.B) {
 	var a G1Jac
 	a.Double(&g1Gen)

--- a/ecc/bn254/g1_test.go
+++ b/ecc/bn254/g1_test.go
@@ -6,6 +6,7 @@
 package bn254
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -661,29 +662,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1JacAdd(b *testing.B) {

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -452,13 +460,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -703,19 +703,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -730,11 +730,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -722,6 +722,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bn254/g2_test.go
+++ b/ecc/bn254/g2_test.go
@@ -6,6 +6,7 @@
 package bn254
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -695,29 +696,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bw6-633/bw6-633.go
+++ b/ecc/bw6-633/bw6-633.go
@@ -75,6 +75,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // seed -x₀ of the curve
 var xGen big.Int
 
@@ -114,6 +120,8 @@ func init() {
 	lambdaGLV.SetString("39705142672498995661671850106945620852186608752525090699191017895721506694646055668218723303426", 10) // 1-x+2*x²-2*x³+3*x⁵-4*x⁶+4*x⁷-3*x⁸+x⁹
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	// -x₀
 	xGen.SetString("3218079743", 10) // negative

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -727,6 +727,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bw6-633/g1_test.go
+++ b/ecc/bw6-633/g1_test.go
@@ -6,6 +6,7 @@
 package bw6633
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -700,29 +701,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bw6-633/g2.go
+++ b/ecc/bw6-633/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -439,13 +447,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -6,6 +6,7 @@
 package bw6633
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -670,29 +671,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -697,6 +697,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bw6-633/g2_test.go
+++ b/ecc/bw6-633/g2_test.go
@@ -678,19 +678,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -705,11 +705,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/bw6-761/bw6-761.go
+++ b/ecc/bw6-761/bw6-761.go
@@ -79,6 +79,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 // seed x₀ of the curve
 var xGen big.Int
 
@@ -123,6 +129,8 @@ func init() {
 	lambdaGLV.SetString("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945", 10) // (x⁵-3x⁴+3x³-x+1)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	// x₀
 	xGen.SetString("9586122913090633729", 10)

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -727,6 +727,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {
 	var a G1Jac
 	a.Set(&g1Gen)

--- a/ecc/bw6-761/g1_test.go
+++ b/ecc/bw6-761/g1_test.go
@@ -6,6 +6,7 @@
 package bw6761
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -700,29 +701,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1AffineCofactorClearing(b *testing.B) {

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -57,7 +57,11 @@ func (p *G2Affine) SetInfinity() *G2Affine {
 func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 	var _p G2Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -66,7 +70,11 @@ func (p *G2Affine) ScalarMultiplication(a *G2Affine, s *big.Int) *G2Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G2Affine) ScalarMultiplicationBase(s *big.Int) *G2Affine {
 	var _p G2Jac
-	_p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		_p.mulGLV(&g2Gen, s)
+	} else {
+		_p.mulWindowed(&g2Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -439,13 +447,21 @@ func (p *G2Jac) DoubleAssign() *G2Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G2Jac) ScalarMultiplication(q *G2Jac, s *big.Int) *G2Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G2Jac) ScalarMultiplicationBase(s *big.Int) *G2Jac {
-	return p.mulGLV(&g2Gen, s)
+	if s.BitLen() >= g2ScalarMulChoose {
+		return p.mulGLV(&g2Gen, s)
+	} else {
+		return p.mulWindowed(&g2Gen, s)
+	}
 
 }
 

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -697,6 +697,24 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {
 	var a G2Jac
 	a.Set(&g2Gen)

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -6,6 +6,7 @@
 package bw6761
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -670,29 +671,30 @@ func BenchmarkG2AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG2JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G2Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g2Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G2Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g2Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG2AffineCofactorClearing(b *testing.B) {

--- a/ecc/bw6-761/g2_test.go
+++ b/ecc/bw6-761/g2_test.go
@@ -678,19 +678,19 @@ func BenchmarkG2JacScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd G2Jac
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&g2Gen, scalar)
 			}
 		})
 
-		var glv G1Jac
+		var glv G2Jac
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&g2Gen, scalar)
 			}
 		})
 
@@ -705,11 +705,11 @@ func BenchmarkG2JacScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res G2Jac
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&g2Gen, scalar)
 			}
 		})
 	}

--- a/ecc/grumpkin/g1.go
+++ b/ecc/grumpkin/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/grumpkin/g1_test.go
+++ b/ecc/grumpkin/g1_test.go
@@ -6,6 +6,7 @@
 package grumpkin
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
@@ -661,29 +662,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1JacAdd(b *testing.B) {

--- a/ecc/grumpkin/g1_test.go
+++ b/ecc/grumpkin/g1_test.go
@@ -688,6 +688,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1JacAdd(b *testing.B) {
 	var a G1Jac
 	a.Double(&g1Gen)

--- a/ecc/grumpkin/grumpkin.go
+++ b/ecc/grumpkin/grumpkin.go
@@ -56,6 +56,12 @@ var xGen big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 func init() {
 	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(17).Neg(&bCurveCoeff)
@@ -74,6 +80,8 @@ func init() {
 	lambdaGLV.SetString("2203960485148121921418603742825762020974279258880205651966", 10)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 
 	xGen.SetString("4965661367192848881", 10)
 }

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -51,7 +51,11 @@ func (p *G1Affine) SetInfinity() *G1Affine {
 func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 	var _p G1Jac
 	_p.FromAffine(a)
-	_p.mulGLV(&_p, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&_p, s)
+	} else {
+		_p.mulWindowed(&_p, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -60,7 +64,11 @@ func (p *G1Affine) ScalarMultiplication(a *G1Affine, s *big.Int) *G1Affine {
 // where g is the affine point generating the prime subgroup.
 func (p *G1Affine) ScalarMultiplicationBase(s *big.Int) *G1Affine {
 	var _p G1Jac
-	_p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		_p.mulGLV(&g1Gen, s)
+	} else {
+		_p.mulWindowed(&g1Gen, s)
+	}
 	p.FromJacobian(&_p)
 	return p
 }
@@ -433,13 +441,21 @@ func (p *G1Jac) DoubleAssign() *G1Jac {
 // using the GLV technique.
 // see https://www.iacr.org/archive/crypto2001/21390189.pdf
 func (p *G1Jac) ScalarMultiplication(q *G1Jac, s *big.Int) *G1Jac {
-	return p.mulGLV(q, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(q, s)
+	} else {
+		return p.mulWindowed(q, s)
+	}
 }
 
 // ScalarMultiplicationBase computes and returns p = [s]g
 // where g is the prime subgroup generator.
 func (p *G1Jac) ScalarMultiplicationBase(s *big.Int) *G1Jac {
-	return p.mulGLV(&g1Gen, s)
+	if s.BitLen() >= g1ScalarMulChoose {
+		return p.mulGLV(&g1Gen, s)
+	} else {
+		return p.mulWindowed(&g1Gen, s)
+	}
 
 }
 

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -688,6 +688,24 @@ func BenchmarkG1JacScalarMultiplication(b *testing.B) {
 	}
 }
 
+func BenchmarkG1JacScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 func BenchmarkG1JacAdd(b *testing.B) {
 	var a G1Jac
 	a.Double(&g1Gen)

--- a/ecc/secp256k1/g1_test.go
+++ b/ecc/secp256k1/g1_test.go
@@ -6,12 +6,11 @@
 package secp256k1
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
 	"testing"
-
-	crand "crypto/rand"
 
 	"github.com/consensys/gnark-crypto/ecc/secp256k1/fp"
 
@@ -663,29 +662,30 @@ func BenchmarkG1AffineBatchScalarMultiplication(b *testing.B) {
 }
 
 func BenchmarkG1JacScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd G1Jac
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&g1Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-	var glv G1Jac
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&g1Gen, &scalar)
-		}
-	})
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
 
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+
+	}
 }
 
 func BenchmarkG1JacAdd(b *testing.B) {

--- a/ecc/secp256k1/secp256k1.go
+++ b/ecc/secp256k1/secp256k1.go
@@ -52,6 +52,12 @@ var lambdaGLV big.Int
 // in ker((u,v) → u+vλ[r]), and their determinant
 var glvBasis ecc.Lattice
 
+// g1ScalarMulChoose and g2ScalarmulChoose indicate the bitlength of the scalar
+// in scalar multiplication from which it is more efficient to use the GLV
+// decomposition. It is computed from the GLV basis and considers the overhead
+// for the GLV decomposition. It is heuristic and may change in the future.
+var g1ScalarMulChoose, g2ScalarMulChoose int
+
 func init() {
 	aCurveCoeff.SetUint64(0)
 	bCurveCoeff.SetUint64(7)
@@ -70,7 +76,8 @@ func init() {
 	lambdaGLV.SetString("37718080363155996902926221483475020450927657555482586988616620542887997980018", 10)  // 3^((r-1)/3)
 	_r := fr.Modulus()
 	ecc.PrecomputeLattice(_r, &lambdaGLV, &glvBasis)
-
+	g1ScalarMulChoose = fr.Bits/16 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
+	g2ScalarMulChoose = fr.Bits/32 + max(glvBasis.V1[0].BitLen(), glvBasis.V1[1].BitLen(), glvBasis.V2[0].BitLen(), glvBasis.V2[1].BitLen())
 }
 
 // Generators return the generators of the r-torsion group, resp. in ker(pi-id), ker(Tr)

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -75,7 +75,11 @@ func (p *{{ $TAffine }}) ScalarMultiplication(a *{{ $TAffine }}, s *big.Int) *{{
 	var _p {{ $TJacobian }}
 	_p.FromAffine(a)
 	{{- if .GLV}}
-        _p.mulGLV(&_p, s)
+		if s.BitLen() >= {{ .PointName }}ScalarMulChoose {
+			_p.mulGLV(&_p, s)
+		} else {
+			_p.mulWindowed(&_p, s)
+		}
 	{{- else }}
         _p.mulWindowed(&_p, s)
 	{{- end }}
@@ -88,7 +92,11 @@ func (p *{{ $TAffine }}) ScalarMultiplication(a *{{ $TAffine }}, s *big.Int) *{{
 func (p *{{ $TAffine }}) ScalarMultiplicationBase(s *big.Int) *{{ $TAffine }} {
 	var _p {{ $TJacobian }}
 	{{- if .GLV}}
-	_p.mulGLV(&{{ toLower .PointName}}Gen, s)
+		if s.BitLen() >= {{ .PointName }}ScalarMulChoose {
+			_p.mulGLV(&{{ toLower .PointName}}Gen, s)
+		} else {
+			_p.mulWindowed(&{{ toLower .PointName}}Gen, s)
+		}
 	{{- else }}
         _p.mulWindowed(&{{ toLower .PointName}}Gen, s)
 	{{- end }}
@@ -523,7 +531,11 @@ func (p *{{ $TJacobian }}) DoubleAssign() *{{ $TJacobian }} {
 {{- end }}
 func (p *{{ $TJacobian }}) ScalarMultiplication(q *{{ $TJacobian }}, s *big.Int) *{{ $TJacobian }} {
 	{{- if .GLV}}
-		return p.mulGLV(q, s)
+		if s.BitLen() >= {{ .PointName }}ScalarMulChoose {
+			return p.mulGLV(q, s)
+		} else {
+			return p.mulWindowed(q, s)
+		}
 	{{- else }}
 		return p.mulWindowed(q, s)
 	{{- end }}
@@ -533,9 +545,13 @@ func (p *{{ $TJacobian }}) ScalarMultiplication(q *{{ $TJacobian }}, s *big.Int)
 // where g is the prime subgroup generator.
 func (p *{{ $TJacobian  }}) ScalarMultiplicationBase(s *big.Int) *{{ $TJacobian  }} {
     {{- if .GLV}}
-        return p.mulGLV(&{{ toLower .PointName }}Gen, s)
+		if s.BitLen() >= {{ .PointName }}ScalarMulChoose {
+			return p.mulGLV(&{{ toLower .PointName }}Gen, s)
+		} else {
+			return p.mulWindowed(&{{ toLower .PointName }}Gen, s)
+		}
     {{- else }}
-        _p.mulWindowed(&{{ toLower .PointName }}Gen, s)
+        return p.mulWindowed(&{{ toLower .PointName }}Gen, s)
     {{- end }}
 
 }

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -818,6 +818,24 @@ func Benchmark{{ $TJacobian }}ScalarMultiplication(b *testing.B) {
 	}
 }
 
+func Benchmark{{ $TJacobian }}ScalarMultiplicationMethod(b *testing.B) {
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
+		}
+
+		var res G1Jac
+		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				res.ScalarMultiplication(&g1Gen, scalar)
+			}
+		})
+	}
+}
+
 {{if .CofactorCleaning}}
 func Benchmark{{ $TAffine }}CofactorClearing(b *testing.B) {
 	var a {{ $TJacobian }}

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -799,19 +799,19 @@ func Benchmark{{ $TJacobian }}ScalarMultiplication(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var doubleAndAdd G1Jac
+		var doubleAndAdd {{ $TJacobian }}
 		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+				doubleAndAdd.mulWindowed(&{{ .PointName }}Gen, scalar)
 			}
 		})
 		{{ if .GLV }}
-		var glv G1Jac
+		var glv {{ $TJacobian }}
 		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				glv.mulGLV(&g1Gen, scalar)
+				glv.mulGLV(&{{ .PointName }}Gen, scalar)
 			}
 		})
 		{{ end }}
@@ -826,11 +826,11 @@ func Benchmark{{ $TJacobian }}ScalarMultiplicationMethod(b *testing.B) {
 			b.Fatalf("failed to generate random scalar: %v", err)
 		}
 
-		var res G1Jac
+		var res {{ $TJacobian }}
 		b.Run(fmt.Sprintf("scalarwidth=%d", i), func(b *testing.B) {
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
-				res.ScalarMultiplication(&g1Gen, scalar)
+				res.ScalarMultiplication(&{{ .PointName }}Gen, scalar)
 			}
 		})
 	}

--- a/internal/generator/ecc/template/tests/point.go.tmpl
+++ b/internal/generator/ecc/template/tests/point.go.tmpl
@@ -20,10 +20,7 @@ import (
 	"math/big"
 	"testing"
 	"math/rand/v2"
-
-	{{if eq .Name "secp256k1"}}
-		crand "crypto/rand"
-	{{end}}
+	crand "crypto/rand"
 
 	{{if or (eq .CoordType "fptower.E2") (eq .CoordType "fptower.E4")}}
 	"github.com/consensys/gnark-crypto/ecc/{{.Name}}/internal/fptower"
@@ -795,33 +792,31 @@ func Benchmark{{ $TAffine }}BatchScalarMultiplication(b *testing.B) {
 }
 
 func Benchmark{{ $TJacobian }}ScalarMultiplication(b *testing.B) {
-
-	var scalar big.Int
-	r := fr.Modulus()
-	scalar.SetString("5243587517512619047944770508185965837690552500527637822603658699938581184513", 10)
-	scalar.Add(&scalar, r)
-
-	var doubleAndAdd {{ $TJacobian }}
-
-	b.Run("double and add", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			doubleAndAdd.mulWindowed(&{{.PointName}}Gen, &scalar)
+	for i := 0; i <= fr.Modulus().BitLen(); i += 8 {
+		bound := new(big.Int).Lsh(big.NewInt(1), uint(i))
+		scalar, err := crand.Int(crand.Reader, bound)
+		if err != nil {
+			b.Fatalf("failed to generate random scalar: %v", err)
 		}
-	})
 
-    {{if .GLV}}
-	var glv {{ $TJacobian }}
-	b.Run("GLV", func(b *testing.B) {
-		b.ResetTimer()
-		for j := 0; j < b.N; j++ {
-			glv.mulGLV(&{{.PointName}}Gen, &scalar)
-		}
-	})
-    {{end}}
-
+		var doubleAndAdd G1Jac
+		b.Run(fmt.Sprintf("method=window/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				doubleAndAdd.mulWindowed(&g1Gen, scalar)
+			}
+		})
+		{{ if .GLV }}
+		var glv G1Jac
+		b.Run(fmt.Sprintf("method=GLV/scalarwidth=%d", i), func(b *testing.B) {
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				glv.mulGLV(&g1Gen, scalar)
+			}
+		})
+		{{ end }}
+	}
 }
-
 
 {{if .CofactorCleaning}}
 func Benchmark{{ $TAffine }}CofactorClearing(b *testing.B) {


### PR DESCRIPTION
# Description

This PR implements switching scalar multiplication to windowed method when scalars are small (according to some heuristic).

Fixes #702

[g1-method-stat.txt](https://github.com/user-attachments/files/20905194/g1-method-stat.txt)
[g2-method-stat.txt](https://github.com/user-attachments/files/20906677/g2-method-stat.txt)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Scalar multiplication consistency has already been checked before using gopter.


# How has this been benchmarked?

G1
```
goos: linux
goarch: amd64
pkg: github.com/consensys/gnark-crypto/ecc/bls12-377
cpu: AMD Ryzen 9 7940HS w/ Radeon 780M Graphics     
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         19387.0n ± 1%   655.2n ± 6%  -96.62% (p=0.002 n=6)
8          20.355µ ± 2%   2.468µ ± 1%  -87.88% (p=0.002 n=6)
16         21.205µ ± 1%   7.126µ ± 0%  -66.39% (p=0.002 n=6)
24         22.812µ ± 0%   9.316µ ± 1%  -59.16% (p=0.002 n=6)
32          23.74µ ± 1%   12.37µ ± 1%  -47.90% (p=0.002 n=6)
40          26.18µ ± 0%   15.80µ ± 0%  -39.65% (p=0.002 n=6)
48          26.61µ ± 1%   19.21µ ± 0%  -27.81% (p=0.002 n=6)
56          27.59µ ± 0%   21.81µ ± 0%  -20.93% (p=0.002 n=6)
64          29.25µ ± 0%   23.68µ ± 0%  -19.03% (p=0.002 n=6)
72          45.14µ ± 0%   26.73µ ± 0%  -40.78% (p=0.002 n=6)
80          45.96µ ± 1%   30.12µ ± 0%  -34.47% (p=0.002 n=6)
88          48.92µ ± 0%   34.11µ ± 0%  -30.27% (p=0.002 n=6)
96          49.90µ ± 1%   36.22µ ± 0%  -27.40% (p=0.002 n=6)
104         50.16µ ± 1%   37.63µ ± 0%  -24.98% (p=0.002 n=6)
112         49.37µ ± 1%   43.48µ ± 1%  -11.93% (p=0.002 n=6)
120         53.09µ ± 1%   43.64µ ± 0%  -17.81% (p=0.002 n=6)
128         52.25µ ± 1%   50.38µ ± 0%   -3.58% (p=0.002 n=6)
136         54.06µ ± 0%   51.46µ ± 1%   -4.81% (p=0.002 n=6)
144         53.32µ ± 0%   52.07µ ± 1%   -2.36% (p=0.002 n=6)
152         54.84µ ± 0%   54.78µ ± 0%        ~ (p=0.221 n=6)
160         52.51µ ± 1%   54.54µ ± 1%   +3.86% (p=0.002 n=6)
168         58.24µ ± 0%   53.75µ ± 0%   -7.72% (p=0.002 n=6)
176         54.13µ ± 0%   56.57µ ± 1%   +4.50% (p=0.002 n=6)
184         56.95µ ± 1%   57.85µ ± 1%   +1.58% (p=0.002 n=6)
192         55.35µ ± 1%   55.46µ ± 1%        ~ (p=0.240 n=6)
200         56.73µ ± 1%   56.29µ ± 0%   -0.78% (p=0.002 n=6)
208         57.00µ ± 0%   57.46µ ± 1%   +0.80% (p=0.002 n=6)
216         54.96µ ± 0%   57.13µ ± 0%   +3.96% (p=0.002 n=6)
224         56.27µ ± 1%   56.85µ ± 1%   +1.03% (p=0.004 n=6)
232         57.83µ ± 0%   56.64µ ± 1%   -2.05% (p=0.002 n=6)
240         59.08µ ± 0%   58.09µ ± 1%   -1.68% (p=0.002 n=6)
248         59.07µ ± 0%   58.00µ ± 0%   -1.81% (p=0.002 n=6)
geomean     42.69µ        29.57µ       -30.73%

pkg: github.com/consensys/gnark-crypto/ecc/bls12-381
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         19823.5n ± 1%   661.1n ± 0%  -96.67% (p=0.002 n=6)
8          21.224µ ± 0%   3.317µ ± 0%  -84.37% (p=0.002 n=6)
16         21.217µ ± 0%   5.511µ ± 0%  -74.03% (p=0.002 n=6)
24         23.590µ ± 1%   9.374µ ± 0%  -60.26% (p=0.002 n=6)
32          24.02µ ± 0%   12.80µ ± 1%  -46.74% (p=0.002 n=6)
40          25.27µ ± 1%   14.66µ ± 1%  -41.97% (p=0.002 n=6)
48          26.05µ ± 1%   17.62µ ± 1%  -32.36% (p=0.002 n=6)
56          28.53µ ± 1%   21.45µ ± 0%  -24.83% (p=0.002 n=6)
64          28.47µ ± 0%   23.25µ ± 0%  -18.35% (p=0.002 n=6)
72          46.41µ ± 0%   27.93µ ± 0%  -39.82% (p=0.002 n=6)
80          46.74µ ± 1%   30.50µ ± 1%  -34.73% (p=0.002 n=6)
88          48.00µ ± 0%   33.15µ ± 0%  -30.93% (p=0.002 n=6)
96          49.75µ ± 1%   38.62µ ± 0%  -22.36% (p=0.002 n=6)
104         48.41µ ± 0%   40.01µ ± 0%  -17.35% (p=0.002 n=6)
112         50.93µ ± 0%   41.40µ ± 1%  -18.73% (p=0.002 n=6)
120         51.25µ ± 0%   46.90µ ± 0%   -8.48% (p=0.002 n=6)
128         55.76µ ± 0%   50.42µ ± 1%   -9.58% (p=0.002 n=6)
136         54.83µ ± 1%   53.75µ ± 0%   -1.97% (p=0.002 n=6)
144         55.69µ ± 2%   54.32µ ± 0%   -2.46% (p=0.002 n=6)
152         54.58µ ± 0%   56.33µ ± 0%   +3.22% (p=0.002 n=6)
160         54.16µ ± 0%   55.38µ ± 0%   +2.24% (p=0.002 n=6)
168         56.22µ ± 0%   55.82µ ± 0%   -0.72% (p=0.002 n=6)
176         56.27µ ± 0%   55.02µ ± 1%   -2.22% (p=0.002 n=6)
184         54.87µ ± 0%   56.17µ ± 0%   +2.38% (p=0.002 n=6)
192         57.19µ ± 0%   55.88µ ± 0%   -2.28% (p=0.002 n=6)
200         56.52µ ± 0%   56.43µ ± 0%        ~ (p=0.240 n=6)
208         57.59µ ± 0%   58.46µ ± 0%   +1.51% (p=0.002 n=6)
216         57.09µ ± 0%   57.55µ ± 0%   +0.81% (p=0.002 n=6)
224         57.58µ ± 0%   57.58µ ± 1%        ~ (p=0.554 n=6)
232         57.17µ ± 1%   59.21µ ± 0%   +3.57% (p=0.002 n=6)
240         58.45µ ± 0%   58.39µ ± 0%        ~ (p=0.180 n=6)
248         58.10µ ± 0%   58.78µ ± 1%   +1.18% (p=0.002 n=6)
geomean     42.98µ        29.84µ       -30.58%

pkg: github.com/consensys/gnark-crypto/ecc/bls24-315
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         15535.0n ± 1%   521.4n ± 0%  -96.64% (p=0.002 n=6)
8          16.767µ ± 0%   2.931µ ± 0%  -82.52% (p=0.002 n=6)
16         17.058µ ± 0%   4.657µ ± 1%  -72.70% (p=0.002 n=6)
24         18.636µ ± 1%   7.044µ ± 0%  -62.20% (p=0.002 n=6)
32          19.55µ ± 1%   10.71µ ± 0%  -45.23% (p=0.002 n=6)
40          18.96µ ± 0%   12.44µ ± 0%  -34.41% (p=0.002 n=6)
48          21.48µ ± 0%   14.14µ ± 0%  -34.16% (p=0.002 n=6)
56          20.51µ ± 1%   16.79µ ± 0%  -18.13% (p=0.002 n=6)
64          23.31µ ± 0%   18.25µ ± 0%  -21.71% (p=0.002 n=6)
72          36.31µ ± 1%   21.91µ ± 1%  -39.66% (p=0.002 n=6)
80          37.12µ ± 0%   23.37µ ± 0%  -37.04% (p=0.002 n=6)
88          38.19µ ± 1%   25.37µ ± 0%  -33.56% (p=0.002 n=6)
96          36.85µ ± 0%   28.34µ ± 0%  -23.10% (p=0.002 n=6)
104         40.04µ ± 0%   31.38µ ± 1%  -21.65% (p=0.002 n=6)
112         39.91µ ± 1%   33.38µ ± 0%  -16.35% (p=0.002 n=6)
120         40.27µ ± 0%   36.76µ ± 0%   -8.73% (p=0.002 n=6)
128         42.80µ ± 0%   35.33µ ± 1%  -17.47% (p=0.002 n=6)
136         42.55µ ± 1%   41.52µ ± 0%   -2.40% (p=0.002 n=6)
144         42.15µ ± 0%   40.33µ ± 0%   -4.31% (p=0.002 n=6)
152         42.21µ ± 0%   44.19µ ± 0%   +4.68% (p=0.002 n=6)
160         41.81µ ± 0%   42.28µ ± 0%   +1.11% (p=0.002 n=6)
168         42.16µ ± 0%   43.51µ ± 0%   +3.20% (p=0.002 n=6)
176         42.47µ ± 0%   43.89µ ± 0%   +3.33% (p=0.002 n=6)
184         44.51µ ± 1%   43.21µ ± 0%   -2.91% (p=0.002 n=6)
192         43.90µ ± 0%   44.85µ ± 0%   +2.15% (p=0.002 n=6)
200         44.78µ ± 1%   44.15µ ± 0%   -1.39% (p=0.002 n=6)
208         44.29µ ± 0%   44.47µ ± 0%   +0.41% (p=0.009 n=6)
216         45.49µ ± 0%   43.24µ ± 0%   -4.93% (p=0.002 n=6)
224         44.49µ ± 0%   44.96µ ± 1%   +1.06% (p=0.002 n=6)
232         45.23µ ± 1%   44.88µ ± 0%   -0.77% (p=0.002 n=6)
240         45.09µ ± 0%   46.20µ ± 0%   +2.45% (p=0.002 n=6)
248         46.37µ ± 0%   45.79µ ± 0%   -1.24% (p=0.002 n=6)
geomean     33.59µ        23.35µ       -30.50%

pkg: github.com/consensys/gnark-crypto/ecc/bls24-317
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         15299.0n ± 0%   521.9n ± 0%  -96.59% (p=0.002 n=6)
8          16.090µ ± 0%   1.951µ ± 0%  -87.87% (p=0.002 n=6)
16         17.067µ ± 0%   4.648µ ± 0%  -72.76% (p=0.002 n=6)
24         17.722µ ± 0%   6.708µ ± 1%  -62.15% (p=0.002 n=6)
32         18.429µ ± 1%   9.699µ ± 0%  -47.37% (p=0.002 n=6)
40          19.36µ ± 0%   11.12µ ± 0%  -42.57% (p=0.002 n=6)
48          20.67µ ± 0%   13.20µ ± 0%  -36.15% (p=0.002 n=6)
56          21.35µ ± 0%   16.83µ ± 1%  -21.16% (p=0.002 n=6)
64          22.69µ ± 0%   17.34µ ± 1%  -23.56% (p=0.002 n=6)
72          35.63µ ± 0%   21.32µ ± 0%  -40.17% (p=0.002 n=6)
80          35.93µ ± 0%   25.56µ ± 1%  -28.87% (p=0.002 n=6)
88          39.26µ ± 1%   26.97µ ± 0%  -31.31% (p=0.002 n=6)
96          37.56µ ± 0%   28.07µ ± 0%  -25.25% (p=0.002 n=6)
104         38.91µ ± 0%   29.52µ ± 1%  -24.13% (p=0.002 n=6)
112         40.92µ ± 0%   34.78µ ± 1%  -15.00% (p=0.002 n=6)
120         42.80µ ± 0%   36.51µ ± 0%  -14.69% (p=0.002 n=6)
128         43.44µ ± 0%   38.52µ ± 0%  -11.33% (p=0.002 n=6)
136         41.35µ ± 1%   39.94µ ± 1%   -3.40% (p=0.002 n=6)
144         41.57µ ± 1%   41.77µ ± 0%   +0.47% (p=0.041 n=6)
152         41.20µ ± 0%   42.00µ ± 0%   +1.95% (p=0.002 n=6)
160         41.94µ ± 0%   42.88µ ± 0%   +2.24% (p=0.002 n=6)
168         43.47µ ± 0%   41.64µ ± 0%   -4.22% (p=0.002 n=6)
176         44.10µ ± 0%   44.29µ ± 0%   +0.44% (p=0.002 n=6)
184         44.51µ ± 1%   43.62µ ± 1%   -2.00% (p=0.002 n=6)
192         44.05µ ± 0%   44.60µ ± 1%   +1.25% (p=0.002 n=6)
200         42.90µ ± 0%   47.13µ ± 0%   +9.86% (p=0.002 n=6)
208         44.10µ ± 0%   44.49µ ± 0%   +0.87% (p=0.002 n=6)
216         44.45µ ± 0%   46.13µ ± 0%   +3.79% (p=0.002 n=6)
224         45.73µ ± 0%   44.90µ ± 0%   -1.81% (p=0.002 n=6)
232         45.06µ ± 1%   45.88µ ± 0%   +1.83% (p=0.002 n=6)
240         44.08µ ± 1%   46.82µ ± 0%   +6.23% (p=0.002 n=6)
248         46.47µ ± 0%   46.16µ ± 0%   -0.67% (p=0.002 n=6)
geomean     33.42µ        22.98µ       -31.25%

pkg: github.com/consensys/gnark-crypto/ecc/bn254
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         10963.0n ± 0%   365.1n ± 1%  -96.67% (p=0.002 n=6)
8          11.593µ ± 0%   1.385µ ± 0%  -88.05% (p=0.002 n=6)
16         11.813µ ± 0%   3.337µ ± 1%  -71.75% (p=0.002 n=6)
24         13.206µ ± 0%   5.264µ ± 0%  -60.14% (p=0.002 n=6)
32         13.710µ ± 2%   6.480µ ± 1%  -52.73% (p=0.002 n=6)
40         14.130µ ± 0%   8.899µ ± 0%  -37.02% (p=0.002 n=6)
48          15.79µ ± 0%   10.57µ ± 0%  -33.09% (p=0.002 n=6)
56          15.80µ ± 0%   11.15µ ± 0%  -29.42% (p=0.002 n=6)
64          16.52µ ± 0%   14.02µ ± 0%  -15.11% (p=0.002 n=6)
72          24.90µ ± 0%   14.72µ ± 0%  -40.86% (p=0.002 n=6)
80          26.69µ ± 0%   16.92µ ± 1%  -36.60% (p=0.002 n=6)
88          27.41µ ± 2%   17.93µ ± 0%  -34.58% (p=0.002 n=6)
96          28.74µ ± 0%   21.05µ ± 1%  -26.76% (p=0.002 n=6)
104         27.15µ ± 1%   22.21µ ± 1%  -18.20% (p=0.002 n=6)
112         29.64µ ± 0%   23.07µ ± 0%  -22.18% (p=0.002 n=6)
120         30.09µ ± 0%   23.77µ ± 0%  -21.02% (p=0.002 n=6)
128         30.86µ ± 0%   27.17µ ± 0%  -11.97% (p=0.002 n=6)
136         31.22µ ± 0%   29.96µ ± 0%   -4.05% (p=0.002 n=6)
144         32.35µ ± 2%   32.48µ ± 1%        ~ (p=0.180 n=6)
152         33.04µ ± 0%   32.89µ ± 2%        ~ (p=0.065 n=6)
160         31.50µ ± 0%   32.87µ ± 0%   +4.33% (p=0.002 n=6)
168         32.55µ ± 0%   32.86µ ± 0%   +0.97% (p=0.002 n=6)
176         32.98µ ± 0%   32.83µ ± 0%   -0.46% (p=0.002 n=6)
184         31.96µ ± 0%   32.65µ ± 1%   +2.15% (p=0.002 n=6)
192         32.37µ ± 0%   32.60µ ± 0%   +0.72% (p=0.002 n=6)
200         33.09µ ± 1%   33.71µ ± 1%   +1.89% (p=0.002 n=6)
208         32.17µ ± 0%   32.51µ ± 0%   +1.05% (p=0.002 n=6)
216         33.45µ ± 0%   32.93µ ± 0%   -1.55% (p=0.002 n=6)
224         33.03µ ± 0%   32.93µ ± 1%        ~ (p=0.093 n=6)
232         33.23µ ± 0%   33.37µ ± 0%   +0.41% (p=0.009 n=6)
240         33.71µ ± 0%   33.72µ ± 0%        ~ (p=0.974 n=6)
248         33.27µ ± 1%   33.54µ ± 0%   +0.80% (p=0.026 n=6)
geomean     24.58µ        16.73µ       -31.94%

pkg: github.com/consensys/gnark-crypto/ecc/bw6-633
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         49.474µ ± 0%   1.660µ ± 1%  -96.64% (p=0.002 n=6)
8         52.756µ ± 1%   9.395µ ± 0%  -82.19% (p=0.002 n=6)
16         53.86µ ± 1%   17.03µ ± 0%  -68.38% (p=0.002 n=6)
24         56.48µ ± 2%   24.73µ ± 0%  -56.21% (p=0.002 n=6)
32         64.59µ ± 0%   29.28µ ± 0%  -54.67% (p=0.002 n=6)
40         63.71µ ± 1%   37.85µ ± 0%  -40.60% (p=0.002 n=6)
48         65.64µ ± 0%   45.69µ ± 0%  -30.40% (p=0.002 n=6)
56         70.10µ ± 0%   54.39µ ± 1%  -22.42% (p=0.002 n=6)
64         72.93µ ± 1%   61.99µ ± 0%  -15.00% (p=0.002 n=6)
72        113.86µ ± 0%   65.46µ ± 0%  -42.51% (p=0.002 n=6)
80        118.33µ ± 0%   75.16µ ± 0%  -36.48% (p=0.002 n=6)
88        121.59µ ± 1%   86.88µ ± 0%  -28.54% (p=0.002 n=6)
96        120.94µ ± 0%   93.72µ ± 1%  -22.51% (p=0.002 n=6)
104        126.9µ ± 0%   101.7µ ± 0%  -19.87% (p=0.002 n=6)
112        132.9µ ± 1%   105.1µ ± 0%  -20.92% (p=0.002 n=6)
120        134.1µ ± 1%   110.5µ ± 1%  -17.54% (p=0.002 n=6)
128        137.4µ ± 0%   123.5µ ± 0%  -10.08% (p=0.002 n=6)
136        177.4µ ± 0%   133.4µ ± 0%  -24.82% (p=0.002 n=6)
144        180.4µ ± 1%   141.2µ ± 0%  -21.76% (p=0.002 n=6)
152        179.7µ ± 0%   145.8µ ± 0%  -18.86% (p=0.002 n=6)
160        188.4µ ± 0%   153.6µ ± 1%  -18.49% (p=0.002 n=6)
168        191.1µ ± 0%   164.2µ ± 0%  -14.09% (p=0.002 n=6)
176        187.9µ ± 0%   163.2µ ± 0%  -13.12% (p=0.002 n=6)
184        185.7µ ± 0%   185.6µ ± 0%        ~ (p=0.240 n=6)
192        189.9µ ± 1%   191.6µ ± 1%   +0.93% (p=0.002 n=6)
200        193.4µ ± 1%   190.8µ ± 0%   -1.37% (p=0.002 n=6)
208        190.9µ ± 0%   188.8µ ± 0%   -1.08% (p=0.002 n=6)
216        195.3µ ± 0%   196.1µ ± 0%   +0.41% (p=0.004 n=6)
224        193.3µ ± 1%   196.2µ ± 1%   +1.52% (p=0.002 n=6)
232        193.4µ ± 0%   196.7µ ± 1%   +1.68% (p=0.002 n=6)
240        198.6µ ± 0%   201.5µ ± 1%   +1.46% (p=0.002 n=6)
248        198.8µ ± 0%   198.2µ ± 0%   -0.31% (p=0.015 n=6)
256        198.8µ ± 1%   197.0µ ± 0%   -0.92% (p=0.002 n=6)
264        196.7µ ± 0%   196.1µ ± 0%        ~ (p=0.394 n=6)
272        198.6µ ± 0%   199.3µ ± 0%   +0.37% (p=0.002 n=6)
280        198.7µ ± 0%   201.5µ ± 0%   +1.40% (p=0.002 n=6)
288        198.9µ ± 0%   200.4µ ± 1%   +0.72% (p=0.002 n=6)
296        201.2µ ± 0%   202.5µ ± 1%   +0.66% (p=0.002 n=6)
304        199.5µ ± 1%   196.1µ ± 0%   -1.67% (p=0.002 n=6)
312        198.6µ ± 0%   201.6µ ± 0%   +1.52% (p=0.002 n=6)
geomean    136.3µ        99.16µ       -27.26%

pkg: github.com/consensys/gnark-crypto/ecc/bw6-761
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         63.790µ ± 0%   2.162µ ± 0%  -96.61% (p=0.002 n=6)
8          66.82µ ± 0%   12.19µ ± 0%  -81.75% (p=0.002 n=6)
16         69.52µ ± 0%   20.80µ ± 0%  -70.08% (p=0.002 n=6)
24         76.54µ ± 1%   32.22µ ± 0%  -57.90% (p=0.002 n=6)
32         82.16µ ± 1%   42.29µ ± 1%  -48.53% (p=0.002 n=6)
40         79.45µ ± 1%   50.94µ ± 1%  -35.88% (p=0.002 n=6)
48         86.27µ ± 0%   63.61µ ± 0%  -26.27% (p=0.002 n=6)
56         90.40µ ± 1%   74.97µ ± 0%  -17.07% (p=0.002 n=6)
64         97.42µ ± 1%   73.82µ ± 0%  -24.22% (p=0.002 n=6)
72        147.18µ ± 0%   92.30µ ± 0%  -37.28% (p=0.002 n=6)
80        149.95µ ± 1%   95.37µ ± 1%  -36.40% (p=0.002 n=6)
88         154.5µ ± 0%   102.8µ ± 1%  -33.47% (p=0.002 n=6)
96         165.4µ ± 0%   122.4µ ± 1%  -26.01% (p=0.002 n=6)
104        170.9µ ± 0%   126.8µ ± 0%  -25.79% (p=0.002 n=6)
112        155.9µ ± 0%   135.6µ ± 0%  -13.03% (p=0.002 n=6)
120        171.3µ ± 0%   153.8µ ± 0%  -10.26% (p=0.002 n=6)
128        178.0µ ± 1%   170.9µ ± 0%   -3.98% (p=0.002 n=6)
136        224.9µ ± 0%   175.3µ ± 0%  -22.06% (p=0.002 n=6)
144        234.3µ ± 0%   182.2µ ± 1%  -22.24% (p=0.002 n=6)
152        230.2µ ± 0%   191.3µ ± 0%  -16.91% (p=0.002 n=6)
160        235.8µ ± 0%   208.2µ ± 0%  -11.68% (p=0.002 n=6)
168        241.3µ ± 0%   211.3µ ± 0%  -12.40% (p=0.002 n=6)
176        245.5µ ± 0%   222.4µ ± 0%   -9.39% (p=0.002 n=6)
184        255.4µ ± 0%   241.0µ ± 0%   -5.62% (p=0.002 n=6)
192        259.7µ ± 1%   241.2µ ± 1%   -7.12% (p=0.002 n=6)
200        256.9µ ± 0%   253.6µ ± 0%   -1.31% (p=0.002 n=6)
208        262.1µ ± 0%   260.6µ ± 1%        ~ (p=0.065 n=6)
216        263.6µ ± 0%   265.9µ ± 0%   +0.87% (p=0.002 n=6)
224        273.0µ ± 0%   269.8µ ± 0%   -1.17% (p=0.002 n=6)
232        262.2µ ± 0%   267.5µ ± 0%   +2.00% (p=0.002 n=6)
240        270.6µ ± 0%   271.5µ ± 0%   +0.32% (p=0.002 n=6)
248        262.2µ ± 0%   271.7µ ± 0%   +3.63% (p=0.002 n=6)
256        274.5µ ± 1%   279.8µ ± 1%   +1.93% (p=0.002 n=6)
264        273.2µ ± 0%   268.6µ ± 0%   -1.68% (p=0.002 n=6)
272        270.6µ ± 0%   270.7µ ± 1%        ~ (p=1.000 n=6)
280        272.2µ ± 0%   269.4µ ± 1%   -1.02% (p=0.002 n=6)
288        276.0µ ± 0%   274.2µ ± 0%   -0.68% (p=0.002 n=6)
296        278.8µ ± 0%   277.0µ ± 0%   -0.63% (p=0.002 n=6)
304        279.9µ ± 0%   287.0µ ± 1%   +2.53% (p=0.002 n=6)
312        281.8µ ± 0%   280.0µ ± 0%   -0.61% (p=0.002 n=6)
320        276.4µ ± 1%   275.8µ ± 0%   -0.20% (p=0.009 n=6)
328        279.0µ ± 0%   282.5µ ± 0%   +1.24% (p=0.002 n=6)
336        280.4µ ± 0%   277.1µ ± 0%   -1.15% (p=0.002 n=6)
344        276.0µ ± 0%   284.2µ ± 2%   +2.95% (p=0.002 n=6)
352        270.8µ ± 0%   277.2µ ± 0%   +2.37% (p=0.002 n=6)
360        281.5µ ± 0%   285.3µ ± 1%   +1.35% (p=0.002 n=6)
368        278.8µ ± 0%   281.4µ ± 0%   +0.91% (p=0.002 n=6)
376        273.3µ ± 0%   281.2µ ± 0%   +2.89% (p=0.002 n=6)
geomean    193.7µ        150.0µ       -22.58%

pkg: github.com/consensys/gnark-crypto/ecc/grumpkin
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         10976.0n ± 0%   368.1n ± 0%  -96.65% (p=0.002 n=6)
8          11.798µ ± 1%   2.088µ ± 0%  -82.30% (p=0.002 n=6)
16         12.285µ ± 0%   3.570µ ± 0%  -70.94% (p=0.002 n=6)
24         12.944µ ± 0%   4.798µ ± 1%  -62.93% (p=0.002 n=6)
32         13.457µ ± 0%   6.077µ ± 0%  -54.84% (p=0.002 n=6)
40         13.912µ ± 0%   8.425µ ± 0%  -39.44% (p=0.002 n=6)
48          15.07µ ± 0%   10.82µ ± 0%  -28.19% (p=0.002 n=6)
56          15.59µ ± 0%   11.61µ ± 0%  -25.55% (p=0.002 n=6)
64          17.64µ ± 1%   14.27µ ± 0%  -19.13% (p=0.002 n=6)
72          25.30µ ± 0%   16.16µ ± 0%  -36.11% (p=0.002 n=6)
80          25.84µ ± 0%   16.94µ ± 0%  -34.42% (p=0.002 n=6)
88          26.35µ ± 0%   18.88µ ± 0%  -28.35% (p=0.002 n=6)
96          26.77µ ± 0%   19.76µ ± 0%  -26.18% (p=0.002 n=6)
104         27.94µ ± 0%   21.85µ ± 0%  -21.79% (p=0.002 n=6)
112         29.29µ ± 0%   24.50µ ± 0%  -16.37% (p=0.002 n=6)
120         28.61µ ± 1%   24.80µ ± 0%  -13.32% (p=0.002 n=6)
128         32.18µ ± 0%   26.48µ ± 0%  -17.72% (p=0.002 n=6)
136         31.05µ ± 0%   29.33µ ± 1%   -5.53% (p=0.002 n=6)
144         30.89µ ± 0%   32.71µ ± 0%   +5.91% (p=0.002 n=6)
152         32.60µ ± 1%   32.32µ ± 0%   -0.85% (p=0.002 n=6)
160         32.48µ ± 0%   32.98µ ± 0%   +1.54% (p=0.002 n=6)
168         32.50µ ± 0%   32.74µ ± 1%   +0.73% (p=0.002 n=6)
176         32.45µ ± 1%   32.70µ ± 0%   +0.75% (p=0.041 n=6)
184         33.06µ ± 1%   32.05µ ± 0%   -3.06% (p=0.002 n=6)
192         33.28µ ± 2%   32.36µ ± 1%   -2.78% (p=0.002 n=6)
200         32.86µ ± 0%   33.23µ ± 0%   +1.12% (p=0.002 n=6)
208         33.71µ ± 0%   33.46µ ± 0%   -0.75% (p=0.002 n=6)
216         33.50µ ± 0%   33.62µ ± 0%   +0.34% (p=0.026 n=6)
224         33.89µ ± 1%   32.80µ ± 0%   -3.22% (p=0.002 n=6)
232         32.30µ ± 0%   33.22µ ± 0%   +2.84% (p=0.002 n=6)
240         33.52µ ± 0%   33.13µ ± 1%   -1.16% (p=0.004 n=6)
248         32.59µ ± 1%   33.30µ ± 0%   +2.18% (p=0.002 n=6)
geomean     24.52µ        16.96µ       -30.81%

pkg: github.com/consensys/gnark-crypto/ecc/secp256k1
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         13900.5n ± 0%   473.1n ± 0%  -96.60% (p=0.002 n=6)
8          14.972µ ± 1%   1.772µ ± 0%  -88.16% (p=0.002 n=6)
16         14.444µ ± 0%   4.853µ ± 1%  -66.40% (p=0.002 n=6)
24         15.908µ ± 1%   6.152µ ± 0%  -61.33% (p=0.002 n=6)
32         17.998µ ± 0%   8.305µ ± 0%  -53.86% (p=0.002 n=6)
40          18.59µ ± 0%   10.82µ ± 1%  -41.81% (p=0.002 n=6)
48          20.11µ ± 0%   13.00µ ± 2%  -35.34% (p=0.002 n=6)
56          19.82µ ± 0%   14.86µ ± 0%  -25.04% (p=0.002 n=6)
64          22.51µ ± 0%   18.82µ ± 1%  -16.37% (p=0.002 n=6)
72          32.69µ ± 0%   19.79µ ± 0%  -39.45% (p=0.002 n=6)
80          31.59µ ± 1%   23.20µ ± 1%  -26.57% (p=0.002 n=6)
88          33.98µ ± 1%   24.76µ ± 0%  -27.14% (p=0.002 n=6)
96          32.91µ ± 1%   27.57µ ± 0%  -16.23% (p=0.002 n=6)
104         36.83µ ± 0%   29.52µ ± 1%  -19.84% (p=0.002 n=6)
112         35.93µ ± 0%   31.05µ ± 0%  -13.58% (p=0.002 n=6)
120         37.99µ ± 0%   32.94µ ± 0%  -13.29% (p=0.002 n=6)
128         39.30µ ± 1%   34.50µ ± 0%  -12.20% (p=0.002 n=6)
136         41.79µ ± 1%   36.70µ ± 0%  -12.17% (p=0.002 n=6)
144         41.81µ ± 0%   40.28µ ± 0%   -3.67% (p=0.002 n=6)
152         42.33µ ± 0%   42.37µ ± 1%        ~ (p=0.310 n=6)
160         42.38µ ± 1%   42.65µ ± 0%   +0.66% (p=0.015 n=6)
168         42.43µ ± 1%   41.71µ ± 0%   -1.69% (p=0.002 n=6)
176         43.37µ ± 0%   42.57µ ± 0%   -1.85% (p=0.002 n=6)
184         42.32µ ± 1%   42.22µ ± 0%   -0.24% (p=0.037 n=6)
192         42.57µ ± 0%   42.06µ ± 1%   -1.21% (p=0.002 n=6)
200         41.77µ ± 1%   41.43µ ± 0%   -0.83% (p=0.002 n=6)
208         42.48µ ± 0%   41.71µ ± 1%   -1.80% (p=0.002 n=6)
216         43.19µ ± 0%   42.91µ ± 0%   -0.66% (p=0.002 n=6)
224         42.92µ ± 0%   41.96µ ± 0%   -2.22% (p=0.002 n=6)
232         42.65µ ± 1%   43.21µ ± 0%   +1.30% (p=0.002 n=6)
240         42.36µ ± 0%   42.58µ ± 0%   +0.53% (p=0.002 n=6)
248         42.03µ ± 0%   43.01µ ± 1%   +2.32% (p=0.002 n=6)
256         42.98µ ± 0%   42.91µ ± 0%        ~ (p=0.310 n=6)
geomean     31.76µ        22.12µ       -30.36%
```

G2
```
goos: linux
goarch: amd64
pkg: github.com/consensys/gnark-crypto/ecc/bls12-377
cpu: AMD Ryzen 9 7940HS w/ Radeon 780M Graphics     
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         56.200µ ± 1%   2.069µ ± 1%  -96.32% (p=0.002 n=6)
8         56.462µ ± 0%   8.516µ ± 2%  -84.92% (p=0.002 n=6)
16         63.39µ ± 0%   20.60µ ± 0%  -67.51% (p=0.002 n=6)
24         62.35µ ± 0%   31.19µ ± 2%  -49.98% (p=0.002 n=6)
32         69.60µ ± 1%   33.50µ ± 3%  -51.87% (p=0.002 n=6)
40         78.06µ ± 0%   49.62µ ± 0%  -36.44% (p=0.002 n=6)
48         80.93µ ± 0%   53.68µ ± 2%  -33.67% (p=0.002 n=6)
56         86.66µ ± 0%   61.27µ ± 0%  -29.30% (p=0.002 n=6)
64         91.00µ ± 0%   74.46µ ± 0%  -18.18% (p=0.002 n=6)
72        127.18µ ± 1%   83.86µ ± 0%  -34.06% (p=0.002 n=6)
80         137.1µ ± 1%   100.0µ ± 0%  -27.08% (p=0.002 n=6)
88         139.8µ ± 0%   103.8µ ± 0%  -25.79% (p=0.002 n=6)
96         144.1µ ± 0%   118.4µ ± 1%  -17.80% (p=0.002 n=6)
104        149.8µ ± 0%   123.9µ ± 0%  -17.23% (p=0.002 n=6)
112        162.8µ ± 0%   126.0µ ± 0%  -22.57% (p=0.002 n=6)
120        158.6µ ± 0%   145.1µ ± 1%   -8.52% (p=0.002 n=6)
128        164.4µ ± 0%   147.2µ ± 0%  -10.43% (p=0.002 n=6)
136        161.7µ ± 1%   164.2µ ± 0%   +1.54% (p=0.002 n=6)
144        169.7µ ± 0%   163.3µ ± 1%   -3.81% (p=0.002 n=6)
152        167.1µ ± 0%   165.7µ ± 1%   -0.89% (p=0.002 n=6)
160        168.8µ ± 0%   164.8µ ± 1%   -2.34% (p=0.002 n=6)
168        169.8µ ± 0%   171.4µ ± 1%   +0.94% (p=0.002 n=6)
176        168.6µ ± 0%   168.7µ ± 0%        ~ (p=0.180 n=6)
184        163.0µ ± 0%   167.3µ ± 0%   +2.64% (p=0.002 n=6)
192        172.6µ ± 0%   168.5µ ± 0%   -2.34% (p=0.002 n=6)
200        175.4µ ± 0%   172.9µ ± 0%   -1.43% (p=0.002 n=6)
208        172.2µ ± 1%   173.9µ ± 1%   +1.03% (p=0.002 n=6)
216        175.2µ ± 0%   178.4µ ± 0%   +1.82% (p=0.002 n=6)
224        179.4µ ± 1%   177.0µ ± 0%   -1.29% (p=0.002 n=6)
232        178.5µ ± 0%   178.6µ ± 1%        ~ (p=1.000 n=6)
240        178.4µ ± 1%   173.9µ ± 1%   -2.51% (p=0.002 n=6)
248        181.0µ ± 0%   178.8µ ± 0%   -1.22% (p=0.002 n=6)
geomean    128.8µ        91.06µ       -29.32%

pkg: github.com/consensys/gnark-crypto/ecc/bls12-381
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         47.489µ ± 0%   1.745µ ± 0%  -96.33% (p=0.002 n=6)
8         51.190µ ± 0%   9.426µ ± 0%  -81.59% (p=0.002 n=6)
16         52.40µ ± 1%   15.87µ ± 0%  -69.70% (p=0.002 n=6)
24         57.14µ ± 0%   25.89µ ± 0%  -54.69% (p=0.002 n=6)
32         62.96µ ± 0%   32.36µ ± 0%  -48.60% (p=0.002 n=6)
40         62.96µ ± 0%   35.27µ ± 1%  -43.97% (p=0.002 n=6)
48         70.12µ ± 1%   48.84µ ± 0%  -30.35% (p=0.002 n=6)
56         72.49µ ± 0%   54.14µ ± 1%  -25.31% (p=0.002 n=6)
64         70.05µ ± 0%   60.54µ ± 1%  -13.57% (p=0.002 n=6)
72        113.78µ ± 0%   65.81µ ± 1%  -42.16% (p=0.002 n=6)
80        117.44µ ± 0%   78.08µ ± 1%  -33.52% (p=0.002 n=6)
88        122.07µ ± 0%   86.81µ ± 0%  -28.89% (p=0.002 n=6)
96        120.96µ ± 0%   87.53µ ± 1%  -27.64% (p=0.002 n=6)
104        119.8µ ± 0%   104.8µ ± 0%  -12.55% (p=0.002 n=6)
112        121.0µ ± 1%   104.3µ ± 1%  -13.83% (p=0.002 n=6)
120        127.0µ ± 0%   112.9µ ± 1%  -11.07% (p=0.002 n=6)
128        130.4µ ± 0%   120.5µ ± 1%   -7.58% (p=0.002 n=6)
136        136.4µ ± 0%   139.0µ ± 1%   +1.94% (p=0.002 n=6)
144        132.9µ ± 0%   136.4µ ± 0%   +2.64% (p=0.002 n=6)
152        142.5µ ± 0%   136.5µ ± 0%   -4.24% (p=0.002 n=6)
160        138.8µ ± 0%   139.9µ ± 0%   +0.84% (p=0.002 n=6)
168        141.1µ ± 0%   139.9µ ± 0%   -0.81% (p=0.002 n=6)
176        138.8µ ± 1%   142.4µ ± 0%   +2.61% (p=0.002 n=6)
184        144.9µ ± 1%   136.4µ ± 0%   -5.86% (p=0.002 n=6)
192        147.1µ ± 0%   145.9µ ± 0%   -0.84% (p=0.002 n=6)
200        144.8µ ± 0%   145.9µ ± 0%   +0.74% (p=0.002 n=6)
208        147.1µ ± 0%   143.8µ ± 1%   -2.26% (p=0.002 n=6)
216        141.2µ ± 0%   145.9µ ± 0%   +3.37% (p=0.002 n=6)
224        147.1µ ± 0%   149.5µ ± 0%   +1.59% (p=0.002 n=6)
232        148.5µ ± 0%   149.4µ ± 0%   +0.58% (p=0.002 n=6)
240        149.4µ ± 0%   148.4µ ± 0%   -0.67% (p=0.002 n=6)
248        147.3µ ± 1%   154.2µ ± 0%   +4.70% (p=0.002 n=6)
geomean    107.6µ        76.11µ       -29.28%

pkg: github.com/consensys/gnark-crypto/ecc/bls24-315
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         133.392µ ± 0%   4.734µ ± 1%  -96.45% (p=0.002 n=6)
8          140.25µ ± 0%   22.79µ ± 0%  -83.75% (p=0.002 n=6)
16         156.84µ ± 0%   34.32µ ± 1%  -78.12% (p=0.002 n=6)
24         156.96µ ± 0%   61.93µ ± 0%  -60.54% (p=0.002 n=6)
32         170.07µ ± 0%   92.70µ ± 0%  -45.49% (p=0.002 n=6)
40          183.8µ ± 0%   101.0µ ± 0%  -45.07% (p=0.002 n=6)
48          193.9µ ± 1%   125.4µ ± 0%  -35.30% (p=0.002 n=6)
56          199.9µ ± 0%   156.2µ ± 0%  -21.86% (p=0.002 n=6)
64          203.5µ ± 1%   161.2µ ± 1%  -20.76% (p=0.002 n=6)
72          303.9µ ± 0%   205.1µ ± 1%  -32.52% (p=0.002 n=6)
80          323.8µ ± 0%   210.0µ ± 0%  -35.13% (p=0.002 n=6)
88          330.7µ ± 0%   237.8µ ± 0%  -28.08% (p=0.002 n=6)
96          337.5µ ± 1%   242.9µ ± 0%  -28.03% (p=0.002 n=6)
104         353.3µ ± 0%   254.5µ ± 0%  -27.97% (p=0.002 n=6)
112         373.1µ ± 0%   317.1µ ± 0%  -15.01% (p=0.002 n=6)
120         366.7µ ± 1%   319.7µ ± 0%  -12.81% (p=0.002 n=6)
128         390.1µ ± 1%   340.2µ ± 0%  -12.80% (p=0.002 n=6)
136         363.5µ ± 0%   395.4µ ± 1%   +8.80% (p=0.002 n=6)
144         403.2µ ± 0%   381.9µ ± 0%   -5.27% (p=0.002 n=6)
152         393.0µ ± 0%   401.4µ ± 0%   +2.15% (p=0.002 n=6)
160         390.0µ ± 1%   385.3µ ± 0%   -1.22% (p=0.002 n=6)
168         393.1µ ± 0%   391.6µ ± 0%   -0.38% (p=0.002 n=6)
176         400.1µ ± 0%   385.5µ ± 0%   -3.65% (p=0.002 n=6)
184         410.3µ ± 0%   404.5µ ± 1%   -1.43% (p=0.002 n=6)
192         413.5µ ± 1%   395.0µ ± 0%   -4.47% (p=0.002 n=6)
200         397.2µ ± 0%   405.3µ ± 1%   +2.02% (p=0.002 n=6)
208         403.8µ ± 0%   398.2µ ± 0%   -1.38% (p=0.002 n=6)
216         412.9µ ± 0%   401.5µ ± 0%   -2.75% (p=0.002 n=6)
224         420.7µ ± 0%   388.6µ ± 0%   -7.63% (p=0.002 n=6)
232         400.8µ ± 1%   398.1µ ± 0%   -0.68% (p=0.002 n=6)
240         411.4µ ± 0%   417.3µ ± 0%   +1.45% (p=0.002 n=6)
248         423.5µ ± 1%   421.4µ ± 0%   -0.48% (p=0.002 n=6)
geomean     303.7µ        207.8µ       -31.56%

pkg: github.com/consensys/gnark-crypto/ecc/bls24-317
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         135.224µ ± 1%   4.911µ ± 0%  -96.37% (p=0.002 n=6)
8          138.43µ ± 1%   16.69µ ± 1%  -87.95% (p=0.002 n=6)
16         152.11µ ± 1%   49.15µ ± 0%  -67.69% (p=0.002 n=6)
24         166.17µ ± 1%   74.74µ ± 0%  -55.03% (p=0.002 n=6)
32         166.62µ ± 0%   96.93µ ± 0%  -41.83% (p=0.002 n=6)
40          180.4µ ± 0%   112.4µ ± 0%  -37.67% (p=0.002 n=6)
48          180.4µ ± 0%   134.5µ ± 1%  -25.45% (p=0.002 n=6)
56          208.6µ ± 1%   153.2µ ± 0%  -26.57% (p=0.002 n=6)
64          211.5µ ± 1%   196.1µ ± 1%   -7.25% (p=0.002 n=6)
72          329.8µ ± 2%   218.0µ ± 0%  -33.89% (p=0.002 n=6)
80          309.5µ ± 0%   219.9µ ± 0%  -28.94% (p=0.002 n=6)
88          357.3µ ± 0%   259.0µ ± 0%  -27.52% (p=0.002 n=6)
96          367.3µ ± 1%   260.9µ ± 0%  -28.96% (p=0.002 n=6)
104         361.3µ ± 0%   293.0µ ± 0%  -18.89% (p=0.002 n=6)
112         381.5µ ± 0%   322.2µ ± 0%  -15.55% (p=0.002 n=6)
120         392.5µ ± 0%   316.8µ ± 0%  -19.28% (p=0.002 n=6)
128         393.3µ ± 0%   359.4µ ± 1%   -8.61% (p=0.002 n=6)
136         382.9µ ± 2%   395.8µ ± 1%   +3.37% (p=0.002 n=6)
144         419.1µ ± 0%   414.1µ ± 0%   -1.20% (p=0.002 n=6)
152         392.6µ ± 0%   389.4µ ± 0%   -0.81% (p=0.002 n=6)
160         385.5µ ± 0%   399.8µ ± 0%   +3.71% (p=0.002 n=6)
168         409.2µ ± 1%   392.8µ ± 1%   -4.01% (p=0.002 n=6)
176         410.1µ ± 5%   414.0µ ± 0%        ~ (p=0.065 n=6)
184         414.4µ ± 1%   406.1µ ± 0%   -1.99% (p=0.002 n=6)
192         404.3µ ± 1%   389.5µ ± 0%   -3.67% (p=0.002 n=6)
200         433.9µ ± 1%   403.9µ ± 1%   -6.92% (p=0.002 n=6)
208         420.0µ ± 1%   420.2µ ± 1%        ~ (p=0.485 n=6)
216         423.3µ ± 0%   426.8µ ± 0%   +0.81% (p=0.002 n=6)
224         402.3µ ± 0%   424.2µ ± 0%   +5.43% (p=0.002 n=6)
232         423.4µ ± 0%   436.1µ ± 1%   +3.00% (p=0.002 n=6)
240         423.5µ ± 0%   439.4µ ± 0%   +3.76% (p=0.002 n=6)
248         430.0µ ± 5%   435.1µ ± 0%        ~ (p=0.065 n=6)
geomean     310.0µ        218.9µ       -29.37%

pkg: github.com/consensys/gnark-crypto/ecc/bn254
        │      OLD      │                NEW                 │
        │    sec/op     │   sec/op     vs base               │
0         24910.0n ± 0%   894.9n ± 0%  -96.41% (p=0.002 n=6)
8          25.626µ ± 1%   4.874µ ± 0%  -80.98% (p=0.002 n=6)
16         28.124µ ± 1%   8.830µ ± 0%  -68.60% (p=0.002 n=6)
24          29.27µ ± 0%   12.77µ ± 0%  -56.37% (p=0.002 n=6)
32          32.15µ ± 0%   13.21µ ± 1%  -58.92% (p=0.002 n=6)
40          33.34µ ± 0%   18.94µ ± 0%  -43.19% (p=0.002 n=6)
48          34.58µ ± 0%   24.05µ ± 0%  -30.47% (p=0.002 n=6)
56          36.93µ ± 0%   29.71µ ± 2%  -19.54% (p=0.002 n=6)
64          39.32µ ± 0%   33.08µ ± 0%  -15.86% (p=0.002 n=6)
72          57.03µ ± 0%   35.83µ ± 0%  -37.17% (p=0.002 n=6)
80          60.62µ ± 0%   38.06µ ± 1%  -37.22% (p=0.002 n=6)
88          60.06µ ± 0%   40.79µ ± 0%  -32.09% (p=0.002 n=6)
96          68.23µ ± 0%   48.34µ ± 0%  -29.15% (p=0.002 n=6)
104         64.74µ ± 1%   54.62µ ± 0%  -15.63% (p=0.002 n=6)
112         71.26µ ± 0%   52.08µ ± 1%  -26.92% (p=0.002 n=6)
120         69.53µ ± 0%   55.48µ ± 0%  -20.20% (p=0.002 n=6)
128         74.30µ ± 1%   69.32µ ± 1%   -6.69% (p=0.002 n=6)
136         75.07µ ± 0%   74.57µ ± 1%   -0.66% (p=0.041 n=6)
144         76.17µ ± 0%   72.84µ ± 0%   -4.38% (p=0.002 n=6)
152         75.05µ ± 1%   75.23µ ± 0%        ~ (p=0.132 n=6)
160         74.88µ ± 1%   75.18µ ± 0%        ~ (p=0.065 n=6)
168         74.33µ ± 0%   78.43µ ± 1%   +5.51% (p=0.002 n=6)
176         77.37µ ± 0%   77.14µ ± 0%   -0.31% (p=0.015 n=6)
184         74.35µ ± 0%   77.24µ ± 1%   +3.88% (p=0.002 n=6)
192         77.37µ ± 0%   77.18µ ± 1%        ~ (p=0.132 n=6)
200         77.98µ ± 1%   78.26µ ± 0%        ~ (p=0.093 n=6)
208         78.58µ ± 0%   78.86µ ± 0%   +0.35% (p=0.009 n=6)
216         78.66µ ± 0%   76.47µ ± 0%   -2.78% (p=0.002 n=6)
224         79.15µ ± 0%   78.13µ ± 0%   -1.29% (p=0.002 n=6)
232         77.48µ ± 0%   79.32µ ± 1%   +2.38% (p=0.002 n=6)
240         79.68µ ± 0%   75.17µ ± 0%   -5.66% (p=0.002 n=6)
248         77.28µ ± 0%   77.11µ ± 0%   -0.21% (p=0.004 n=6)
geomean     57.32µ        39.83µ       -30.52%

pkg: github.com/consensys/gnark-crypto/ecc/bw6-633
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         49.510µ ± 0%   1.674µ ± 1%  -96.62% (p=0.002 n=6)
8         51.764µ ± 0%   7.295µ ± 0%  -85.91% (p=0.002 n=6)
16         53.86µ ± 1%   16.00µ ± 0%  -70.29% (p=0.002 n=6)
24         60.18µ ± 0%   23.72µ ± 1%  -60.58% (p=0.002 n=6)
32         65.56µ ± 0%   32.48µ ± 0%  -50.46% (p=0.002 n=6)
40         64.52µ ± 0%   40.10µ ± 0%  -37.84% (p=0.002 n=6)
48         70.90µ ± 0%   45.77µ ± 0%  -35.44% (p=0.002 n=6)
56         64.39µ ± 0%   55.48µ ± 0%  -13.83% (p=0.002 n=6)
64         71.77µ ± 1%   63.11µ ± 0%  -12.06% (p=0.002 n=6)
72        113.64µ ± 0%   66.64µ ± 1%  -41.36% (p=0.002 n=6)
80        116.86µ ± 0%   76.30µ ± 0%  -34.70% (p=0.002 n=6)
88        121.02µ ± 0%   87.33µ ± 0%  -27.84% (p=0.002 n=6)
96        124.15µ ± 0%   87.54µ ± 0%  -29.49% (p=0.002 n=6)
104        126.4µ ± 0%   100.8µ ± 0%  -20.29% (p=0.002 n=6)
112        135.0µ ± 0%   107.5µ ± 0%  -20.36% (p=0.002 n=6)
120        128.6µ ± 0%   119.2µ ± 0%   -7.37% (p=0.002 n=6)
128        133.8µ ± 0%   121.7µ ± 1%   -9.04% (p=0.002 n=6)
136        174.5µ ± 0%   130.6µ ± 1%  -25.14% (p=0.002 n=6)
144        180.8µ ± 0%   136.1µ ± 0%  -24.73% (p=0.002 n=6)
152        184.2µ ± 1%   150.1µ ± 0%  -18.52% (p=0.002 n=6)
160        189.8µ ± 0%   156.3µ ± 0%  -17.68% (p=0.002 n=6)
168        190.0µ ± 0%   191.3µ ± 0%   +0.67% (p=0.002 n=6)
176        191.0µ ± 0%   192.0µ ± 0%   +0.51% (p=0.002 n=6)
184        197.4µ ± 0%   187.0µ ± 1%   -5.25% (p=0.002 n=6)
192        193.9µ ± 1%   196.6µ ± 2%   +1.37% (p=0.015 n=6)
200        191.7µ ± 0%   189.6µ ± 0%   -1.13% (p=0.002 n=6)
208        192.9µ ± 0%   190.2µ ± 0%   -1.42% (p=0.002 n=6)
216        196.5µ ± 0%   188.8µ ± 0%   -3.89% (p=0.002 n=6)
224        192.9µ ± 1%   193.1µ ± 0%        ~ (p=0.240 n=6)
232        198.1µ ± 0%   192.0µ ± 0%   -3.13% (p=0.002 n=6)
240        199.3µ ± 0%   198.3µ ± 0%   -0.50% (p=0.002 n=6)
248        197.4µ ± 0%   200.5µ ± 0%   +1.57% (p=0.002 n=6)
256        198.4µ ± 1%   198.2µ ± 0%        ~ (p=0.240 n=6)
264        197.1µ ± 0%   198.9µ ± 1%   +0.88% (p=0.002 n=6)
272        202.5µ ± 0%   199.6µ ± 0%   -1.43% (p=0.002 n=6)
280        198.1µ ± 0%   201.9µ ± 1%   +1.91% (p=0.002 n=6)
288        200.3µ ± 0%   200.7µ ± 0%        ~ (p=0.132 n=6)
296        201.3µ ± 0%   195.4µ ± 1%   -2.96% (p=0.002 n=6)
304        201.4µ ± 0%   197.7µ ± 0%   -1.88% (p=0.002 n=6)
312        200.2µ ± 0%   199.6µ ± 0%   -0.34% (p=0.009 n=6)
geomean    136.9µ        99.50µ       -27.33%

pkg: github.com/consensys/gnark-crypto/ecc/bw6-761
        │     OLD      │                NEW                 │
        │    sec/op    │   sec/op     vs base               │
0         63.817µ ± 0%   2.173µ ± 0%  -96.59% (p=0.002 n=6)
8         68.208µ ± 0%   9.489µ ± 1%  -86.09% (p=0.002 n=6)
16         70.86µ ± 0%   20.84µ ± 1%  -70.59% (p=0.002 n=6)
24         76.45µ ± 0%   29.38µ ± 0%  -61.56% (p=0.002 n=6)
32         82.09µ ± 0%   40.78µ ± 1%  -50.32% (p=0.002 n=6)
40         84.80µ ± 1%   54.99µ ± 0%  -35.15% (p=0.002 n=6)
48         87.74µ ± 0%   62.30µ ± 0%  -28.99% (p=0.002 n=6)
56         89.11µ ± 0%   72.15µ ± 1%  -19.04% (p=0.002 n=6)
64         98.83µ ± 0%   84.87µ ± 0%  -14.13% (p=0.002 n=6)
72        144.47µ ± 0%   85.27µ ± 0%  -40.98% (p=0.002 n=6)
80         147.2µ ± 0%   106.7µ ± 0%  -27.54% (p=0.002 n=6)
88         154.2µ ± 0%   115.2µ ± 0%  -25.26% (p=0.002 n=6)
96         166.8µ ± 2%   128.1µ ± 0%  -23.20% (p=0.002 n=6)
104        158.5µ ± 0%   126.8µ ± 0%  -19.99% (p=0.002 n=6)
112        170.9µ ± 0%   141.3µ ± 1%  -17.32% (p=0.002 n=6)
120        165.4µ ± 0%   145.5µ ± 0%  -12.02% (p=0.002 n=6)
128        175.0µ ± 0%   154.2µ ± 0%  -11.88% (p=0.002 n=6)
136        230.3µ ± 0%   172.2µ ± 1%  -25.20% (p=0.002 n=6)
144        224.5µ ± 0%   185.6µ ± 1%  -17.31% (p=0.002 n=6)
152        235.9µ ± 0%   188.3µ ± 0%  -20.15% (p=0.002 n=6)
160        239.0µ ± 1%   195.7µ ± 0%  -18.11% (p=0.002 n=6)
168        256.1µ ± 0%   215.7µ ± 0%  -15.79% (p=0.002 n=6)
176        250.0µ ± 0%   214.2µ ± 0%  -14.33% (p=0.002 n=6)
184        256.2µ ± 1%   234.2µ ± 1%   -8.60% (p=0.002 n=6)
192        258.9µ ± 0%   246.5µ ± 0%   -4.79% (p=0.002 n=6)
200        256.2µ ± 0%   248.1µ ± 1%   -3.14% (p=0.002 n=6)
208        260.9µ ± 0%   267.6µ ± 1%   +2.59% (p=0.002 n=6)
216        260.3µ ± 0%   264.9µ ± 0%   +1.77% (p=0.002 n=6)
224        271.2µ ± 1%   263.5µ ± 1%   -2.83% (p=0.002 n=6)
232        267.6µ ± 0%   257.9µ ± 1%   -3.63% (p=0.002 n=6)
240        265.8µ ± 0%   268.7µ ± 0%   +1.09% (p=0.002 n=6)
248        277.0µ ± 0%   277.9µ ± 1%        ~ (p=0.180 n=6)
256        274.1µ ± 0%   272.9µ ± 1%   -0.44% (p=0.041 n=6)
264        276.7µ ± 0%   277.5µ ± 0%   +0.30% (p=0.002 n=6)
272        273.8µ ± 1%   270.6µ ± 0%   -1.14% (p=0.002 n=6)
280        273.8µ ± 0%   284.0µ ± 0%   +3.72% (p=0.002 n=6)
288        275.1µ ± 0%   270.0µ ± 0%   -1.88% (p=0.002 n=6)
296        272.7µ ± 1%   274.0µ ± 0%        ~ (p=0.065 n=6)
304        275.0µ ± 0%   272.6µ ± 0%   -0.90% (p=0.002 n=6)
312        283.2µ ± 0%   281.0µ ± 2%        ~ (p=0.065 n=6)
320        276.3µ ± 0%   278.3µ ± 1%   +0.74% (p=0.002 n=6)
328        283.0µ ± 0%   282.0µ ± 0%   -0.36% (p=0.009 n=6)
336        284.6µ ± 0%   282.4µ ± 0%   -0.76% (p=0.002 n=6)
344        279.6µ ± 0%   285.3µ ± 0%   +2.04% (p=0.002 n=6)
352        277.9µ ± 0%   285.7µ ± 1%   +2.82% (p=0.002 n=6)
360        284.8µ ± 1%   285.7µ ± 0%        ~ (p=0.093 n=6)
368        280.7µ ± 0%   272.0µ ± 0%   -3.11% (p=0.002 n=6)
376        282.0µ ± 0%   282.2µ ± 0%        ~ (p=0.818 n=6)
geomean    194.9µ        149.1µ       -23.48%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

