### PR TITLE
Perf: Small Field Montgomery Reduction

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -932,7 +932,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -945,7 +945,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -932,7 +932,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -945,7 +945,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -850,7 +850,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -862,7 +862,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -850,7 +850,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -862,7 +862,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -1320,7 +1320,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -1337,7 +1337,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -850,7 +850,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -862,7 +862,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -1550,7 +1550,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -1569,7 +1569,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -932,7 +932,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -945,7 +945,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/grumpkin/fp/element.go
+++ b/ecc/grumpkin/fp/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/grumpkin/fr/element.go
+++ b/ecc/grumpkin/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -805,7 +805,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -816,7 +816,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -805,7 +805,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -816,7 +816,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -777,7 +777,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -788,7 +788,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/field/babybear/element.go
+++ b/field/babybear/element.go
@@ -511,7 +511,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -519,7 +519,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	const rBits = 32
 	z[0] = uint32((uint64(z[0]) << rBits) % q)

--- a/field/babybear/element_purego.go
+++ b/field/babybear/element_purego.go
@@ -5,6 +5,8 @@
 
 package babybear
 
+import "math/bits"
+
 // MulBy3 x *= 3 (mod q)
 func MulBy3(x *Element) {
 	var y Element
@@ -47,12 +49,19 @@ func reduce(z *Element) {
 	_reduceGeneric(z)
 }
 func montReduce(v uint64) uint32 {
-	m := uint32(v) * qInvNeg
-	t := uint32((v + uint64(m)*q) >> 32)
-	if t >= q {
-		t -= q
+	const (
+		R    = 1 << 32
+		qInv = R - qInvNeg
+	)
+
+	m := uint32(v) * qInv
+	t, borrow := bits.Sub64(v, uint64(m)*q, 0)
+
+	res := uint32(t / R)
+	if borrow != 0 {
+		res += q
 	}
-	return t
+	return res
 }
 
 // Mul z = x * y (mod q)

--- a/field/generator/internal/templates/element/conv.go
+++ b/field/generator/internal/templates/element/conv.go
@@ -2,7 +2,7 @@ package element
 
 const Conv = `
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = {{.ElementName}}{
@@ -11,7 +11,7 @@ var rSquare = {{.ElementName}}{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *{{.ElementName}}) toMont() *{{.ElementName}} {
 	{{- if .F31}}
 		const rBits = 32

--- a/field/generator/internal/templates/element/ops_purego.go
+++ b/field/generator/internal/templates/element/ops_purego.go
@@ -2,9 +2,7 @@ package element
 
 const OpsNoAsm = `
 
-{{- if not .F31}}
 import "math/bits"
-{{- end}}
 
 {{ $mulConsts := list 3 5 13 }}
 {{- range $i := $mulConsts }}
@@ -61,12 +59,19 @@ func reduce(z *{{.ElementName}})  {
 
 {{- if $.F31}}
 func montReduce(v uint64) uint32 {
-	m := uint32(v) * qInvNeg
-	t := uint32((v + uint64(m) * q) >> 32)
-	if t >= q {
-		t -= q
+	const (
+		R    = 1 << 32
+		qInv = R - qInvNeg
+	)
+
+	m := uint32(v) * qInv
+	t, borrow := bits.Sub64(v, uint64(m)*q, 0)
+
+	res := uint32(t / R)
+	if borrow != 0 {
+		res += q
 	}
-	return t
+	return res
 }
 {{- end}}
 

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -536,7 +536,7 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	return z
 }
 
-// rSquare where r is the Montgommery constant
+// rSquare where r is the Montgomery constant
 // see section 2.3.2 of Tolga Acar's thesis
 // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 var rSquare = Element{
@@ -544,7 +544,7 @@ var rSquare = Element{
 }
 
 // toMont converts z to Montgomery form
-// sets and returns z = z * r²
+// sets and returns z = z * r
 func (z *Element) toMont() *Element {
 	return z.Mul(z, &rSquare)
 }

--- a/field/koalabear/element.go
+++ b/field/koalabear/element.go
@@ -521,9 +521,8 @@ var rSquare = Element{
 // toMont converts z to Montgomery form
 // sets and returns z = z * r
 func (z *Element) toMont() *Element {
-	const rSquaredModQ = ((1 << 32) % q << 32) % q
-
-	z[0] = montReduce(uint64(z[0]) * rSquaredModQ)
+	const rBits = 32
+	z[0] = uint32((uint64(z[0]) << rBits) % q)
 	return z
 }
 

--- a/field/koalabear/element_purego.go
+++ b/field/koalabear/element_purego.go
@@ -90,12 +90,3 @@ func (z *Element) Square(x *Element) *Element {
 func Butterfly(a, b *Element) {
 	_butterflyGeneric(a, b)
 }
-
-func ModSub(x, y uint32) uint32 {
-	const q = 0x12345
-	res, borrow := bits.Sub32(x, y, 0)
-	if borrow != 0 {
-		res += q
-	}
-	return res
-}


### PR DESCRIPTION
Slight modification to the Montgomery reduction algorithm to combine an addition and comparison into one subtraction.
The classic Montgomery reduction algo goes as follows (source [Wikipedia](https://en.wikipedia.org/wiki/Montgomery_modular_multiplication))

```
function REDC is
    input: Integers R and N with gcd(R, N) = 1,
           Integer N′ in [0, R − 1] such that NN′ ≡ −1 mod R,
           Integer T in the range [0, RN − 1].
    output: Integer S in the range [0, N − 1] such that S ≡ TR−1 mod N

    m ← ((T mod R)N′) mod R
    t ← (T + mN) / R
    if t ≥ N then
        return t − N
    else
        return t
    end if
end function
```

If instead of $N′$ we use $N″ = R-N′$ (due to @DavePearce) we get $m′ ← TN″ \mod R = T(R-N′) \mod R = -TN′ \mod R$.
Since the next multiplication and addition are performed modulo $R²$, after casting (zero-extend) we get $m′ ∈ \\{R-m, -m\\}$, the second case happening when $m = 0 = -m$. Let $t′ ← (T - m′N) / R$. If $m = 0$ then $R|T$ i.e. $T = nR$ for $0 ≤ n < N$, which gives $0 ≤ t′ = n < N$. Otherwise we get $-N ≤ t′ = t - N < N$. In either case $t′ = t \mod N$.

So we end up with:
```
function REDC is
    input: Integers R and N with gcd(R, N) = 1,
           Integer N″ in [0, R − 1] such that NN″ ≡ 1 mod R,
           Integer T in the range [0, RN − 1].
    output: Integer S in the range [0, N − 1] such that S ≡ TR−1 mod N

    m′ ← ((T mod R)N″) mod R
    t′ ← (T - m′N) / R
    if t′ < 0 then
        return t′ + N
    else
        return t′
    end if
end function
```

But this new "range check" is equivalent to whether `T - m′N` produces a borrow out. So may skip the `CMP`.

Benchmarking on an M1 Macbook Pro, currently the gains are a meager %1, but I expect that to rise if/when https://github.com/golang/go/issues/74878 is addressed.