### PR TITLE
fix: prevent panic on empty vectors in AMD64 vector operations

### DIFF
--- a/ecc/bls12-377/fp/vector_test.go
+++ b/ecc/bls12-377/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls12-377/fr/vector_amd64.go
+++ b/ecc/bls12-377/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bls12-377/fr/vector_amd64.go
+++ b/ecc/bls12-377/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bls12-377/fr/vector_test.go
+++ b/ecc/bls12-377/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls12-381/fp/vector_test.go
+++ b/ecc/bls12-381/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls12-381/fr/vector_amd64.go
+++ b/ecc/bls12-381/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bls12-381/fr/vector_amd64.go
+++ b/ecc/bls12-381/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bls12-381/fr/vector_test.go
+++ b/ecc/bls12-381/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls24-315/fp/vector_test.go
+++ b/ecc/bls24-315/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls24-315/fr/vector_amd64.go
+++ b/ecc/bls24-315/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bls24-315/fr/vector_amd64.go
+++ b/ecc/bls24-315/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bls24-315/fr/vector_test.go
+++ b/ecc/bls24-315/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls24-317/fp/vector_test.go
+++ b/ecc/bls24-317/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bls24-317/fr/vector_amd64.go
+++ b/ecc/bls24-317/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bls24-317/fr/vector_amd64.go
+++ b/ecc/bls24-317/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bls24-317/fr/vector_test.go
+++ b/ecc/bls24-317/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bn254/fp/vector_amd64.go
+++ b/ecc/bn254/fp/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bn254/fp/vector_amd64.go
+++ b/ecc/bn254/fp/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bn254/fp/vector_test.go
+++ b/ecc/bn254/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bn254/fr/vector_amd64.go
+++ b/ecc/bn254/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/bn254/fr/vector_amd64.go
+++ b/ecc/bn254/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/bn254/fr/vector_test.go
+++ b/ecc/bn254/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bw6-633/fp/vector_test.go
+++ b/ecc/bw6-633/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bw6-633/fr/vector_test.go
+++ b/ecc/bw6-633/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bw6-761/fp/vector_test.go
+++ b/ecc/bw6-761/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/bw6-761/fr/vector_test.go
+++ b/ecc/bw6-761/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/grumpkin/fp/vector_amd64.go
+++ b/ecc/grumpkin/fp/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/grumpkin/fp/vector_amd64.go
+++ b/ecc/grumpkin/fp/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/grumpkin/fp/vector_test.go
+++ b/ecc/grumpkin/fp/vector_test.go
@@ -77,39 +77,23 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 func TestVectorEmptyOps(t *testing.T) {
 	assert := require.New(t)
 
-	// Test operations with empty vectors
 	empty := make(Vector, 0)
 	result := make(Vector, 0)
 
-	// Test Add with empty vectors
-	assert.NotPanics(func() {
-		result.Add(empty, empty)
-	})
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
 
-	// Test Sub with empty vectors
-	assert.NotPanics(func() {
-		result.Sub(empty, empty)
-	})
-
-	// Test ScalarMul with empty vector
 	var scalar Element
 	scalar.SetUint64(42)
-	assert.NotPanics(func() {
-		result.ScalarMul(empty, &scalar)
-	})
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
 
-	// Test Mul with empty vectors
-	assert.NotPanics(func() {
-		result.Mul(empty, empty)
-	})
+	assert.NotPanics(func() { result.Mul(empty, empty) })
 
-	// Test Sum with empty vector
 	sum := empty.Sum()
 	assert.True(sum.IsZero())
 
-	// Test InnerProduct with empty vectors
-	innerProd := empty.InnerProduct(empty)
-	assert.True(innerProd.IsZero())
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
 }
 
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {

--- a/ecc/grumpkin/fp/vector_test.go
+++ b/ecc/grumpkin/fp/vector_test.go
@@ -74,6 +74,44 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	// Test operations with empty vectors
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	// Test Add with empty vectors
+	assert.NotPanics(func() {
+		result.Add(empty, empty)
+	})
+
+	// Test Sub with empty vectors
+	assert.NotPanics(func() {
+		result.Sub(empty, empty)
+	})
+
+	// Test ScalarMul with empty vector
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() {
+		result.ScalarMul(empty, &scalar)
+	})
+
+	// Test Mul with empty vectors
+	assert.NotPanics(func() {
+		result.Mul(empty, empty)
+	})
+
+	// Test Sum with empty vector
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	// Test InnerProduct with empty vectors
+	innerProd := empty.InnerProduct(empty)
+	assert.True(innerProd.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/grumpkin/fr/vector_amd64.go
+++ b/ecc/grumpkin/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/grumpkin/fr/vector_amd64.go
+++ b/ecc/grumpkin/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/grumpkin/fr/vector_test.go
+++ b/ecc/grumpkin/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/secp256k1/fp/vector_test.go
+++ b/ecc/secp256k1/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/secp256k1/fr/vector_test.go
+++ b/ecc/secp256k1/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/stark-curve/fp/vector_amd64.go
+++ b/ecc/stark-curve/fp/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/stark-curve/fp/vector_amd64.go
+++ b/ecc/stark-curve/fp/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/stark-curve/fp/vector_test.go
+++ b/ecc/stark-curve/fp/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/ecc/stark-curve/fr/vector_amd64.go
+++ b/ecc/stark-curve/fr/vector_amd64.go
@@ -38,7 +38,7 @@ func (vector *Vector) Sub(a, b Vector) {
 	if n == 0 {
 		return
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape

--- a/ecc/stark-curve/fr/vector_amd64.go
+++ b/ecc/stark-curve/fr/vector_amd64.go
@@ -19,6 +19,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -30,6 +33,10 @@ func addVec(res, a, b *Element, n uint64)
 func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
+	}
+	n := uint64(len(a))
+	if n == 0 {
+		return
 	}
 	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
 }
@@ -94,11 +101,11 @@ func sumVec(res *Element, a *Element, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res Element) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {

--- a/ecc/stark-curve/fr/vector_test.go
+++ b/ecc/stark-curve/fr/vector_test.go
@@ -74,6 +74,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3, v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar Element
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/field/generator/internal/templates/element/tests_vector.go
+++ b/field/generator/internal/templates/element/tests_vector.go
@@ -72,6 +72,28 @@ func TestVectorEmptyRoundTrip(t *testing.T) {
 	assert.True(reflect.DeepEqual(v3,v2))
 }
 
+func TestVectorEmptyOps(t *testing.T) {
+	assert := require.New(t)
+
+	empty := make(Vector, 0)
+	result := make(Vector, 0)
+
+	assert.NotPanics(func() { result.Add(empty, empty) })
+	assert.NotPanics(func() { result.Sub(empty, empty) })
+
+	var scalar {{.ElementName}}
+	scalar.SetUint64(42)
+	assert.NotPanics(func() { result.ScalarMul(empty, &scalar) })
+
+	assert.NotPanics(func() { result.Mul(empty, empty) })
+
+	sum := empty.Sum()
+	assert.True(sum.IsZero())
+
+	inner := empty.InnerProduct(empty)
+	assert.True(inner.IsZero())
+}
+
 func (vector *Vector) unmarshalBinaryAsync(data []byte) error {
 	r := bytes.NewReader(data)
 	_, err, chErr := vector.AsyncReadFrom(r)

--- a/field/generator/internal/templates/element/vector_ops_asm.go
+++ b/field/generator/internal/templates/element/vector_ops_asm.go
@@ -14,6 +14,9 @@ func (vector *Vector) Add(a, b Vector) {
 		panic("vector.Add: vectors don't have the same length")
 	}
 		n := uint64(len(a))
+	if n == 0 {
+		return
+	}
 	addVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
@@ -26,7 +29,11 @@ func (vector *Vector) Sub(a, b Vector) {
 	if len(a) != len(b) || len(a) != len(*vector) {
 		panic("vector.Sub: vectors don't have the same length")
 	}
-	subVec(&(*vector)[0], &a[0], &b[0], uint64(len(a)))
+	n := uint64(len(a))
+	if n == 0 {
+		return
+	}
+	subVec(&(*vector)[0], &a[0], &b[0], n)
 }
 
 //go:noescape
@@ -89,11 +96,11 @@ func sumVec(res *{{.ElementName}}, a *{{.ElementName}}, n uint64)
 // It panics if the vectors don't have the same length.
 func (vector *Vector) InnerProduct(other Vector) (res {{.ElementName}}) {
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 	const maxN = (1 << 32) - 1
 	if !cpu.SupportAVX512 || n >= maxN {
@@ -419,11 +426,11 @@ func (vector *Vector) InnerProduct(other Vector) (res {{.ElementName}}) {
 	}
 
 	n := uint64(len(*vector))
-	if n == 0 {
-		return
-	}
 	if n != uint64(len(other)) {
 		panic("vector.InnerProduct: vectors don't have the same length")
+	}
+	if n == 0 {
+		return
 	}
 
 	const blockSize = 16


### PR DESCRIPTION
Fix panic when calling Add/Sub methods on empty vectors in AMD64-optimized
vector implementations across multiple elliptic curve packages.

- Add length check for empty vectors before accessing &a[0] in Add/Sub methods
- Fix InnerProduct validation order to check lengths before empty check
- Ensure consistent behavior with generic implementations
- Apply fixes to all affected curve packages: grumpkin, bn254, stark-curve,
  bls12-381, bls12-377, bls24-315, bls24-317 (both fp and fr packages)
- Add comprehensive test coverage for empty vector operations

This prevents runtime panics that could occur when processing empty vectors
in high-performance cryptographic operations, improving robustness of the
vector math library.