### PR TITLE
Refector: Add feed-forward step to CompressPoseidon2 function

### DIFF
--- a/field/koalabear/vortex/hash.go
+++ b/field/koalabear/vortex/hash.go
@@ -20,11 +20,17 @@ func CompressPoseidon2(a, b Hash) Hash {
 	var x [16]koalabear.Element
 	copy(x[:], a[:])
 	copy(x[8:], b[:])
+
+	// Create a buffer to hold the feed-forward input.
+	copy(res[:], x[8:])
 	if err := compressPerm.Permutation(x[:]); err != nil {
 		// can't error (size is correct)
 		panic(err)
 	}
-	copy(res[:], x[:8])
+
+	for i := range res {
+		res[i].Add(&res[i], &x[8+i])
+	}
 	return res
 }
 

--- a/field/koalabear/vortex/merkle_test.go
+++ b/field/koalabear/vortex/merkle_test.go
@@ -7,8 +7,47 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/field/koalabear"
+	"github.com/consensys/gnark-crypto/field/koalabear/poseidon2"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPoseidon2BlockCompression(t *testing.T) {
+	// This test ensures that the CompressPoseidon2 function is correctly implemented and produces the same output as
+	// the poseidon2.NewMerkleDamgardHasher(), which uses Write and Sum methods to get the final hash output
+
+	for i := 0; i < 100; i++ {
+		var zero [8]koalabear.Element
+		var input [8]koalabear.Element
+
+		var inputBytes [32]byte
+		for i := 0; i < 8; i++ {
+			startIndex := i * 4
+			input[i].SetRandom()
+			valBytes := input[i].Bytes()
+			copy(inputBytes[startIndex:startIndex+4], valBytes[:])
+		}
+
+		h := CompressPoseidon2(zero, input)
+
+		merkleHasher := poseidon2.NewMerkleDamgardHasher()
+		merkleHasher.Reset()
+		merkleHasher.Write(inputBytes[:])
+		newBytes := merkleHasher.Sum(nil)
+
+		var result [8]koalabear.Element // Array to store the 8 reconstructed Elements
+
+		for i := 0; i < 8; i++ {
+			startIndex := i * 4
+			segment := newBytes[startIndex : startIndex+4]
+			var newElement koalabear.Element
+			newElement.SetBytes(segment)
+			result[i] = newElement
+			require.Equal(t, result[i].String(), h[i].String())
+
+		}
+
+	}
+}
 
 func TestMerkleTree(t *testing.T) {
 


### PR DESCRIPTION
# Description

This PR adds a feed-forward step in the `CompressPoseidon2` function to enhance collision resistance. The previous implementation of the compression function relied solely on the Poseidon2 permutation. 

A new test is introduced to ensure that the `CompressPoseidon2` function is correctly implemented and produces the same output as  the `poseidon2.NewMerkleDamgardHasher()`, which uses Write and Sum methods to get the final hash output.