### PR TITLE
feat: add parallel prefix product for vector e4

### DIFF
--- a/field/babybear/extensions/e4_test.go
+++ b/field/babybear/extensions/e4_test.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 
@@ -605,6 +606,49 @@ func TestVectorExp(t *testing.T) {
 
 }
 
+// prefixProductGeneric computes the prefix product of the vector in place (single-threaded).
+func prefixProductGeneric(vector Vector) {
+	if len(vector) == 0 {
+		return
+	}
+	for i := 1; i < len(vector); i++ {
+		vector[i].Mul(&vector[i-1], &vector[i])
+	}
+}
+
+func randomVector(size int) Vector {
+	v := make(Vector, size)
+	for i := range v {
+		v[i].MustSetRandom()
+	}
+	return v
+}
+
+func TestPrefixProduct_EmptyVector(t *testing.T) {
+	assert := require.New(t)
+	v := make(Vector, 0)
+	expected := make(Vector, 0)
+	prefixProductGeneric(expected)
+	v.PrefixProduct()
+	assert.Equal(expected, v)
+}
+
+func TestPrefixProduct_VariousNbTasks(t *testing.T) {
+	assert := require.New(t)
+	sizes := []int{1, 2, 256, 1024}
+	nbTasksList := []int{1, 16, 32, runtime.NumCPU()}
+	for _, size := range sizes {
+		for _, nbTasks := range nbTasksList {
+			v := randomVector(size)
+			expected := make(Vector, size)
+			copy(expected, v)
+			prefixProductGeneric(expected)
+			v.PrefixProduct(nbTasks)
+			assert.Equal(expected, v, "size=%d nbTasks=%d", size, nbTasks)
+		}
+	}
+}
+
 func TestVectorEmptyOps(t *testing.T) {
 	assert := require.New(t)
 
@@ -868,6 +912,29 @@ func BenchmarkVectorOps(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkPrefixProduct(b *testing.B) {
+	const N = 1 << 19
+	a1 := make(Vector, N)
+	for i := 0; i < N; i++ {
+		a1[i].MustSetRandom()
+	}
+
+	b.Run("generic", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			prefixProductGeneric(a1)
+		}
+	})
+
+	b.Run("PrefixProduct", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a1.PrefixProduct()
+		}
+	})
+
 }
 
 func BenchmarkVectorSerialization(b *testing.B) {

--- a/field/babybear/extensions/vector.go
+++ b/field/babybear/extensions/vector.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"unsafe"
 
 	fr "github.com/consensys/gnark-crypto/field/babybear"
@@ -376,18 +377,33 @@ func (vector Vector) PrefixProduct(nbTasks ...int) {
 		}
 	}, numWorkers)
 
+	// get the chunk indices
 	chunks := parallel.Chunks(N, numWorkers)
 
-	// the first chunk is correct, we need to update the other chunks
+	// Compute multipliers for each chunk (product of all previous chunks)
+	multipliers := make([]E4, len(chunks))
+	multipliers[0].SetOne()
 	for i := 1; i < len(chunks); i++ {
-		// take last value from previous chunk
-		prevChunkEnd := chunks[i-1][1] - 1
-		multiplier := vector[prevChunkEnd]
-		// multiply all values in current chunk by this value
-		start, stop := chunks[i][0], chunks[i][1]
-		subVector := vector[start:stop]
-		subVector.ScalarMul(subVector, &multiplier)
+		multipliers[i].SetOne()
+		for j := 0; j < i; j++ {
+			prevChunkEnd := chunks[j][1] - 1
+			multipliers[i].Mul(&multipliers[i], &vector[prevChunkEnd])
+		}
 	}
+
+	// propagate the multipliers to each chunk in parallel
+	// note: the first chunk is not modified (multiplier is 1)
+	var wg sync.WaitGroup
+	wg.Add(len(chunks) - 1)
+	for i := 1; i < len(chunks); i++ {
+		go func(i int) {
+			defer wg.Done()
+			start, stop := chunks[i][0], chunks[i][1]
+			subVector := vector[start:stop]
+			subVector.ScalarMul(subVector, &multipliers[i])
+		}(i)
+	}
+	wg.Wait()
 
 }
 

--- a/field/generator/internal/templates/extensions/e4_test.go.tmpl
+++ b/field/generator/internal/templates/extensions/e4_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"reflect"
 	"sort"
+	"runtime"
 	"bytes"
 
 	fr "{{ .FieldPackagePath }}"
@@ -600,6 +601,49 @@ func TestVectorExp(t *testing.T) {
 	
 }
 
+// prefixProductGeneric computes the prefix product of the vector in place (single-threaded).
+func prefixProductGeneric(vector Vector) {
+	if len(vector) == 0 {
+		return
+	}
+	for i := 1; i < len(vector); i++ {
+		vector[i].Mul(&vector[i-1], &vector[i])
+	}
+}
+
+func randomVector(size int) Vector {
+	v := make(Vector, size)
+	for i := range v {
+		v[i].MustSetRandom()
+	}
+	return v
+}
+
+func TestPrefixProduct_EmptyVector(t *testing.T) {
+	assert := require.New(t)
+	v := make(Vector, 0)
+	expected := make(Vector, 0)
+	prefixProductGeneric(expected)
+	v.PrefixProduct()
+	assert.Equal(expected, v)
+}
+
+func TestPrefixProduct_VariousNbTasks(t *testing.T) {
+	assert := require.New(t)
+	sizes := []int{1, 2, 256, 1024}
+	nbTasksList := []int{1, 16, 32, runtime.NumCPU()}
+	for _, size := range sizes {
+		for _, nbTasks := range nbTasksList {
+			v := randomVector(size)
+			expected := make(Vector, size)
+			copy(expected, v)
+			prefixProductGeneric(expected)
+			v.PrefixProduct(nbTasks)
+			assert.Equal(expected, v, "size=%d nbTasks=%d", size, nbTasks)
+		}
+	}
+}
+
 
 func TestVectorEmptyOps(t *testing.T) {
 	assert := require.New(t)
@@ -869,6 +913,28 @@ func BenchmarkVectorOps(b *testing.B) {
 	}
 }
 
+func BenchmarkPrefixProduct(b *testing.B) {
+	const N = 1 << 19
+	a1 := make(Vector, N)
+	for i := 0; i < N; i++ {
+		a1[i].MustSetRandom()
+	}
+
+	b.Run("generic", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			prefixProductGeneric(a1)
+		}
+	})
+
+	b.Run("PrefixProduct", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a1.PrefixProduct()
+		}
+	})
+
+}
 
 
 func BenchmarkVectorSerialization(b *testing.B) {

--- a/field/generator/internal/templates/extensions/vector.go.tmpl
+++ b/field/generator/internal/templates/extensions/vector.go.tmpl
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"runtime"
 	"github.com/consensys/gnark-crypto/internal/parallel"
+	"sync"
 
 	fr "{{ .FieldPackagePath }}"
 	{{- if .IsKoalaBear}}
@@ -573,18 +574,33 @@ func (vector Vector) PrefixProduct(nbTasks ...int) {
 		}
 	}, numWorkers)
 
+	// get the chunk indices
 	chunks := parallel.Chunks(N, numWorkers)
 
-	// the first chunk is correct, we need to update the other chunks
+	// Compute multipliers for each chunk (product of all previous chunks)
+	multipliers := make([]E4, len(chunks))
+	multipliers[0].SetOne()
 	for i := 1; i < len(chunks); i++ {
-		// take last value from previous chunk
-		prevChunkEnd := chunks[i-1][1] - 1
-		multiplier := vector[prevChunkEnd]
-		// multiply all values in current chunk by this value
-		start, stop := chunks[i][0], chunks[i][1]
-		subVector := vector[start:stop]
-		subVector.ScalarMul(subVector, &multiplier)
+		multipliers[i].SetOne()
+		for j := 0; j < i; j++ {
+			prevChunkEnd := chunks[j][1] - 1
+			multipliers[i].Mul(&multipliers[i], &vector[prevChunkEnd])
+		}
 	}
+
+	// propagate the multipliers to each chunk in parallel
+	// note: the first chunk is not modified (multiplier is 1)
+	var wg sync.WaitGroup
+	wg.Add(len(chunks) - 1)
+	for i := 1; i < len(chunks); i++ {
+		go func(i int) {
+			defer wg.Done()
+			start, stop := chunks[i][0], chunks[i][1]
+			subVector := vector[start:stop]
+			subVector.ScalarMul(subVector, &multipliers[i])
+		}(i)
+	}
+	wg.Wait()
 
 }
 

--- a/field/generator/internal/templates/extensions/vector.go.tmpl
+++ b/field/generator/internal/templates/extensions/vector.go.tmpl
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"slices"
 	"encoding/binary"
+	"runtime"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 
 	fr "{{ .FieldPackagePath }}"
 	{{- if .IsKoalaBear}}
@@ -536,6 +538,62 @@ func (vector *Vector) ReadFrom(r io.Reader) (int64, error) {
 	}
 	return n, <-chErr
 }
+
+// PrefixProduct computes the prefix product of the vector in place.
+// i.e. vector[i] = vector[0] * vector[1] * ... * vector[i]
+// If nbTasks > 1, it uses nbTasks goroutines to compute the prefix product in parallel.
+// If nbTasks is not provided, it uses the number of CPU cores.
+func (vector Vector) PrefixProduct(nbTasks ...int) {
+	N := len(vector)
+	if N < 2 {
+		return
+	}
+
+	if N < 512 {
+		vector.prefixProductGeneric()
+		return
+	}
+
+	// Use one worker per available CPU core.
+	numWorkers := runtime.GOMAXPROCS(0)
+	if len(nbTasks) == 1 && nbTasks[0] > 0 && nbTasks[0] < numWorkers {
+		numWorkers = nbTasks[0]
+	}
+
+	for N / numWorkers < 64 && numWorkers > 1 {
+		numWorkers >>= 1
+	}
+	numWorkers = max(1, numWorkers)
+
+		// --- PASS 1: Calculate prefix product for each chunk independently ---
+	parallel.Execute(N, func(start, stop int) {
+		// This is the original sequential algorithm applied to the smaller chunk.
+		for j := start + 1; j < stop; j++ {
+			vector[j].Mul(&vector[j], &vector[j-1])
+		}
+	}, numWorkers)
+
+	chunks := parallel.Chunks(N, numWorkers)
+
+	// the first chunk is correct, we need to update the other chunks
+	for i := 1; i < len(chunks); i++ {
+		// take last value from previous chunk
+		prevChunkEnd := chunks[i-1][1] - 1
+		multiplier := vector[prevChunkEnd]
+		// multiply all values in current chunk by this value
+		start, stop := chunks[i][0], chunks[i][1]
+		subVector := vector[start:stop]
+		subVector.ScalarMul(subVector, &multiplier)
+	}
+
+}
+
+func (vector Vector) prefixProductGeneric() {
+	for i := 1; i < len(vector); i++ {
+		vector[i].Mul(&vector[i], &vector[i-1])
+	}
+}
+
 
 
 func vectorAddGeneric(res, a, b Vector) {

--- a/field/koalabear/extensions/e4_test.go
+++ b/field/koalabear/extensions/e4_test.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 
@@ -605,6 +606,49 @@ func TestVectorExp(t *testing.T) {
 
 }
 
+// prefixProductGeneric computes the prefix product of the vector in place (single-threaded).
+func prefixProductGeneric(vector Vector) {
+	if len(vector) == 0 {
+		return
+	}
+	for i := 1; i < len(vector); i++ {
+		vector[i].Mul(&vector[i-1], &vector[i])
+	}
+}
+
+func randomVector(size int) Vector {
+	v := make(Vector, size)
+	for i := range v {
+		v[i].MustSetRandom()
+	}
+	return v
+}
+
+func TestPrefixProduct_EmptyVector(t *testing.T) {
+	assert := require.New(t)
+	v := make(Vector, 0)
+	expected := make(Vector, 0)
+	prefixProductGeneric(expected)
+	v.PrefixProduct()
+	assert.Equal(expected, v)
+}
+
+func TestPrefixProduct_VariousNbTasks(t *testing.T) {
+	assert := require.New(t)
+	sizes := []int{1, 2, 256, 1024}
+	nbTasksList := []int{1, 16, 32, runtime.NumCPU()}
+	for _, size := range sizes {
+		for _, nbTasks := range nbTasksList {
+			v := randomVector(size)
+			expected := make(Vector, size)
+			copy(expected, v)
+			prefixProductGeneric(expected)
+			v.PrefixProduct(nbTasks)
+			assert.Equal(expected, v, "size=%d nbTasks=%d", size, nbTasks)
+		}
+	}
+}
+
 func TestVectorEmptyOps(t *testing.T) {
 	assert := require.New(t)
 
@@ -868,6 +912,29 @@ func BenchmarkVectorOps(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkPrefixProduct(b *testing.B) {
+	const N = 1 << 19
+	a1 := make(Vector, N)
+	for i := 0; i < N; i++ {
+		a1[i].MustSetRandom()
+	}
+
+	b.Run("generic", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			prefixProductGeneric(a1)
+		}
+	})
+
+	b.Run("PrefixProduct", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			a1.PrefixProduct()
+		}
+	})
+
 }
 
 func BenchmarkVectorSerialization(b *testing.B) {

--- a/field/koalabear/extensions/vector.go
+++ b/field/koalabear/extensions/vector.go
@@ -8,8 +8,10 @@ package extensions
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/consensys/gnark-crypto/internal/parallel"
 	"io"
 	"math/bits"
+	"runtime"
 	"slices"
 	"strings"
 	"unsafe"
@@ -487,6 +489,61 @@ func (vector *Vector) ReadFrom(r io.Reader) (int64, error) {
 		return n, err
 	}
 	return n, <-chErr
+}
+
+// PrefixProduct computes the prefix product of the vector in place.
+// i.e. vector[i] = vector[0] * vector[1] * ... * vector[i]
+// If nbTasks > 1, it uses nbTasks goroutines to compute the prefix product in parallel.
+// If nbTasks is not provided, it uses the number of CPU cores.
+func (vector Vector) PrefixProduct(nbTasks ...int) {
+	N := len(vector)
+	if N < 2 {
+		return
+	}
+
+	if N < 512 {
+		vector.prefixProductGeneric()
+		return
+	}
+
+	// Use one worker per available CPU core.
+	numWorkers := runtime.GOMAXPROCS(0)
+	if len(nbTasks) == 1 && nbTasks[0] > 0 && nbTasks[0] < numWorkers {
+		numWorkers = nbTasks[0]
+	}
+
+	for N/numWorkers < 64 && numWorkers > 1 {
+		numWorkers >>= 1
+	}
+	numWorkers = max(1, numWorkers)
+
+	// --- PASS 1: Calculate prefix product for each chunk independently ---
+	parallel.Execute(N, func(start, stop int) {
+		// This is the original sequential algorithm applied to the smaller chunk.
+		for j := start + 1; j < stop; j++ {
+			vector[j].Mul(&vector[j], &vector[j-1])
+		}
+	}, numWorkers)
+
+	chunks := parallel.Chunks(N, numWorkers)
+
+	// the first chunk is correct, we need to update the other chunks
+	for i := 1; i < len(chunks); i++ {
+		// take last value from previous chunk
+		prevChunkEnd := chunks[i-1][1] - 1
+		multiplier := vector[prevChunkEnd]
+		// multiply all values in current chunk by this value
+		start, stop := chunks[i][0], chunks[i][1]
+		subVector := vector[start:stop]
+		subVector.ScalarMul(subVector, &multiplier)
+	}
+
+}
+
+func (vector Vector) prefixProductGeneric() {
+	for i := 1; i < len(vector); i++ {
+		vector[i].Mul(&vector[i], &vector[i-1])
+	}
 }
 
 func vectorAddGeneric(res, a, b Vector) {

--- a/field/koalabear/extensions/vector.go
+++ b/field/koalabear/extensions/vector.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"unsafe"
 
 	fr "github.com/consensys/gnark-crypto/field/koalabear"
@@ -525,18 +526,33 @@ func (vector Vector) PrefixProduct(nbTasks ...int) {
 		}
 	}, numWorkers)
 
+	// get the chunk indices
 	chunks := parallel.Chunks(N, numWorkers)
 
-	// the first chunk is correct, we need to update the other chunks
+	// Compute multipliers for each chunk (product of all previous chunks)
+	multipliers := make([]E4, len(chunks))
+	multipliers[0].SetOne()
 	for i := 1; i < len(chunks); i++ {
-		// take last value from previous chunk
-		prevChunkEnd := chunks[i-1][1] - 1
-		multiplier := vector[prevChunkEnd]
-		// multiply all values in current chunk by this value
-		start, stop := chunks[i][0], chunks[i][1]
-		subVector := vector[start:stop]
-		subVector.ScalarMul(subVector, &multiplier)
+		multipliers[i].SetOne()
+		for j := 0; j < i; j++ {
+			prevChunkEnd := chunks[j][1] - 1
+			multipliers[i].Mul(&multipliers[i], &vector[prevChunkEnd])
+		}
 	}
+
+	// propagate the multipliers to each chunk in parallel
+	// note: the first chunk is not modified (multiplier is 1)
+	var wg sync.WaitGroup
+	wg.Add(len(chunks) - 1)
+	for i := 1; i < len(chunks); i++ {
+		go func(i int) {
+			defer wg.Done()
+			start, stop := chunks[i][0], chunks[i][1]
+			subVector := vector[start:stop]
+			subVector.ScalarMul(subVector, &multipliers[i])
+		}(i)
+	}
+	wg.Wait()
 
 }
 

--- a/internal/parallel/execute.go
+++ b/internal/parallel/execute.go
@@ -54,3 +54,50 @@ func Execute(nbIterations int, work func(int, int), maxCpus ...int) {
 
 	wg.Wait()
 }
+
+// Chunks returns a slice of [2]int where each element is a (start, end) range to be processed by a worker,
+// exactly as Execute does.
+func Chunks(nbIterations int, maxCpus ...int) [][2]int {
+
+	var chunks [][2]int
+
+	nbTasks := runtime.NumCPU()
+	if len(maxCpus) == 1 {
+		nbTasks = maxCpus[0]
+		if nbTasks < 1 {
+			nbTasks = 1
+		} else if nbTasks > 512 {
+			nbTasks = 512
+		}
+	}
+
+	if nbTasks == 1 {
+		// no go routines
+		chunks = append(chunks, [2]int{0, nbIterations})
+		return chunks
+	}
+
+	nbIterationsPerCpus := nbIterations / nbTasks
+
+	// more CPUs than tasks: a CPU will work on exactly one iteration
+	if nbIterationsPerCpus < 1 {
+		nbIterationsPerCpus = 1
+		nbTasks = nbIterations
+	}
+
+	extraTasks := nbIterations - (nbTasks * nbIterationsPerCpus)
+	extraTasksOffset := 0
+
+	for i := 0; i < nbTasks; i++ {
+		_start := i*nbIterationsPerCpus + extraTasksOffset
+		_end := _start + nbIterationsPerCpus
+		if extraTasks > 0 {
+			_end++
+			extraTasks--
+			extraTasksOffset++
+		}
+		chunks = append(chunks, [2]int{_start, _end})
+	}
+
+	return chunks
+}


### PR DESCRIPTION
# Description

Adds a parallel prefix product method for e4 vectors. 

```
cpu: AMD EPYC 9R14
BenchmarkPrefixProduct/generic-96                     84          14388851 ns/op               0 B/op          0 allocs/op
BenchmarkPrefixProduct/PrefixProduct-96             1026           1150196 ns/op           21797 B/op        298 allocs/op
```