### PR TITLE
fix: implement Max function in utils package

### DIFF
--- a/utils/max.go
+++ b/utils/max.go
@@ -3,5 +3,8 @@ package utils
 // Max returns the maximum of two integers
 func Max(a, b int) int {
 	// Deprecated: but keeping until next major release to avoid breaking some vendored code
-	return max(a, b)
+	if a > b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
# Description

Fix implementation of deprecated `Max` function in utils package to prevent compilation errors. The function was referencing a non-existent `max` function while still being used in several places throughout the codebase.

Fixes compilation error in utils package

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] Manual verification that the function compiles and behaves as expected

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] `golangci-lint` does not output errors locally

