### PR TITLE
mpcsetup(generator): use G2Affine in UpdateMonomialsG2 template

### DIFF
--- a/ecc/bls12-377/mpcsetup/mpcsetup.go
+++ b/ecc/bls12-377/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bls12-381/mpcsetup/mpcsetup.go
+++ b/ecc/bls12-381/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bls24-315/mpcsetup/mpcsetup.go
+++ b/ecc/bls24-315/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bls24-317/mpcsetup/mpcsetup.go
+++ b/ecc/bls24-317/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bn254/mpcsetup/mpcsetup.go
+++ b/ecc/bn254/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bw6-633/mpcsetup/mpcsetup.go
+++ b/ecc/bw6-633/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/ecc/bw6-761/mpcsetup/mpcsetup.go
+++ b/ecc/bw6-761/mpcsetup/mpcsetup.go
@@ -456,7 +456,7 @@ func linearCombinationG1(A []curve.G1Affine, r []fr.Element) curve.G1Affine {
 }
 
 // UpdateMonomialsG2 A[i] <- r^i.A[i]
-func UpdateMonomialsG2(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG2(A []curve.G2Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I    big.Int

--- a/internal/generator/mpcsetup/template/mpcsetup.go.tmpl
+++ b/internal/generator/mpcsetup/template/mpcsetup.go.tmpl
@@ -357,7 +357,7 @@ func SameRatioMany(slices ...any) error {
 
 {{ define "curveFuncs" }}
 // UpdateMonomialsG{{.I}} A[i] <- r^i.A[i]
-func UpdateMonomialsG{{.I}}(A []curve.G1Affine, r *fr.Element) {
+func UpdateMonomialsG{{.I}}(A []curve.G{{.I}}Affine, r *fr.Element) {
 	var (
 		rExp fr.Element
 		I big.Int


### PR DESCRIPTION
Fix template signature to use []curve.G{{.I}}Affine instead of []curve.G1Affine for UpdateMonomialsG{{.I}}. Ensures UpdateMonomialsG2 is generated with G2Affine across all curves. Aligns with linearCombinationsG{{.I}} and function naming; previous mismatch was a generator typo.



