### PR TITLE
CI: Upgrade linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,9 +25,9 @@ jobs:
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after running go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-          version: v1.60
+          version: v2.1.6
           args: -v --timeout=5m
   
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,36 @@
+version: "2"
+run:
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
     - staticcheck
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
-linters-settings:
-  gosec:
-    excludes:
-      - G115 # Conversions from int -> uint etc.
-issues:
-  exclude-generated: disable
-run:
-  issues-exit-code: 1
+
+  settings:
+    gosec:
+      excludes:
+        - G115
+  exclusions:
+    generated: disable
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: disable
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/ecc/bls12-377/fp/vector.go
+++ b/ecc/bls12-377/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -129,7 +129,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-377/fp/vector_test.go
+++ b/ecc/bls12-377/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-377/fr/fft/fft.go
+++ b/ecc/bls12-377/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bls12-377/fr/iop/polynomial.go
+++ b/ecc/bls12-377/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bls12-377/fr/poseidon2/poseidon2.go
+++ b/ecc/bls12-377/fr/poseidon2/poseidon2.go
@@ -160,19 +160,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bls12-377/fr/vector.go
+++ b/ecc/bls12-377/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-377/fr/vector_test.go
+++ b/ecc/bls12-377/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-377/internal/fptower/e12.go
+++ b/ecc/bls12-377/internal/fptower/e12.go
@@ -533,7 +533,7 @@ func (z *E12) CyclotomicExp(x E12, k *big.Int) *E12 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bls12-377/marshal.go
+++ b/ecc/bls12-377/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bls12-377 objects

--- a/ecc/bls12-377/marshal_test.go
+++ b/ecc/bls12-377/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bls12-381/fp/vector.go
+++ b/ecc/bls12-381/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -129,7 +129,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-381/fp/vector_test.go
+++ b/ecc/bls12-381/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-381/fr/fft/fft.go
+++ b/ecc/bls12-381/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bls12-381/fr/iop/polynomial.go
+++ b/ecc/bls12-381/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bls12-381/fr/poseidon2/poseidon2.go
+++ b/ecc/bls12-381/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bls12-381/fr/vector.go
+++ b/ecc/bls12-381/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls12-381/fr/vector_test.go
+++ b/ecc/bls12-381/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-381/internal/fptower/e12.go
+++ b/ecc/bls12-381/internal/fptower/e12.go
@@ -533,7 +533,7 @@ func (z *E12) CyclotomicExp(x E12, k *big.Int) *E12 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bls12-381/marshal.go
+++ b/ecc/bls12-381/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bls12-381 objects

--- a/ecc/bls12-381/marshal_test.go
+++ b/ecc/bls12-381/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bls24-315/fp/vector.go
+++ b/ecc/bls24-315/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -128,7 +128,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-315/fp/vector_test.go
+++ b/ecc/bls24-315/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-315/fr/fft/fft.go
+++ b/ecc/bls24-315/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bls24-315/fr/iop/polynomial.go
+++ b/ecc/bls24-315/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bls24-315/fr/poseidon2/poseidon2.go
+++ b/ecc/bls24-315/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bls24-315/fr/vector.go
+++ b/ecc/bls24-315/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-315/fr/vector_test.go
+++ b/ecc/bls24-315/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-315/internal/fptower/e24.go
+++ b/ecc/bls24-315/internal/fptower/e24.go
@@ -523,7 +523,7 @@ func (z *E24) CyclotomicExp(x E24, k *big.Int) *E24 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bls24-315/marshal.go
+++ b/ecc/bls24-315/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bls24-315 objects

--- a/ecc/bls24-315/marshal_test.go
+++ b/ecc/bls24-315/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bls24-315/pairing.go
+++ b/ecc/bls24-315/pairing.go
@@ -201,10 +201,11 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			l1.r0.MulByElement(&l1.r0, &p[k].Y)
 			l1.r1.MulByElement(&l1.r1, &p[k].X)
 
-			if LoopCounter[i] == 0 {
+			switch LoopCounter[i] {
+			case 0:
 				// ℓ × result
 				result.MulBy034(&l1.r0, &l1.r1, &l1.r2)
-			} else if LoopCounter[i] == 1 {
+			case 1:
 				// qProj[k] ← qProj[k]+Q[k] and
 				// l2 the line ℓ passing qProj[k] and Q[k]
 				qProj[k].addMixedStep(&l2, &q[k])
@@ -215,7 +216,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				prodLines = fptower.Mul034By034(&l1.r0, &l1.r1, &l1.r2, &l2.r0, &l2.r1, &l2.r2)
 				// (ℓ × ℓ) × result
 				result.MulBy01234(&prodLines)
-			} else if LoopCounter[i] == -1 {
+			case -1:
 				// qProj[k] ← qProj[k]-Q[k] and
 				// l2 the line ℓ passing qProj[k] and -Q[k]
 				qProj[k].addMixedStep(&l2, &qNeg[k])
@@ -399,11 +400,12 @@ func PrecomputeLines(Q G2Affine) (PrecomputedLines [2][len(LoopCounter) - 1]Line
 	n := len(LoopCounter)
 	for i := n - 2; i >= 0; i-- {
 		accQ.doubleStep(&PrecomputedLines[0][i])
-		if LoopCounter[i] == 1 {
+		switch LoopCounter[i] {
+		case 1:
 			accQ.addStep(&PrecomputedLines[1][i], &Q)
-		} else if LoopCounter[i] == -1 {
+		case -1:
 			accQ.addStep(&PrecomputedLines[1][i], &negQ)
-		} else {
+		default:
 			continue
 		}
 	}

--- a/ecc/bls24-317/fp/vector.go
+++ b/ecc/bls24-317/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -128,7 +128,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-317/fp/vector_test.go
+++ b/ecc/bls24-317/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-317/fr/fft/fft.go
+++ b/ecc/bls24-317/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bls24-317/fr/iop/polynomial.go
+++ b/ecc/bls24-317/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bls24-317/fr/poseidon2/poseidon2.go
+++ b/ecc/bls24-317/fr/poseidon2/poseidon2.go
@@ -159,19 +159,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bls24-317/fr/vector.go
+++ b/ecc/bls24-317/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bls24-317/fr/vector_test.go
+++ b/ecc/bls24-317/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-317/internal/fptower/e24.go
+++ b/ecc/bls24-317/internal/fptower/e24.go
@@ -445,7 +445,7 @@ func (z *E24) CyclotomicExp(x E24, k *big.Int) *E24 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bls24-317/marshal.go
+++ b/ecc/bls24-317/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bls24-317 objects

--- a/ecc/bls24-317/marshal_test.go
+++ b/ecc/bls24-317/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bls24-317/pairing.go
+++ b/ecc/bls24-317/pairing.go
@@ -205,7 +205,8 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			l1.r1.MulByElement(&l1.r1, &p[k].X)
 			l1.r2.MulByElement(&l1.r2, &p[k].Y)
 
-			if LoopCounter[i] == 1 {
+			switch LoopCounter[i] {
+			case 1:
 				// qProj[k] ← qProj[k]+Q[k] and
 				// l2 the line ℓ passing qProj[k] and Q[k]
 				qProj[k].addMixedStep(&l2, &q[k])
@@ -216,7 +217,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				prodLines = fptower.Mul014By014(&l2.r0, &l2.r1, &l2.r2, &l1.r0, &l1.r1, &l1.r2)
 				// (ℓ × ℓ) × result
 				result.MulBy01245(&prodLines)
-			} else if LoopCounter[i] == -1 {
+			case -1:
 				// qProj[k] ← qProj[k]-Q[k] and
 				// l2 the line ℓ passing qProj[k] and -Q[k]
 				qProj[k].addMixedStep(&l2, &qNeg[k])
@@ -227,7 +228,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				prodLines = fptower.Mul014By014(&l2.r0, &l2.r1, &l2.r2, &l1.r0, &l1.r1, &l1.r2)
 				// (ℓ × ℓ) × result
 				result.MulBy01245(&prodLines)
-			} else {
+			default:
 				// ℓ × result
 				result.MulBy014(&l1.r0, &l1.r1, &l1.r2)
 			}
@@ -397,11 +398,12 @@ func PrecomputeLines(Q G2Affine) (PrecomputedLines [2][len(LoopCounter) - 1]Line
 	n := len(LoopCounter)
 	for i := n - 2; i >= 0; i-- {
 		accQ.doubleStep(&PrecomputedLines[0][i])
-		if LoopCounter[i] == 1 {
+		switch LoopCounter[i] {
+		case 1:
 			accQ.addStep(&PrecomputedLines[1][i], &Q)
-		} else if LoopCounter[i] == -1 {
+		case -1:
 			accQ.addStep(&PrecomputedLines[1][i], &negQ)
-		} else {
+		default:
 			continue
 		}
 	}

--- a/ecc/bn254/fp/vector.go
+++ b/ecc/bn254/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bn254/fp/vector_test.go
+++ b/ecc/bn254/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bn254/fr/fft/fft.go
+++ b/ecc/bn254/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bn254/fr/iop/polynomial.go
+++ b/ecc/bn254/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bn254/fr/poseidon2/poseidon2.go
+++ b/ecc/bn254/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bn254/fr/vector.go
+++ b/ecc/bn254/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bn254/fr/vector_test.go
+++ b/ecc/bn254/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bn254/internal/fptower/e12.go
+++ b/ecc/bn254/internal/fptower/e12.go
@@ -533,7 +533,7 @@ func (z *E12) CyclotomicExp(x E12, k *big.Int) *E12 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bn254/marshal.go
+++ b/ecc/bn254/marshal.go
@@ -379,7 +379,7 @@ func (dec *Decoder) readUint64() (r uint64, err error) {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !(mData == mUncompressed)
+	return mData != mUncompressed
 }
 
 // NewEncoder returns a binary encoder supporting curve bn254 objects

--- a/ecc/bn254/marshal_test.go
+++ b/ecc/bn254/marshal_test.go
@@ -249,7 +249,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -267,7 +267,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -342,7 +342,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -360,7 +360,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bn254/pairing.go
+++ b/ecc/bn254/pairing.go
@@ -223,7 +223,8 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 			l1.r0.MulByElement(&l1.r0, &p[k].Y)
 			l1.r1.MulByElement(&l1.r1, &p[k].X)
 
-			if LoopCounter[i] == 1 {
+			switch LoopCounter[i] {
+			case 1:
 				// qProj[k] ← qProj[k]+Q[k] and
 				// l2 the line ℓ passing qProj[k] and Q[k]
 				qProj[k].addMixedStep(&l2, &q[k])
@@ -234,8 +235,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				prodLines = fptower.Mul034By034(&l1.r0, &l1.r1, &l1.r2, &l2.r0, &l2.r1, &l2.r2)
 				// (ℓ × ℓ) × res
 				result.MulBy01234(&prodLines)
-
-			} else if LoopCounter[i] == -1 {
+			case -1:
 				// qProj[k] ← qProj[k]-Q[k] and
 				// l2 the line ℓ passing qProj[k] and -Q[k]
 				qProj[k].addMixedStep(&l2, &qNeg[k])
@@ -246,7 +246,7 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 				prodLines = fptower.Mul034By034(&l1.r0, &l1.r1, &l1.r2, &l2.r0, &l2.r1, &l2.r2)
 				// (ℓ × ℓ) × res
 				result.MulBy01234(&prodLines)
-			} else {
+			default:
 				// ℓ × res
 				result.MulBy034(&l1.r0, &l1.r1, &l1.r2)
 			}

--- a/ecc/bw6-633/fp/vector.go
+++ b/ecc/bw6-633/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -133,7 +133,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-633/fp/vector_test.go
+++ b/ecc/bw6-633/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-633/fr/fft/fft.go
+++ b/ecc/bw6-633/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bw6-633/fr/iop/polynomial.go
+++ b/ecc/bw6-633/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bw6-633/fr/poseidon2/poseidon2.go
+++ b/ecc/bw6-633/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bw6-633/fr/vector.go
+++ b/ecc/bw6-633/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -128,7 +128,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-633/fr/vector_test.go
+++ b/ecc/bw6-633/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-633/internal/fptower/e6.go
+++ b/ecc/bw6-633/internal/fptower/e6.go
@@ -523,7 +523,7 @@ func (z *E6) CyclotomicExp(x E6, k *big.Int) *E6 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bw6-633/marshal.go
+++ b/ecc/bw6-633/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bw6-633 objects

--- a/ecc/bw6-633/marshal_test.go
+++ b/ecc/bw6-633/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/bw6-761/fp/vector.go
+++ b/ecc/bw6-761/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -135,7 +135,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-761/fp/vector_test.go
+++ b/ecc/bw6-761/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-761/fr/fft/fft.go
+++ b/ecc/bw6-761/fr/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/ecc/bw6-761/fr/iop/polynomial.go
+++ b/ecc/bw6-761/fr/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x fr.Element) fr.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) fr.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(fr.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/ecc/bw6-761/fr/poseidon2/poseidon2.go
+++ b/ecc/bw6-761/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/bw6-761/fr/vector.go
+++ b/ecc/bw6-761/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -129,7 +129,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/bw6-761/fr/vector_test.go
+++ b/ecc/bw6-761/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-761/internal/fptower/e6.go
+++ b/ecc/bw6-761/internal/fptower/e6.go
@@ -446,7 +446,7 @@ func (z *E6) CyclotomicExp(x E6, k *big.Int) *E6 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 { // nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)

--- a/ecc/bw6-761/marshal.go
+++ b/ecc/bw6-761/marshal.go
@@ -414,7 +414,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed) || (mData == mUncompressedInfinity))
+	return mData != mUncompressed && mData != mUncompressedInfinity
 }
 
 // NewEncoder returns a binary encoder supporting curve bw6-761 objects

--- a/ecc/bw6-761/marshal_test.go
+++ b/ecc/bw6-761/marshal_test.go
@@ -269,7 +269,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -287,7 +287,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -382,7 +382,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -400,7 +400,7 @@ func TestG2AffineSerialization(t *testing.T) {
 			if n != SizeOfG2AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/grumpkin/fp/vector.go
+++ b/ecc/grumpkin/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/grumpkin/fp/vector_test.go
+++ b/ecc/grumpkin/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/grumpkin/fr/poseidon2/poseidon2.go
+++ b/ecc/grumpkin/fr/poseidon2/poseidon2.go
@@ -158,19 +158,19 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
 			Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
+	default:
 		panic("only Width=2,3 are supported")
 	}
 }

--- a/ecc/grumpkin/fr/vector.go
+++ b/ecc/grumpkin/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/grumpkin/fr/vector_test.go
+++ b/ecc/grumpkin/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/grumpkin/marshal.go
+++ b/ecc/grumpkin/marshal.go
@@ -295,7 +295,7 @@ func (dec *Decoder) readUint64() (r uint64, err error) {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !(mData == mUncompressed)
+	return mData != mUncompressed
 }
 
 // NewEncoder returns a binary encoder supporting curve bn254 objects

--- a/ecc/grumpkin/marshal_test.go
+++ b/ecc/grumpkin/marshal_test.go
@@ -205,7 +205,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -223,7 +223,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/secp256k1/fp/vector.go
+++ b/ecc/secp256k1/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/secp256k1/fp/vector_test.go
+++ b/ecc/secp256k1/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/secp256k1/fr/vector.go
+++ b/ecc/secp256k1/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/secp256k1/fr/vector_test.go
+++ b/ecc/secp256k1/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/secp256k1/marshal_test.go
+++ b/ecc/secp256k1/marshal_test.go
@@ -32,7 +32,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/ecc/stark-curve/fp/vector.go
+++ b/ecc/stark-curve/fp/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/stark-curve/fp/vector_test.go
+++ b/ecc/stark-curve/fp/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/stark-curve/fr/vector.go
+++ b/ecc/stark-curve/fr/vector.go
@@ -73,12 +73,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-		return int64(read), err, chErr
+		return int64(read), chErr, err
 	}
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -86,7 +86,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -94,7 +94,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 	go func() {
@@ -127,7 +127,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded Element.

--- a/ecc/stark-curve/fr/vector_test.go
+++ b/ecc/stark-curve/fr/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/ecc/stark-curve/marshal.go
+++ b/ecc/stark-curve/marshal.go
@@ -242,7 +242,7 @@ func (dec *Decoder) readUint32() (r uint32, err error) {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !(mData == mUncompressed)
+	return mData != mUncompressed
 }
 
 // NewEncoder returns a binary encoder supporting curve stark-curve objects

--- a/ecc/stark-curve/marshal_test.go
+++ b/ecc/stark-curve/marshal_test.go
@@ -164,7 +164,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineCompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -182,7 +182,7 @@ func TestG1AffineSerialization(t *testing.T) {
 			if n != SizeOfG1AffineUncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/field/babybear/fft/fft.go
+++ b/field/babybear/fft/fft.go
@@ -207,7 +207,7 @@ func difFFT(a []babybear.Element, w babybear.Element, twiddles [][]babybear.Elem
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 {
+		if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -287,7 +287,7 @@ func ditFFT(a []babybear.Element, w babybear.Element, twiddles [][]babybear.Elem
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 {
+		if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/field/babybear/iop/polynomial.go
+++ b/field/babybear/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x babybear.Element) babybear.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x babybear.Element) babybear.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x babybear.Element) babybear.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) babybear.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(babybear.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/field/babybear/vector_test.go
+++ b/field/babybear/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/field/generator/asm/amd64/build.go
+++ b/field/generator/asm/amd64/build.go
@@ -204,7 +204,7 @@ func (f *FFAmd64) UnsafePush(registers *amd64.Registers, rIn ...amd64.Register) 
 }
 
 func (f *FFAmd64) Pop(registers *amd64.Registers, forceStack ...bool) amd64.Register {
-	if registers.Available() >= 1 && !(len(forceStack) > 0 && forceStack[0]) {
+	if registers.Available() >= 1 && (len(forceStack) == 0 || !forceStack[0]) {
 		return registers.Pop()
 	}
 	r := amd64.Register(fmt.Sprintf("s%d-%d(SP)", f.nbElementsOnStack, 8+f.nbElementsOnStack*8))

--- a/field/generator/asm/arm64/build.go
+++ b/field/generator/asm/arm64/build.go
@@ -165,7 +165,7 @@ func (f *FFArm64) Push(registers *arm64.Registers, rIn ...arm64.Register) {
 }
 
 func (f *FFArm64) Pop(registers *arm64.Registers, forceStack ...bool) arm64.Register {
-	if registers.Available() >= 1 && !(len(forceStack) > 0 && forceStack[0]) {
+	if registers.Available() >= 1 && (len(forceStack) == 0 || !forceStack[0]) {
 		return registers.Pop()
 	}
 	r := arm64.Register(fmt.Sprintf("s%d-%d(SP)", f.nbElementsOnStack, 8+f.nbElementsOnStack*8))

--- a/field/generator/asm/arm64/element_mul.go
+++ b/field/generator/asm/arm64/element_mul.go
@@ -211,10 +211,10 @@ func (f *FFArm64) reduceAndStore(t, q []arm64.Register, zPtr arm64.Register) {
 }
 
 func (f *FFArm64) add0n(i int) func(op1, op2, dst interface{}, comment ...string) {
-	switch {
-	case i == 0:
+	switch i {
+	case 0:
 		return f.ADDS
-	case i == f.NbWordsLastIndex:
+	case f.NbWordsLastIndex:
 		return f.ADC
 	default:
 		return f.ADCS
@@ -222,10 +222,10 @@ func (f *FFArm64) add0n(i int) func(op1, op2, dst interface{}, comment ...string
 }
 
 func (f *FFArm64) add0m(i int) func(op1, op2, dst interface{}, comment ...string) {
-	switch {
-	case i == 0:
+	switch i {
+	case 0:
 		return f.ADDS
-	case i == f.NbWordsLastIndex+1:
+	case f.NbWordsLastIndex + 1:
 		return f.ADC
 	default:
 		return f.ADCS
@@ -233,10 +233,10 @@ func (f *FFArm64) add0m(i int) func(op1, op2, dst interface{}, comment ...string
 }
 
 func (f *FFArm64) add1m(i int, dumb ...bool) func(op1, op2, dst interface{}, comment ...string) {
-	switch {
-	case i == 1:
+	switch i {
+	case 1:
 		return f.ADDS
-	case i == f.NbWordsLastIndex+1:
+	case f.NbWordsLastIndex + 1:
 		if len(dumb) == 1 && dumb[0] {
 			// odd, but it performs better on c8g instances.
 			return f.ADCS

--- a/field/generator/generator_asm.go
+++ b/field/generator/generator_asm.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -95,8 +96,10 @@ func generateDummyGoPackage(F *config.Field, asm *config.Assembly) error {
 	f.WriteString("\nconst qInvNeg = 0")
 	f.WriteString("\nconst mu = 0")
 	f.WriteString("\nconst q = 0")
-	for i := 0; i < F.NbWords; i++ {
-		f.WriteString(fmt.Sprintf("\nconst q%d = 0", i))
+	for i := range F.NbWords {
+		if _, err = fmt.Fprintf(f, "\nconst q%d = 0", i); err != nil {
+			return errors.Join(err, f.Close())
+		}
 	}
 
 	f.WriteString("\n")

--- a/field/generator/generator_field.go
+++ b/field/generator/generator_field.go
@@ -128,16 +128,16 @@ func generateField(F *config.Field, outputDir, asmDirIncludePath, hashArm64, has
 
 	// purego files have no build tags if we don't generate asm
 	pureGoBuildTag := "purego || (!amd64 && !arm64)"
-	if !(F.GenerateOpsAMD64 && hashAMD64 != "") && !(F.GenerateOpsARM64 && hashArm64 != "") {
+	if (!F.GenerateOpsAMD64 || hashAMD64 == "") && (!F.GenerateOpsARM64 || hashArm64 == "") {
 		pureGoBuildTag = ""
-	} else if !(F.GenerateOpsARM64 && hashArm64 != "") {
+	} else if !F.GenerateOpsARM64 || hashArm64 == "" {
 		pureGoBuildTag = "purego || (!amd64)"
 	}
 
 	pureGoVectorBuildTag := "purego || (!amd64 && !arm64)"
-	if !(F.GenerateVectorOpsAMD64 && hashAMD64 != "") && !(F.GenerateVectorOpsARM64 && hashArm64 != "") {
+	if (!F.GenerateVectorOpsAMD64 || hashAMD64 == "") && (!F.GenerateVectorOpsARM64 || hashArm64 == "") {
 		pureGoVectorBuildTag = ""
-	} else if !(F.GenerateVectorOpsARM64 && hashArm64 != "") {
+	} else if !F.GenerateVectorOpsARM64 || hashArm64 == "" {
 		pureGoVectorBuildTag = "purego || (!amd64)"
 	}
 

--- a/field/generator/generator_sis.go
+++ b/field/generator/generator_sis.go
@@ -107,9 +107,9 @@ func partialFFT(domainSize, numField int, mask int64) string {
 	gen.indent()
 
 	var (
-		numStages int = log2Ceil(int(domainSize))
-		numSplits int = 1
-		splitSize int = int(domainSize)
+		numStages = log2Ceil(domainSize)
+		numSplits = 1
+		splitSize = domainSize
 	)
 
 	for level := 0; level < numStages; level++ {

--- a/field/generator/internal/templates/element/tests_vector.go
+++ b/field/generator/internal/templates/element/tests_vector.go
@@ -74,7 +74,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/field/generator/internal/templates/element/vector.go
+++ b/field/generator/internal/templates/element/vector.go
@@ -70,12 +70,12 @@ func (vector *Vector) WriteTo(w io.Writer) (int64, error) {
 // It also returns a channel that will be closed when the validation is done.
 // The validation consist of checking that the elements are smaller than the modulus, and
 // converting them to montgomery form.
-func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
+func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error) {
 	chErr := make(chan error, 1)
 	var buf [Bytes]byte 
 	if read, err := io.ReadFull(r, buf[:4]); err != nil {
 		close(chErr)
-        return int64(read), err, chErr
+        return int64(read), chErr, err
     }
 	sliceLen := binary.BigEndian.Uint32(buf[:4])
 
@@ -83,7 +83,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	(*vector) = make(Vector, sliceLen)
 	if sliceLen == 0 {
 		close(chErr)
-		return n, nil, chErr
+		return n, chErr, nil
 	}
 
 	bSlice := unsafe.Slice((*byte)(unsafe.Pointer(&(*vector)[0])), sliceLen*Bytes)
@@ -91,7 +91,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 	n += int64(read)
 	if err != nil {
 		close(chErr)
-		return n, err, chErr
+		return n, chErr, err
 	}
 
 
@@ -128,7 +128,7 @@ func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error) {
 		}
 		close(chErr)
 	}()
-	return n, nil, chErr
+	return n, chErr, nil
 }
 
 // ReadFrom implements io.ReaderFrom and reads a vector of big endian encoded {{.ElementName}}.

--- a/field/generator/internal/templates/fft/fft.go.tmpl
+++ b/field/generator/internal/templates/fft/fft.go.tmpl
@@ -213,7 +213,7 @@ func difFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 		return
 	} else if  stage >= twiddlesStartStage {
 		{{- range $ki, $klog2 :=  $.Kernels}}
-			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} {
+			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} {	// nolint QF1003
 				{{- $ksize := shl 1 $klog2}}
 				kerDIFNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
 				return
@@ -307,7 +307,7 @@ func ditFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 		return
 	} else if stage >= twiddlesStartStage {
 		{{- range $ki, $klog2 :=  $.Kernels}}
-			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} {
+			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} { // nolint QF1003
 				{{- $ksize := shl 1 $klog2}}
 				kerDITNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
 				return

--- a/field/generator/internal/templates/iop/polynomial.go.tmpl
+++ b/field/generator/internal/templates/iop/polynomial.go.tmpl
@@ -103,7 +103,7 @@ func (p *Polynomial) Evaluate(x {{ .ElementType }}) {{ .ElementType }} {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -113,14 +113,14 @@ func (p *Polynomial) Evaluate(x {{ .ElementType }}) {{ .ElementType }} {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen .Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -128,7 +128,7 @@ func (p *Polynomial) Evaluate(x {{ .ElementType }}) {{ .ElementType }} {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -144,7 +144,7 @@ func (p *Polynomial) GetCoeff(i int) {{ .ElementType }} {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -385,7 +385,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -422,11 +422,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make({{ .FieldPackageName }}.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/field/goff/cmd/root.go
+++ b/field/goff/cmd/root.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/field/generator"
 	"github.com/consensys/gnark-crypto/field/generator/config"
-	field "github.com/consensys/gnark-crypto/field/generator/config"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +55,7 @@ func cmdGenerate(cmd *cobra.Command, args []string) {
 	}
 
 	// generate code
-	F, err := field.NewFieldConfig(fPackageName, fElementName, fModulus, false)
+	F, err := config.NewFieldConfig(fPackageName, fElementName, fModulus, false)
 	if err != nil {
 		fmt.Printf("\n%s\n", err.Error())
 		os.Exit(-1)

--- a/field/goldilocks/fft/fft.go
+++ b/field/goldilocks/fft/fft.go
@@ -201,10 +201,10 @@ func difFFT(a []goldilocks.Element, w goldilocks.Element, twiddles [][]goldilock
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -290,10 +290,10 @@ func ditFFT(a []goldilocks.Element, w goldilocks.Element, twiddles [][]goldilock
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 {
+		if n == 1<<5 { // nolint QF1003
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 {
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/field/goldilocks/iop/polynomial.go
+++ b/field/goldilocks/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x goldilocks.Element) goldilocks.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x goldilocks.Element) goldilocks.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x goldilocks.Element) goldilocks.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) goldilocks.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(goldilocks.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/field/goldilocks/vector_test.go
+++ b/field/goldilocks/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -207,7 +207,7 @@ func difFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 {
+		if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -287,7 +287,7 @@ func ditFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 {
+		if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}

--- a/field/koalabear/iop/polynomial.go
+++ b/field/koalabear/iop/polynomial.go
@@ -110,7 +110,7 @@ func (p *Polynomial) Evaluate(x koalabear.Element) koalabear.Element {
 	}
 
 	if p.shift == 0 {
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	gen, err := fft.Generator(uint64(p.size))
@@ -120,14 +120,14 @@ func (p *Polynomial) Evaluate(x koalabear.Element) koalabear.Element {
 	if p.shift <= 5 {
 		gen = smallExp(gen, p.shift)
 		x.Mul(&x, &gen)
-		return p.polynomial.evaluate(x)
+		return p.evaluate(x)
 	}
 
 	bs := big.NewInt(int64(p.shift))
 	gen.Exp(gen, bs)
 	x.Mul(&x, &gen)
 
-	return p.polynomial.evaluate(x)
+	return p.evaluate(x)
 }
 
 // Clone returns a deep copy of p. The underlying polynomial is cloned;
@@ -135,7 +135,7 @@ func (p *Polynomial) Evaluate(x koalabear.Element) koalabear.Element {
 // If capacity is provided, the new coefficient slice capacity will be set accordingly.
 func (p *Polynomial) Clone(capacity ...int) *Polynomial {
 	res := p.ShallowClone()
-	res.polynomial = p.polynomial.clone(capacity...)
+	res.polynomial = p.clone(capacity...)
 	return res
 }
 
@@ -151,7 +151,7 @@ func (p *Polynomial) GetCoeff(i int) koalabear.Element {
 
 	n := p.coefficients.Len()
 	rho := n / p.size
-	if p.polynomial.Form.Layout == Regular {
+	if p.Layout == Regular {
 		return (*p.coefficients)[(i+rho*p.shift)%n]
 	} else {
 		nn := uint64(64 - bits.TrailingZeros(uint(n)))
@@ -392,7 +392,7 @@ func (p *Polynomial) ToLagrangeCoset(d *fft.Domain) *Polynomial {
 func (p *Polynomial) WriteTo(w io.Writer) (int64, error) {
 
 	// encode coefficients
-	n, err := p.polynomial.coefficients.WriteTo(w)
+	n, err := p.coefficients.WriteTo(w)
 	if err != nil {
 		return n, err
 	}
@@ -429,11 +429,11 @@ func (p *Polynomial) ReadFrom(r io.Reader) (int64, error) {
 	if p.polynomial == nil {
 		p.polynomial = new(polynomial)
 	}
-	if p.polynomial.coefficients == nil {
+	if p.coefficients == nil {
 		v := make(koalabear.Vector, 0)
-		p.polynomial.coefficients = &v
+		p.coefficients = &v
 	}
-	n, err := p.polynomial.coefficients.ReadFrom(r)
+	n, err := p.coefficients.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}

--- a/field/koalabear/vector_test.go
+++ b/field/koalabear/vector_test.go
@@ -76,7 +76,7 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
-	_, err, chErr := vector.AsyncReadFrom(r)
+	_, chErr, err := vector.AsyncReadFrom(r)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/crypto/hash/poseidon2/template/poseidon2.go.tmpl
+++ b/internal/generator/crypto/hash/poseidon2/template/poseidon2.go.tmpl
@@ -170,20 +170,20 @@ func (h *Permutation) sBox(index int, input []fr.Element) {
 // see https://eprint.iacr.org/2023/323.pdf page 15, case T=2,3
 func (h *Permutation) matMulExternalInPlace(input []fr.Element) {
 
-	if h.params.Width == 2 {
-		var tmp fr.Element
+	var tmp fr.Element
+	switch h.params.Width {
+	case 2:
 		tmp.Add(&input[0], &input[1])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
-	} else if h.params.Width == 3 {
-		var tmp fr.Element
+	case 3:
 		tmp.Add(&input[0], &input[1]).
-			Add(&tmp, &input[2])
+		Add(&tmp, &input[2])
 		input[0].Add(&tmp, &input[0])
 		input[1].Add(&tmp, &input[1])
 		input[2].Add(&tmp, &input[2])
-	} else {
-        panic("only Width=2,3 are supported")
+	default:
+		panic("only Width=2,3 are supported")
 	}
 }
 

--- a/internal/generator/ecc/template/marshal.go.tmpl
+++ b/internal/generator/ecc/template/marshal.go.tmpl
@@ -441,7 +441,7 @@ func isMaskInvalid(msb byte) bool {
 
 func isCompressed(msb byte) bool {
 	mData := msb & mMask
-	return !((mData == mUncompressed){{- if ge .FpUnusedBits 3}}||(mData == mUncompressedInfinity) {{- end}})
+	return mData != mUncompressed{{- if ge .FpUnusedBits 3}}&& mData != mUncompressedInfinity {{- end}}
 }
 
 

--- a/internal/generator/ecc/template/tests/marshal.go.tmpl
+++ b/internal/generator/ecc/template/tests/marshal.go.tmpl
@@ -290,7 +290,7 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 			if n != SizeOf{{ $.TAffine }}Compressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}
@@ -308,7 +308,7 @@ func Test{{ $.TAffine }}Serialization(t *testing.T) {
 			if n != SizeOf{{ $.TAffine }}Uncompressed {
 				t.Fatal("invalid number of bytes consumed in buffer")
 			}
-			if !(p2.X.IsZero() && p2.Y.IsZero()) {
+			if !(p2.X.IsZero() && p2.Y.IsZero()) { // nolint QF1001
 				t.Fatal("deserialization of uncompressed infinity point is not infinity")
 			}
 		}

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -73,7 +73,7 @@ func main() {
 			conf.FpUnusedBits = 64 - (conf.Fp.NbBits % 64)
 
 			frOpts := []generator.Option{generator.WithASM(asmConfig)}
-			if !(conf.Equal(config.STARK_CURVE) || conf.Equal(config.SECP256K1) || conf.Equal(config.GRUMPKIN)) {
+			if !(conf.Equal(config.STARK_CURVE) || conf.Equal(config.SECP256K1) || conf.Equal(config.GRUMPKIN)) { // nolint QF1001
 				frOpts = append(frOpts, generator.WithFFT(fftConfig), generator.WithIOP())
 			}
 			if conf.Equal(config.BLS12_377) {

--- a/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq12.go.tmpl
@@ -521,7 +521,7 @@ func (z *E12) CyclotomicExp(x E12, k *big.Int) *E12 {
 	n := ecc.NafDecomposition(e, eNAF[:])
 	for i := n - 1; i >= 0; i-- {
 		res.CyclotomicSquare(&res)
-		if eNAF[i] == 1 {
+		if eNAF[i] == 1 {	// nolint QF1003
 			res.Mul(&res, &x)
 		} else if eNAF[i] == -1 {
 			res.Mul(&res, &xInv)


### PR DESCRIPTION
Upgrade `golangci-lint` to `v2.1.6`.
Some changes were made to satisfy the now-stricter `staticcheck` linter.

WARNING: Fixing `ST1008` involved an API change:
```go
func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, error, chan error)
```
is now
```go
func (vector *Vector) AsyncReadFrom(r io.Reader) (int64, chan error, error)
```