### PR TITLE
chore: update GitHub actions in CI workflows 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: install Go
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     steps:
     - name: checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: install Go
@@ -45,7 +45,7 @@ jobs:
       failures: ${{ steps.generate-job-summary.outputs.failures }}
     steps:
     - name: checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: install Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0
