### PR TITLE
perf: e2 mul on koalabear

### DIFF
--- a/field/generator/internal/templates/extensions/e2.go.tmpl
+++ b/field/generator/internal/templates/extensions/e2.go.tmpl
@@ -310,7 +310,8 @@ func (z *E2) Mul(x, y *E2) *E2 {
     {{- if eq .FF "koalabear"}}
 		d.Add(&d, &c)
 		a.Sub(&a, &d)
-		d.Add(&d, &c).Add(&d, &c)
+        b.Double(&c)
+        d.Add(&d, &b)
 		z.A0 = d
 		z.A1 = a
     {{- else if eq .FF "babybear"}}

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -299,7 +299,8 @@ func (z *E2) Mul(x, y *E2) *E2 {
 	a.Mul(&a, &b)
 	d.Add(&d, &c)
 	a.Sub(&a, &d)
-	d.Add(&d, &c).Add(&d, &c)
+	b.Double(&c)
+	d.Add(&d, &b)
 	z.A0 = d
 	z.A1 = a
 


### PR DESCRIPTION
# Description

tiny change in e2 mul; karatsuba already computes `a+b` so we use `Double` to compute `2b` and add it to the sum to have `a+3b` where `3` is the quadratic non-residue. This yields -10%.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Current tests pass.

# How has this been benchmarked?

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkE2Mul-8              16.1          14.4          -10.52%
BenchmarkE4Mul-8              27.6          26.3          -4.71%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

