### PR TITLE
fix: resolve dangling pointer in Transcript.ComputeChallenge

### DIFF
--- a/fiat-shamir/transcript.go
+++ b/fiat-shamir/transcript.go
@@ -120,7 +120,7 @@ func (t *Transcript) ComputeChallenge(challengeID string) ([]byte, error) {
 	challenge.isComputed = true
 
 	t.challenges[challengeID] = challenge
-	t.previous = &challenge
+	t.previous = &t.challenges[challengeID]
 
 	return res, nil
 


### PR DESCRIPTION
Fix t.previous pointing to local variable that gets destroyed after function exit.
Changed t.previous = &challenge to t.previous = &t.challenges[challengeID] to ensure
pointer points to actual data in map.