### PR TITLE
perf: add for small fields int64 for exp

### DIFF
--- a/field/babybear/element.go
+++ b/field/babybear/element.go
@@ -482,8 +482,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsInt64() {
+		return z.ExpInt64(x, k.Int64())
 	}
 
 	e := k
@@ -504,6 +504,32 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	for i := e.BitLen() - 2; i >= 0; i-- {
 		z.Square(z)
 		if e.Bit(i) == 1 {
+			z.Mul(z, &x)
+		}
+	}
+
+	return z
+}
+
+// ExpInt64 z = xᵏ (mod q)
+func (z *Element) ExpInt64(x Element, k int64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+
+	if k < 0 {
+		// negative k, we invert
+		// if k < 0: xᵏ (mod q) == (x⁻¹)⁻ᵏ (mod q)
+		x.Inverse(&x)
+		k = -k
+	}
+	e := uint64(k)
+
+	z.Set(&x)
+
+	for i := int(bits.Len64(e)) - 2; i >= 0; i-- {
+		z.Square(z)
+		if (e>>i)&1 == 1 {
 			z.Mul(z, &x)
 		}
 	}

--- a/field/babybear/extensions/e4.go
+++ b/field/babybear/extensions/e4.go
@@ -7,6 +7,7 @@ package extensions
 
 import (
 	"math/big"
+	"math/bits"
 
 	fr "github.com/consensys/gnark-crypto/field/babybear"
 )
@@ -211,8 +212,8 @@ func (z *E4) Inverse(x *E4) *E4 {
 
 // Exp sets z=xᵏ (mod q⁴) and returns it
 func (z *E4) Exp(x E4, k *big.Int) *E4 {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsInt64() {
+		return z.ExpInt64(x, k.Int64())
 	}
 
 	e := k
@@ -237,6 +238,31 @@ func (z *E4) Exp(x E4, k *big.Int) *E4 {
 			if (w & (0b10000000 >> j)) != 0 {
 				z.Mul(z, &x)
 			}
+		}
+	}
+
+	return z
+}
+
+// ExpInt64 sets z=xᵏ (mod q⁴) and returns it, where k is an int64
+func (z *E4) ExpInt64(x E4, k int64) *E4 {
+	if k == 0 {
+		return z.SetOne()
+	}
+
+	exp := k
+	if k < 0 {
+		x.Inverse(&x)
+		exp = -k
+	}
+
+	z.Set(&x)
+
+	// Use bits.Len64 to iterate only over significant bits
+	for i := bits.Len64(uint64(exp)) - 2; i >= 0; i-- {
+		z.Square(z)
+		if (uint64(exp)>>uint(i))&1 != 0 {
+			z.Mul(z, &x)
 		}
 	}
 

--- a/field/babybear/extensions/e4_test.go
+++ b/field/babybear/extensions/e4_test.go
@@ -8,6 +8,7 @@ package extensions
 import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"math/big"
 	"os"
 	"testing"
 
@@ -224,6 +225,60 @@ func TestE4Ops(t *testing.T) {
 			d.Square(&c)
 			e.Neg(&a)
 			return (c.Equal(&a) || c.Equal(&e)) && d.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestE4Exp(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 100
+
+	properties := gopter.NewProperties(parameters)
+	genA := genE4()
+
+	properties.Property("[koalabear] Exp(x, 0) should return one", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			var one E4
+			one.SetOne()
+			res.Exp(a, big.NewInt(0))
+			return res.Equal(&one)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 1) should return x", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			res.Exp(a, big.NewInt(1))
+			return res.Equal(&a)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 2) should return x squared", prop.ForAll(
+		func(a E4) bool {
+			var res, sq E4
+			res.Exp(a, big.NewInt(2))
+			sq.Square(&a)
+			return res.Equal(&sq)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, k) should match repeated multiplication", prop.ForAll(
+		func(a E4) bool {
+			var res, mul E4
+			k := int64(0b101101) // 45
+			res.Exp(a, big.NewInt(k))
+			mul.SetOne()
+			for i := int64(0); i < k; i++ {
+				mul.Mul(&mul, &a)
+			}
+			return res.Equal(&mul)
 		},
 		genA,
 	))

--- a/field/generator/internal/templates/element/exp.go
+++ b/field/generator/internal/templates/element/exp.go
@@ -3,9 +3,15 @@ package element
 const Exp = `
 // Exp z = xᵏ (mod q)
 func (z *{{.ElementName}}) Exp(x {{.ElementName}}, k *big.Int) *{{.ElementName}} {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
-	}
+	{{- if .F31}}
+		if k.IsInt64() {
+			return z.ExpInt64(x, k.Int64())
+		}	
+	{{- else}}
+		if k.IsUint64() && k.Uint64() == 0 {
+			return z.SetOne()
+		}
+	{{- end}}
 
 	e := k
 	if k.Sign() == -1 {
@@ -31,5 +37,33 @@ func (z *{{.ElementName}}) Exp(x {{.ElementName}}, k *big.Int) *{{.ElementName}}
 
 	return z
 }
+
+{{- if .F31}}
+// ExpInt64 z = xᵏ (mod q)
+func (z *{{.ElementName}}) ExpInt64(x {{.ElementName}}, k int64) *{{.ElementName}} {
+	if k == 0 {
+		return z.SetOne()
+	}
+
+	if k < 0 {
+		// negative k, we invert
+		// if k < 0: xᵏ (mod q) == (x⁻¹)⁻ᵏ (mod q)
+		x.Inverse(&x)
+		k = -k
+	}
+	e := uint64(k)
+
+	z.Set(&x)
+
+	for i := int(bits.Len64(e)) - 2; i >= 0; i-- {
+		z.Square(z)
+		if (e>>i)&1 == 1 {
+			z.Mul(z, &x)
+		}
+	}
+
+	return z
+}
+{{- end}}
 
 `

--- a/field/generator/internal/templates/extensions/e4.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4.go.tmpl
@@ -1,5 +1,6 @@
 import (
 	"math/big"
+	"math/bits"
 
 	fr "{{ .FieldPackagePath }}"
 	{{- if .IsKoalaBear}}
@@ -207,8 +208,8 @@ func (z *E4) Inverse(x *E4) *E4 {
 
 // Exp sets z=xᵏ (mod q⁴) and returns it
 func (z *E4) Exp(x E4, k *big.Int) *E4 {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsInt64() {
+		return z.ExpInt64(x, k.Int64())
 	}
 
 	e := k
@@ -238,6 +239,32 @@ func (z *E4) Exp(x E4, k *big.Int) *E4 {
 
 	return z
 }
+
+// ExpInt64 sets z=xᵏ (mod q⁴) and returns it, where k is an int64
+func (z *E4) ExpInt64(x E4, k int64) *E4 {
+	if k == 0 {
+		return z.SetOne()
+	}
+
+	exp := k
+	if k < 0 {
+		x.Inverse(&x)
+		exp = -k
+	}
+
+	z.Set(&x)
+
+	// Use bits.Len64 to iterate only over significant bits
+	for i := bits.Len64(uint64(exp)) - 2; i >= 0; i-- {
+		z.Square(z)
+		if (uint64(exp)>>uint(i))&1 != 0 {
+			z.Mul(z, &x)
+		}
+	}
+
+	return z
+}
+
 
 // Conjugate sets z to x conjugated and returns z
 func (z *E4) Conjugate(x *E4) *E4 {

--- a/field/generator/internal/templates/extensions/e4_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4_test.go.tmpl
@@ -3,6 +3,7 @@ import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"os"
+	"math/big"
 
 	fr "{{ .FieldPackagePath }}"
 	"fmt"
@@ -220,6 +221,62 @@ func TestE4Ops(t *testing.T) {
 		},
 		genA,
 	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+
+func TestE4Exp(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 100
+
+	properties := gopter.NewProperties(parameters)
+	genA := genE4()
+
+	properties.Property("[koalabear] Exp(x, 0) should return one", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			var one E4
+			one.SetOne()
+			res.Exp(a, big.NewInt(0))
+			return res.Equal(&one)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 1) should return x", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			res.Exp(a, big.NewInt(1))
+			return res.Equal(&a)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 2) should return x squared", prop.ForAll(
+		func(a E4) bool {
+			var res, sq E4
+			res.Exp(a, big.NewInt(2))
+			sq.Square(&a)
+			return res.Equal(&sq)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, k) should match repeated multiplication", prop.ForAll(
+		func(a E4) bool {
+			var res, mul E4
+			k := int64(0b101101) // 45
+			res.Exp(a, big.NewInt(k))
+			mul.SetOne()
+			for i := int64(0); i < k; i++ {
+				mul.Mul(&mul, &a)
+			}
+			return res.Equal(&mul)
+		},
+		genA,
+	))
+
 
 	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }

--- a/field/koalabear/element.go
+++ b/field/koalabear/element.go
@@ -482,8 +482,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsInt64() {
+		return z.ExpInt64(x, k.Int64())
 	}
 
 	e := k
@@ -504,6 +504,32 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 	for i := e.BitLen() - 2; i >= 0; i-- {
 		z.Square(z)
 		if e.Bit(i) == 1 {
+			z.Mul(z, &x)
+		}
+	}
+
+	return z
+}
+
+// ExpInt64 z = xᵏ (mod q)
+func (z *Element) ExpInt64(x Element, k int64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+
+	if k < 0 {
+		// negative k, we invert
+		// if k < 0: xᵏ (mod q) == (x⁻¹)⁻ᵏ (mod q)
+		x.Inverse(&x)
+		k = -k
+	}
+	e := uint64(k)
+
+	z.Set(&x)
+
+	for i := int(bits.Len64(e)) - 2; i >= 0; i-- {
+		z.Square(z)
+		if (e>>i)&1 == 1 {
 			z.Mul(z, &x)
 		}
 	}

--- a/field/koalabear/extensions/e4_test.go
+++ b/field/koalabear/extensions/e4_test.go
@@ -8,6 +8,7 @@ package extensions
 import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
+	"math/big"
 	"os"
 	"testing"
 
@@ -224,6 +225,60 @@ func TestE4Ops(t *testing.T) {
 			d.Square(&c)
 			e.Neg(&a)
 			return (c.Equal(&a) || c.Equal(&e)) && d.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestE4Exp(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 100
+
+	properties := gopter.NewProperties(parameters)
+	genA := genE4()
+
+	properties.Property("[koalabear] Exp(x, 0) should return one", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			var one E4
+			one.SetOne()
+			res.Exp(a, big.NewInt(0))
+			return res.Equal(&one)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 1) should return x", prop.ForAll(
+		func(a E4) bool {
+			var res E4
+			res.Exp(a, big.NewInt(1))
+			return res.Equal(&a)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, 2) should return x squared", prop.ForAll(
+		func(a E4) bool {
+			var res, sq E4
+			res.Exp(a, big.NewInt(2))
+			sq.Square(&a)
+			return res.Equal(&sq)
+		},
+		genA,
+	))
+
+	properties.Property("[koalabear] Exp(x, k) should match repeated multiplication", prop.ForAll(
+		func(a E4) bool {
+			var res, mul E4
+			k := int64(0b101101) // 45
+			res.Exp(a, big.NewInt(k))
+			mul.SetOne()
+			for i := int64(0); i < k; i++ {
+				mul.Mul(&mul, &a)
+			}
+			return res.Equal(&mul)
 		},
 		genA,
 	))


### PR DESCRIPTION
# Description

Add (for koalabear / babybear) a fast path when exponent is int64 for base and extension. About 10% faster with 0 alloc (useful upstream).