### PR TITLE
fix: reintroduce BitReverse in fft package as deprecated for backward…

### DIFF
--- a/ecc/bls12-377/fr/fft/domain.go
+++ b/ecc/bls12-377/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bls12-381/fr/fft/domain.go
+++ b/ecc/bls12-381/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bls24-315/fr/fft/domain.go
+++ b/ecc/bls24-315/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bls24-317/fr/fft/domain.go
+++ b/ecc/bls24-317/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bn254/fr/fft/domain.go
+++ b/ecc/bn254/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bw6-633/fr/fft/domain.go
+++ b/ecc/bw6-633/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/ecc/bw6-761/fr/fft/domain.go
+++ b/ecc/bw6-761/fr/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []fr.Element) {
+	utils.BitReverse(v)
 }

--- a/field/babybear/fft/domain.go
+++ b/field/babybear/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/field/babybear"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []babybear.Element) {
+	utils.BitReverse(v)
 }

--- a/field/generator/internal/templates/fft/domain.go.tmpl
+++ b/field/generator/internal/templates/fft/domain.go.tmpl
@@ -10,6 +10,7 @@ import (
 	"{{ .FieldPackagePath }}"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -309,4 +310,14 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []{{ .FF }}.Element) {
+	utils.BitReverse(v)
 }

--- a/field/goldilocks/fft/domain.go
+++ b/field/goldilocks/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/field/goldilocks"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []goldilocks.Element) {
+	utils.BitReverse(v)
 }

--- a/field/koalabear/fft/domain.go
+++ b/field/koalabear/fft/domain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/gnark-crypto/field/koalabear"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/utils"
 )
 
 // Domain with a power of 2 cardinality
@@ -314,4 +315,13 @@ func (d *Domain) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return read, nil
+}
+
+// BitReverse applies the bit-reversal permutation to v.
+//
+// The length of v must be a power of 2.
+//
+// Deprecated: Use [utils.BitReverse] instead.
+func BitReverse(v []koalabear.Element) {
+	utils.BitReverse(v)
 }


### PR DESCRIPTION
Previous #736  PR made upstream usage break (...) since it removed the `BitReverse` function from the individual field fft pacakges. Added in back as deprecated. 