### PR TITLE
perf: optimize (purego) extension for koalabear

### DIFF
--- a/field/babybear/element_purego.go
+++ b/field/babybear/element_purego.go
@@ -8,8 +8,8 @@ package babybear
 // MulBy3 x *= 3 (mod q)
 func MulBy3(x *Element) {
 	var y Element
-	y.SetUint64(3)
-	x.Mul(x, &y)
+	y.Double(x)
+	x.Add(x, &y)
 }
 
 // MulBy5 x *= 5 (mod q)

--- a/field/babybear/extensions/e2.go
+++ b/field/babybear/extensions/e2.go
@@ -298,48 +298,45 @@ func MulBy11(x *fr.Element) {
 
 // Mul sets z to the E2-product of x,y, returns z
 func (z *E2) Mul(x, y *E2) *E2 {
-	var a, b, c fr.Element
+	var a, b, c, d fr.Element
 	a.Add(&x.A0, &x.A1)
 	b.Add(&y.A0, &y.A1)
-	a.Mul(&a, &b)
-	b.Mul(&x.A0, &y.A0)
+	d.Mul(&x.A0, &y.A0)
 	c.Mul(&x.A1, &y.A1)
-	z.A1.Sub(&a, &b).Sub(&z.A1, &c)
+	a.Mul(&a, &b)
+	z.A1.Sub(&a, &d).Sub(&z.A1, &c)
 	MulBy11(&c)
-	z.A0.Add(&b, &c)
+	z.A0.Add(&d, &c)
+
 	return z
 }
 
 // Square sets z to the E2-product of x,x returns z
 func (z *E2) Square(x *E2) *E2 {
 	var a, b, c fr.Element
-	a.Mul(&x.A0, &x.A1).Double(&a)
+	a.Mul(&x.A0, &x.A1)
 	c.Square(&x.A0)
 	b.Square(&x.A1)
 	MulBy11(&b)
 	z.A0.Add(&c, &b)
-	z.A1 = a
+	z.A1.Double(&a)
 	return z
 }
 
 // MulByNonResidue multiplies a E2 by (0,1)
 func (z *E2) MulByNonResidue(x *E2) *E2 {
-	a := x.A0
-	b := x.A1 // fetching x.A1 in the function below is slower
-	MulBy11(&b)
-	z.A0 = b
-	z.A1 = a
+	z.A0, z.A1 = x.A1, x.A0
+	MulBy11(&z.A0)
 	return z
 }
 
 // MulByNonResidueInv multiplies a E2 by (0,1)^{-1}
 func (z *E2) MulByNonResidueInv(x *E2) *E2 {
-	a := x.A1
+	z.A0, z.A1 = x.A1, x.A0
 	// 1/11 mod r
 	var elevenInv fr.Element
 	elevenInv.SetUint64(549072524)
-	z.A1.Mul(&x.A0, &elevenInv)
-	z.A0 = a
+	z.A1.Mul(&z.A1, &elevenInv)
 	return z
 }
 

--- a/field/babybear/extensions/e2_test.go
+++ b/field/babybear/extensions/e2_test.go
@@ -387,44 +387,42 @@ func TestE2Ops(t *testing.T) {
 // ------------------------------------------------------------
 // benches
 
+var benchRes E2
+
 func BenchmarkE2Add(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Add(&a, &c)
+		benchRes.Add(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Sub(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Sub(&a, &c)
+		benchRes.Sub(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Mul(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Mul(&a, &c)
+		benchRes.Mul(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2MulByElement(b *testing.B) {
-	var a E2
 	var c fr.Element
 	c.MustSetRandom()
-	a.MustSetRandom()
+	benchRes.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.MulByElement(&a, &c)
+		benchRes.MulByElement(&benchRes, &c)
 	}
 }
 

--- a/field/babybear/extensions/e4.go
+++ b/field/babybear/extensions/e4.go
@@ -160,29 +160,32 @@ func (z *E4) MulByNonResidue(x *E4) *E4 {
 
 // Mul sets z=x*y in E4 and returns z
 func (z *E4) Mul(x, y *E4) *E4 {
-	var a, b, c E2
+	var a, b, c, d E2
 	a.Add(&x.B0, &x.B1)
 	b.Add(&y.B0, &y.B1)
-	a.Mul(&a, &b)
-	b.Mul(&x.B0, &y.B0)
+	d.Mul(&x.B0, &y.B0)
 	c.Mul(&x.B1, &y.B1)
-	z.B1.Sub(&a, &b).Sub(&z.B1, &c)
-	z.B0.MulByNonResidue(&c).Add(&z.B0, &b)
+	a.Mul(&a, &b)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 	return z
 }
 
 // Square sets z=x*x in E4 and returns z
 func (z *E4) Square(x *E4) *E4 {
-
-	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
-	var c0, c2, c3 E2
-	c0.Sub(&x.B0, &x.B1)
-	c3.MulByNonResidue(&x.B1).Sub(&x.B0, &c3)
-	c2.Mul(&x.B0, &x.B1)
-	c0.Mul(&c0, &c3).Add(&c0, &c2)
-	z.B1.Double(&c2)
-	c2.MulByNonResidue(&c2)
-	z.B0.Add(&c0, &c2)
+	// same as mul, but we remove duplicate add and simplify multiplications with squaring
+	// note: this is more efficient than Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
+	var a, c, d E2
+	a.Add(&x.B0, &x.B1)
+	d.Square(&x.B0)
+	c.Square(&x.B1)
+	a.Square(&a)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 
 	return z
 }

--- a/field/generator/internal/templates/element/ops_purego.go
+++ b/field/generator/internal/templates/element/ops_purego.go
@@ -13,8 +13,13 @@ import "math/bits"
 func MulBy{{$i}}(x *{{$.ElementName}}) {
 	{{- if eq 1 $.NbWords}}
 	var y {{$.ElementName}}
-	y.SetUint64({{$i}})
-	x.Mul(x, &y)
+		{{- if eq $i 3}}
+			y.Double(x)
+			x.Add(x, &y)
+		{{- else}}
+			y.SetUint64({{$i}})
+			x.Mul(x, &y)
+		{{- end}}
 	{{- else}}
 		{{- if eq $i 3}}
 			_x := *x

--- a/field/generator/internal/templates/extensions/e2.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2.go.tmpl
@@ -300,28 +300,36 @@ func MulBy7(x *fr.Element) {
 
 // Mul sets z to the E2-product of x,y, returns z
 func (z *E2) Mul(x, y *E2) *E2 {
-	var a, b, c fr.Element
+	var a, b, c, d fr.Element
 	a.Add(&x.A0, &x.A1)
 	b.Add(&y.A0, &y.A1)
-	a.Mul(&a, &b)
-	b.Mul(&x.A0, &y.A0)
+	d.Mul(&x.A0, &y.A0)
 	c.Mul(&x.A1, &y.A1)
-	z.A1.Sub(&a, &b).Sub(&z.A1, &c)
+	a.Mul(&a, &b)
+
     {{- if eq .FF "koalabear"}}
-	fr.MulBy3(&c)
+		d.Add(&d, &c)
+		a.Sub(&a, &d)
+		d.Add(&d, &c).Add(&d, &c)
+		z.A0 = d
+		z.A1 = a
     {{- else if eq .FF "babybear"}}
-	MulBy11(&c)
+		z.A1.Sub(&a, &d).Sub(&z.A1, &c)
+		MulBy11(&c)
+		z.A0.Add(&d, &c)
     {{- else if eq .FF "goldilocks"}}
-	MulBy7(&c)
+		z.A1.Sub(&a, &d).Sub(&z.A1, &c)
+		MulBy7(&c)
+		z.A0.Add(&d, &c)
     {{- end}}
-	z.A0.Add(&b, &c)
+
 	return z
 }
 
 // Square sets z to the E2-product of x,x returns z
 func (z *E2) Square(x *E2) *E2 {
 	var a, b, c fr.Element
-	a.Mul(&x.A0, &x.A1).Double(&a)
+	a.Mul(&x.A0, &x.A1)
 	c.Square(&x.A0)
 	b.Square(&x.A1)
     {{- if eq .FF "koalabear"}}
@@ -332,46 +340,42 @@ func (z *E2) Square(x *E2) *E2 {
 	MulBy7(&b)
     {{- end}}
 	z.A0.Add(&c, &b)
-	z.A1 = a
+	z.A1.Double(&a)
 	return z
 }
 
 // MulByNonResidue multiplies a E2 by (0,1)
 func (z *E2) MulByNonResidue(x *E2) *E2 {
-	a := x.A0
-	b := x.A1 // fetching x.A1 in the function below is slower
+	z.A0, z.A1 = x.A1, x.A0
     {{- if eq .FF "koalabear"}}
-	fr.MulBy3(&b)
+	fr.MulBy3(&z.A0)
     {{- else if eq .FF "babybear"}}
-	MulBy11(&b)
+	MulBy11(&z.A0)
     {{- else if eq .FF "goldilocks"}}
-	MulBy7(&b)
+	MulBy7(&z.A0)
     {{- end}}
-	z.A0 = b
-	z.A1 = a
 	return z
 }
 
 // MulByNonResidueInv multiplies a E2 by (0,1)^{-1}
 func (z *E2) MulByNonResidueInv(x *E2) *E2 {
-	a := x.A1
+	z.A0, z.A1 = x.A1, x.A0
     {{- if eq .FF "koalabear"}}
 	// 1/3 mod r
 	var threeInv fr.Element
-	threeInv.SetUint64(710235478)
-	z.A1.Mul(&x.A0, &threeInv)
+	threeInv[0] = 11184810 // threeInv.SetUint64(710235478)
+	z.A1.Mul(&z.A1, &threeInv)
     {{- else if eq .FF "babybear"}}
 	// 1/11 mod r
 	var elevenInv fr.Element
 	elevenInv.SetUint64(549072524)
-	z.A1.Mul(&x.A0, &elevenInv)
+	z.A1.Mul(&z.A1, &elevenInv)
     {{- else if eq .FF "goldilocks"}}
 	// 1/7 mod r
 	var sevenInv fr.Element
 	sevenInv.SetUint64(2635249152773512046)
-	z.A1.Mul(&x.A0, &sevenInv)
+	z.A1.Mul(&z.A1, &sevenInv)
     {{- end}}
-	z.A0 = a
 	return z
 }
 

--- a/field/generator/internal/templates/extensions/e2_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2_test.go.tmpl
@@ -386,44 +386,42 @@ func TestE2Ops(t *testing.T) {
 // ------------------------------------------------------------
 // benches
 
+var benchRes E2
+
 func BenchmarkE2Add(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Add(&a, &c)
+		benchRes.Add(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Sub(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Sub(&a, &c)
+		benchRes.Sub(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Mul(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Mul(&a, &c)
+		benchRes.Mul(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2MulByElement(b *testing.B) {
-	var a E2
 	var c fr.Element
 	c.MustSetRandom()
-	a.MustSetRandom()
+	benchRes.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.MulByElement(&a, &c)
+		benchRes.MulByElement(&benchRes, &c)
 	}
 }
 

--- a/field/generator/internal/templates/extensions/e4.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4.go.tmpl
@@ -155,29 +155,32 @@ func (z *E4) MulByNonResidue(x *E4) *E4 {
 
 // Mul sets z=x*y in E4 and returns z
 func (z *E4) Mul(x, y *E4) *E4 {
-	var a, b, c E2
+	var a, b, c, d E2
 	a.Add(&x.B0, &x.B1)
 	b.Add(&y.B0, &y.B1)
-	a.Mul(&a, &b)
-	b.Mul(&x.B0, &y.B0)
+	d.Mul(&x.B0, &y.B0)
 	c.Mul(&x.B1, &y.B1)
-	z.B1.Sub(&a, &b).Sub(&z.B1, &c)
-	z.B0.MulByNonResidue(&c).Add(&z.B0, &b)
+	a.Mul(&a, &b)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 	return z
 }
 
 // Square sets z=x*x in E4 and returns z
 func (z *E4) Square(x *E4) *E4 {
-
-	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
-	var c0, c2, c3 E2
-	c0.Sub(&x.B0, &x.B1)
-	c3.MulByNonResidue(&x.B1).Sub(&x.B0, &c3)
-	c2.Mul(&x.B0, &x.B1)
-	c0.Mul(&c0, &c3).Add(&c0, &c2)
-	z.B1.Double(&c2)
-	c2.MulByNonResidue(&c2)
-	z.B0.Add(&c0, &c2)
+	// same as mul, but we remove duplicate add and simplify multiplications with squaring
+	// note: this is more efficient than Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
+	var a, c, d E2
+	a.Add(&x.B0, &x.B1)
+	d.Square(&x.B0)
+	c.Square(&x.B1)
+	a.Square(&a)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 
 	return z
 }

--- a/field/goldilocks/element_purego.go
+++ b/field/goldilocks/element_purego.go
@@ -10,8 +10,8 @@ import "math/bits"
 // MulBy3 x *= 3 (mod q)
 func MulBy3(x *Element) {
 	var y Element
-	y.SetUint64(3)
-	x.Mul(x, &y)
+	y.Double(x)
+	x.Add(x, &y)
 }
 
 // MulBy5 x *= 5 (mod q)

--- a/field/goldilocks/extensions/e2.go
+++ b/field/goldilocks/extensions/e2.go
@@ -298,48 +298,45 @@ func MulBy7(x *fr.Element) {
 
 // Mul sets z to the E2-product of x,y, returns z
 func (z *E2) Mul(x, y *E2) *E2 {
-	var a, b, c fr.Element
+	var a, b, c, d fr.Element
 	a.Add(&x.A0, &x.A1)
 	b.Add(&y.A0, &y.A1)
-	a.Mul(&a, &b)
-	b.Mul(&x.A0, &y.A0)
+	d.Mul(&x.A0, &y.A0)
 	c.Mul(&x.A1, &y.A1)
-	z.A1.Sub(&a, &b).Sub(&z.A1, &c)
+	a.Mul(&a, &b)
+	z.A1.Sub(&a, &d).Sub(&z.A1, &c)
 	MulBy7(&c)
-	z.A0.Add(&b, &c)
+	z.A0.Add(&d, &c)
+
 	return z
 }
 
 // Square sets z to the E2-product of x,x returns z
 func (z *E2) Square(x *E2) *E2 {
 	var a, b, c fr.Element
-	a.Mul(&x.A0, &x.A1).Double(&a)
+	a.Mul(&x.A0, &x.A1)
 	c.Square(&x.A0)
 	b.Square(&x.A1)
 	MulBy7(&b)
 	z.A0.Add(&c, &b)
-	z.A1 = a
+	z.A1.Double(&a)
 	return z
 }
 
 // MulByNonResidue multiplies a E2 by (0,1)
 func (z *E2) MulByNonResidue(x *E2) *E2 {
-	a := x.A0
-	b := x.A1 // fetching x.A1 in the function below is slower
-	MulBy7(&b)
-	z.A0 = b
-	z.A1 = a
+	z.A0, z.A1 = x.A1, x.A0
+	MulBy7(&z.A0)
 	return z
 }
 
 // MulByNonResidueInv multiplies a E2 by (0,1)^{-1}
 func (z *E2) MulByNonResidueInv(x *E2) *E2 {
-	a := x.A1
+	z.A0, z.A1 = x.A1, x.A0
 	// 1/7 mod r
 	var sevenInv fr.Element
 	sevenInv.SetUint64(2635249152773512046)
-	z.A1.Mul(&x.A0, &sevenInv)
-	z.A0 = a
+	z.A1.Mul(&z.A1, &sevenInv)
 	return z
 }
 

--- a/field/goldilocks/extensions/e2_test.go
+++ b/field/goldilocks/extensions/e2_test.go
@@ -387,44 +387,42 @@ func TestE2Ops(t *testing.T) {
 // ------------------------------------------------------------
 // benches
 
+var benchRes E2
+
 func BenchmarkE2Add(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Add(&a, &c)
+		benchRes.Add(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Sub(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Sub(&a, &c)
+		benchRes.Sub(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Mul(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Mul(&a, &c)
+		benchRes.Mul(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2MulByElement(b *testing.B) {
-	var a E2
 	var c fr.Element
 	c.MustSetRandom()
-	a.MustSetRandom()
+	benchRes.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.MulByElement(&a, &c)
+		benchRes.MulByElement(&benchRes, &c)
 	}
 }
 

--- a/field/koalabear/element_purego.go
+++ b/field/koalabear/element_purego.go
@@ -8,8 +8,8 @@ package koalabear
 // MulBy3 x *= 3 (mod q)
 func MulBy3(x *Element) {
 	var y Element
-	y.SetUint64(3)
-	x.Mul(x, &y)
+	y.Double(x)
+	x.Add(x, &y)
 }
 
 // MulBy5 x *= 5 (mod q)

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -291,48 +291,47 @@ func (z *E2) Div(x *E2, y *E2) *E2 {
 
 // Mul sets z to the E2-product of x,y, returns z
 func (z *E2) Mul(x, y *E2) *E2 {
-	var a, b, c fr.Element
+	var a, b, c, d fr.Element
 	a.Add(&x.A0, &x.A1)
 	b.Add(&y.A0, &y.A1)
-	a.Mul(&a, &b)
-	b.Mul(&x.A0, &y.A0)
+	d.Mul(&x.A0, &y.A0)
 	c.Mul(&x.A1, &y.A1)
-	z.A1.Sub(&a, &b).Sub(&z.A1, &c)
-	fr.MulBy3(&c)
-	z.A0.Add(&b, &c)
+	a.Mul(&a, &b)
+	d.Add(&d, &c)
+	a.Sub(&a, &d)
+	d.Add(&d, &c).Add(&d, &c)
+	z.A0 = d
+	z.A1 = a
+
 	return z
 }
 
 // Square sets z to the E2-product of x,x returns z
 func (z *E2) Square(x *E2) *E2 {
 	var a, b, c fr.Element
-	a.Mul(&x.A0, &x.A1).Double(&a)
+	a.Mul(&x.A0, &x.A1)
 	c.Square(&x.A0)
 	b.Square(&x.A1)
 	fr.MulBy3(&b)
 	z.A0.Add(&c, &b)
-	z.A1 = a
+	z.A1.Double(&a)
 	return z
 }
 
 // MulByNonResidue multiplies a E2 by (0,1)
 func (z *E2) MulByNonResidue(x *E2) *E2 {
-	a := x.A0
-	b := x.A1 // fetching x.A1 in the function below is slower
-	fr.MulBy3(&b)
-	z.A0 = b
-	z.A1 = a
+	z.A0, z.A1 = x.A1, x.A0
+	fr.MulBy3(&z.A0)
 	return z
 }
 
 // MulByNonResidueInv multiplies a E2 by (0,1)^{-1}
 func (z *E2) MulByNonResidueInv(x *E2) *E2 {
-	a := x.A1
+	z.A0, z.A1 = x.A1, x.A0
 	// 1/3 mod r
 	var threeInv fr.Element
-	threeInv.SetUint64(710235478)
-	z.A1.Mul(&x.A0, &threeInv)
-	z.A0 = a
+	threeInv[0] = 11184810 // threeInv.SetUint64(710235478)
+	z.A1.Mul(&z.A1, &threeInv)
 	return z
 }
 

--- a/field/koalabear/extensions/e2_test.go
+++ b/field/koalabear/extensions/e2_test.go
@@ -387,44 +387,42 @@ func TestE2Ops(t *testing.T) {
 // ------------------------------------------------------------
 // benches
 
+var benchRes E2
+
 func BenchmarkE2Add(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Add(&a, &c)
+		benchRes.Add(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Sub(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Sub(&a, &c)
+		benchRes.Sub(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2Mul(b *testing.B) {
-	var a, c E2
+	var a E2
 	a.MustSetRandom()
-	c.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.Mul(&a, &c)
+		benchRes.Mul(&a, &benchRes)
 	}
 }
 
 func BenchmarkE2MulByElement(b *testing.B) {
-	var a E2
 	var c fr.Element
 	c.MustSetRandom()
-	a.MustSetRandom()
+	benchRes.MustSetRandom()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.MulByElement(&a, &c)
+		benchRes.MulByElement(&benchRes, &c)
 	}
 }
 

--- a/field/koalabear/extensions/e4.go
+++ b/field/koalabear/extensions/e4.go
@@ -160,29 +160,32 @@ func (z *E4) MulByNonResidue(x *E4) *E4 {
 
 // Mul sets z=x*y in E4 and returns z
 func (z *E4) Mul(x, y *E4) *E4 {
-	var a, b, c E2
+	var a, b, c, d E2
 	a.Add(&x.B0, &x.B1)
 	b.Add(&y.B0, &y.B1)
-	a.Mul(&a, &b)
-	b.Mul(&x.B0, &y.B0)
+	d.Mul(&x.B0, &y.B0)
 	c.Mul(&x.B1, &y.B1)
-	z.B1.Sub(&a, &b).Sub(&z.B1, &c)
-	z.B0.MulByNonResidue(&c).Add(&z.B0, &b)
+	a.Mul(&a, &b)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 	return z
 }
 
 // Square sets z=x*x in E4 and returns z
 func (z *E4) Square(x *E4) *E4 {
-
-	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
-	var c0, c2, c3 E2
-	c0.Sub(&x.B0, &x.B1)
-	c3.MulByNonResidue(&x.B1).Sub(&x.B0, &c3)
-	c2.Mul(&x.B0, &x.B1)
-	c0.Mul(&c0, &c3).Add(&c0, &c2)
-	z.B1.Double(&c2)
-	c2.MulByNonResidue(&c2)
-	z.B0.Add(&c0, &c2)
+	// same as mul, but we remove duplicate add and simplify multiplications with squaring
+	// note: this is more efficient than Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
+	var a, c, d E2
+	a.Add(&x.B0, &x.B1)
+	d.Square(&x.B0)
+	c.Square(&x.B1)
+	a.Square(&a)
+	var bc E2
+	bc.Add(&d, &c)
+	z.B1.Sub(&a, &bc)
+	z.B0.MulByNonResidue(&c).Add(&z.B0, &d)
 
 	return z
 }


### PR DESCRIPTION
# Description

Optimize perf for koalabear extension. Benchmarked on a `c7a.8xlarge` .

```
BenchmarkE2Mul-32              11.4          8.56          -24.99%
BenchmarkE2Square-32           10.6          6.01          -43.13%
BenchmarkE2Sqrt-32             1372          1003          -26.90%
BenchmarkE2Exp-32              580           493           -15.01%
BenchmarkE2MulNonRes-32        3.28          1.06          -67.63%
BenchmarkE2MulNonResInv-32     2.25          1.98          -12.04%
BenchmarkE4Mul-32              44.3          26.0          -41.17%
BenchmarkE4Square-32           41.1          22.2          -46.07%
BenchmarkE4Sqrt-32             9206          5404          -41.30%
BenchmarkE4Inverse-32          148           129           -12.41%
BenchmarkE4MulNonRes-32        6.83          5.46          -20.01%
```