### PR TITLE
feat: add typed field hasher interface in MiMC package

### DIFF
--- a/ecc/bls12-377/fr/mimc/mimc.go
+++ b/ecc/bls12-377/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS12_377, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bls12-377/fr/mimc/mimc.go
+++ b/ecc/bls12-377/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS12_377, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bls12-377/fr/mimc/mimc.go
+++ b/ecc/bls12-377/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bls12-377/fr/mimc/mimc_test.go
+++ b/ecc/bls12-377/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bls12-377/fr/mimc/mimc_test.go
+++ b/ecc/bls12-377/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bls12-377/fr/mimc/mimc_test.go
+++ b/ecc/bls12-377/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bls12-381/fr/mimc/mimc.go
+++ b/ecc/bls12-381/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS12_381, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bls12-381/fr/mimc/mimc.go
+++ b/ecc/bls12-381/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS12_381, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bls12-381/fr/mimc/mimc.go
+++ b/ecc/bls12-381/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bls12-381/fr/mimc/mimc_test.go
+++ b/ecc/bls12-381/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bls12-381/fr/mimc/mimc_test.go
+++ b/ecc/bls12-381/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bls12-381/fr/mimc/mimc_test.go
+++ b/ecc/bls12-381/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bls24-315/fr/mimc/mimc.go
+++ b/ecc/bls24-315/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS24_315, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bls24-315/fr/mimc/mimc.go
+++ b/ecc/bls24-315/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS24_315, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bls24-315/fr/mimc/mimc.go
+++ b/ecc/bls24-315/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bls24-315/fr/mimc/mimc_test.go
+++ b/ecc/bls24-315/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bls24-315/fr/mimc/mimc_test.go
+++ b/ecc/bls24-315/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bls24-315/fr/mimc/mimc_test.go
+++ b/ecc/bls24-315/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bls24-317/fr/mimc/mimc.go
+++ b/ecc/bls24-317/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS24_317, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bls24-317/fr/mimc/mimc.go
+++ b/ecc/bls24-317/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BLS24_317, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bls24-317/fr/mimc/mimc.go
+++ b/ecc/bls24-317/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bls24-317/fr/mimc/mimc_test.go
+++ b/ecc/bls24-317/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bls24-317/fr/mimc/mimc_test.go
+++ b/ecc/bls24-317/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bls24-317/fr/mimc/mimc_test.go
+++ b/ecc/bls24-317/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bn254/fr/mimc/mimc.go
+++ b/ecc/bn254/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BN254, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bn254/fr/mimc/mimc.go
+++ b/ecc/bn254/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bn254/fr/mimc/mimc_test.go
+++ b/ecc/bn254/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bn254/fr/mimc/mimc_test.go
+++ b/ecc/bn254/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bn254/fr/mimc/mimc_test.go
+++ b/ecc/bn254/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bw6-633/fr/mimc/mimc.go
+++ b/ecc/bw6-633/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BW6_633, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bw6-633/fr/mimc/mimc.go
+++ b/ecc/bw6-633/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BW6_633, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bw6-633/fr/mimc/mimc.go
+++ b/ecc/bw6-633/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bw6-633/fr/mimc/mimc_test.go
+++ b/ecc/bw6-633/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bw6-633/fr/mimc/mimc_test.go
+++ b/ecc/bw6-633/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bw6-633/fr/mimc/mimc_test.go
+++ b/ecc/bw6-633/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/bw6-761/fr/mimc/mimc.go
+++ b/ecc/bw6-761/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_BW6_761, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/bw6-761/fr/mimc/mimc.go
+++ b/ecc/bw6-761/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_BW6_761, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/bw6-761/fr/mimc/mimc.go
+++ b/ecc/bw6-761/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/bw6-761/fr/mimc/mimc_test.go
+++ b/ecc/bw6-761/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/bw6-761/fr/mimc/mimc_test.go
+++ b/ecc/bw6-761/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/bw6-761/fr/mimc/mimc_test.go
+++ b/ecc/bw6-761/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/ecc/grumpkin/fr/mimc/mimc.go
+++ b/ecc/grumpkin/fr/mimc/mimc.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -40,8 +41,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_GRUMPKIN, func() stdhash.Hash {
@@ -79,8 +78,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/ecc/grumpkin/fr/mimc/mimc.go
+++ b/ecc/grumpkin/fr/mimc/mimc.go
@@ -19,8 +19,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 
 var _ FieldHasher = NewMiMC()
@@ -161,6 +179,32 @@ func (d *digest) checksum() fr.Element {
 		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
 	}
 
+	return d.h
+}
+
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//
+//	for _, e := range elems {
+//	    h.WriteElement(e)
+//	}
+//	return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
 	return d.h
 }
 

--- a/ecc/grumpkin/fr/mimc/mimc.go
+++ b/ecc/grumpkin/fr/mimc/mimc.go
@@ -17,6 +17,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_GRUMPKIN, func() stdhash.Hash {
 		return NewMiMC()
@@ -54,7 +62,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -72,10 +80,17 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
+}
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
 }
 
 // BlockSize returns the hash's underlying block size.
@@ -122,6 +137,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/ecc/grumpkin/fr/mimc/mimc_test.go
+++ b/ecc/grumpkin/fr/mimc/mimc_test.go
@@ -142,4 +142,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/ecc/grumpkin/fr/mimc/mimc_test.go
+++ b/ecc/grumpkin/fr/mimc/mimc_test.go
@@ -116,3 +116,30 @@ func TestSetState(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+}

--- a/ecc/grumpkin/fr/mimc/mimc_test.go
+++ b/ecc/grumpkin/fr/mimc/mimc_test.go
@@ -120,9 +120,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
@@ -10,6 +10,13 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+type FieldHasher interface {
+	hash.StateStorer
+	WriteElement(e fr.Element)
+	SumElement() fr.Element
+}
+var _ FieldHasher = NewMiMC()
+
 func init() {
 	hash.RegisterHash(hash.MIMC_{{ .EnumID }}, func() stdhash.Hash {
 		return NewMiMC()
@@ -63,7 +70,7 @@ func GetConstants() []big.Int {
 }
 
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) hash.StateStorer {
+func NewMiMC(opts ...Option) FieldHasher {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)
@@ -81,11 +88,19 @@ func (d *digest) Reset() {
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
 	buffer := d.checksum()
-	d.data = nil // flush the data already hashed
+	d.data = d.data[:0]
 	hash := buffer.Bytes()
 	b = append(b, hash[:]...)
 	return b
 }
+
+// SumElement returns the current hash as a field element.
+func (d *digest) SumElement() fr.Element {
+	r := d.checksum()
+	d.data = d.data[:0]
+	return r
+}
+
 
 // BlockSize returns the hash's underlying block size.
 // The Write method must be able to accept any amount
@@ -131,6 +146,11 @@ func (d *digest) Write(p []byte) (int, error) {
 		return 0, errors.New("invalid input length: must represent a list of field elements, expects a []byte of len m*BlockSize")
 	}
 	return len(p), nil
+}
+
+// WriteElement adds a field element to the running hash.
+func (d *digest) WriteElement(e fr.Element) {
+	d.data = append(d.data, e)
 }
 
 // Hash hash using Miyaguchi-Preneel:

--- a/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
@@ -12,8 +12,26 @@ import (
 
 type FieldHasher interface {
 	hash.StateStorer
+
+	// WriteElement adds a field element to the running hash.
 	WriteElement(e fr.Element)
+
+	// SumElement returns the current hash as a field element.
 	SumElement() fr.Element
+
+	// SumElements returns the current hash as a field element,
+	// after hashing all the provided elements (in addition to the already hashed ones).
+	// This is a convenience method to avoid multiple calls to WriteElement
+	// followed by a call to SumElement.
+	// It is equivalent to:
+	//   for _, e := range elems {
+	//       h.WriteElement(e)
+	//   }
+	//   return h. SumElement()
+	//
+	// This avoids copying the elements into the data slice and
+	// is more efficient.
+	SumElements([]fr.Element) fr.Element
 }
 var _ FieldHasher = NewMiMC()
 
@@ -173,6 +191,30 @@ func (d *digest) checksum() fr.Element {
 	return d.h
 }
 
+// SumElements returns the current hash as a field element,
+// after hashing all the provided elements (in addition to the already hashed ones).
+// This is a convenience method to avoid multiple calls to WriteElement
+// followed by a call to SumElement.
+// It is equivalent to:
+//   for _, e := range elems {
+//       h.WriteElement(e)
+//   }
+//   return h. SumElement()
+//
+// This avoids copying the elements into the data slice and
+// is more efficient.
+func (d *digest) SumElements(elems []fr.Element) fr.Element {
+	for i := range d.data {
+		r := d.encrypt(d.data[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &d.data[i])
+	}
+	for i := range elems {
+		r := d.encrypt(elems[i])
+		d.h.Add(&r, &d.h).Add(&d.h, &elems[i])
+	}
+	d.data = d.data[:0]
+	return d.h
+}
 
 {{ if eq .Name "bls12-377" }}
 // plain execution of a mimc run

--- a/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/mimc.go.tmpl
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// FieldHasher is an interface for a hash function that operates on field elements
 type FieldHasher interface {
 	hash.StateStorer
 
@@ -33,7 +34,6 @@ type FieldHasher interface {
 	// is more efficient.
 	SumElements([]fr.Element) fr.Element
 }
-var _ FieldHasher = NewMiMC()
 
 func init() {
 	hash.RegisterHash(hash.MIMC_{{ .EnumID }}, func() stdhash.Hash {
@@ -87,8 +87,19 @@ func GetConstants() []big.Int {
 	return res
 }
 
+// NewFieldHasher returns a FieldHasher (works with typed field elements, not bytes)
+func NewFieldHasher(opts ...Option) FieldHasher {
+	r := NewMiMC(opts...)
+	return r.(FieldHasher)
+}
+
+// NewBinaryHasher returns a hash.StateStorer (works with bytes, not typed field elements)
+func NewBinaryHasher(opts ...Option) hash.StateStorer {
+	return NewMiMC(opts...)
+}
+
 // NewMiMC returns a MiMC implementation, pure Go reference implementation.
-func NewMiMC(opts ...Option) FieldHasher {
+func NewMiMC(opts ...Option) hash.StateStorer {
 	d := new(digest)
 	d.Reset()
 	cfg := mimcOptions(opts...)

--- a/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
@@ -113,9 +113,9 @@ func TestSetState(t *testing.T) {
 func TestFieldHasher(t *testing.T) {
 	assert := require.New(t)
 
-	h1 := mimc.NewMiMC()
-	h2 := mimc.NewMiMC()
-	h3 := mimc.NewMiMC()
+	h1 := mimc.NewFieldHasher()
+	h2 := mimc.NewFieldHasher()
+	h3 := mimc.NewFieldHasher()
 	randInputs := make(fr.Vector, 10)
 	randInputs.MustSetRandom()
 

--- a/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
@@ -135,4 +135,11 @@ func TestFieldHasher(t *testing.T) {
 	_dgst3 := h3.SumElement()
 	dgst3 := _dgst3.Bytes()
 	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
+	// test SumElements
+	h3.Reset()
+	_dgst3 = h3.SumElements(randInputs)
+	dgst3 = _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
+
 }

--- a/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
+++ b/internal/generator/crypto/hash/mimc/template/tests/mimc_test.go.tmpl
@@ -84,7 +84,6 @@ func TestSetState(t *testing.T) {
 
 	storedStates := make([][]byte, len(randInputs))
 
-
 	for i := range randInputs {
 		storedStates[i] = h1.State()
 
@@ -109,4 +108,31 @@ func TestSetState(t *testing.T) {
 			t.Fatal("hashes do not match")
 		}
 	}
+}
+
+func TestFieldHasher(t *testing.T) {
+	assert := require.New(t)
+
+	h1 := mimc.NewMiMC()
+	h2 := mimc.NewMiMC()
+	h3 := mimc.NewMiMC()
+	randInputs := make(fr.Vector, 10)
+	randInputs.MustSetRandom()
+
+	for i := range randInputs {
+		h1.Write(randInputs[i].Marshal())
+		h2.WriteElement(randInputs[i])
+	}
+	dgst1 := h1.Sum(nil)
+	dgst2 := h2.Sum(nil)
+	assert.Equal(dgst1, dgst2, "hashes do not match")
+
+	// test SumElement
+	h3.WriteElement(randInputs[0])
+	for i := 1; i < len(randInputs); i++ {
+		h3.Write(randInputs[i].Marshal())
+	}
+	_dgst3 := h3.SumElement()
+	dgst3 := _dgst3.Bytes()
+	assert.Equal(dgst1, dgst3[:], "hashes do not match")
 }


### PR DESCRIPTION
Adds a interface in `mimc` packages to enable callers to directly work with field elements instead of dancing with bytes (e.g. linea monorepo).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a typed field-element MiMC hasher with WriteElement/SumElement/SumElements and supporting factories, update internals to reuse buffers, and add tests/templates for all curves.
> 
> - **API**:
>   - Add `FieldHasher` interface with `WriteElement`, `SumElement`, and `SumElements`.
>   - New constructors: `NewFieldHasher` (field elements) and `NewBinaryHasher` (bytes).
> - **Implementation**:
>   - Implement `WriteElement`, `SumElement`, and `SumElements` in `digest` for `bls12-377`, `bls12-381`, `bls24-315`, `bls24-317`, `bn254`, `bw6-633`, `bw6-761`, and `grumpkin`.
>   - Change `Sum` to reset internal buffer with `d.data = d.data[:0]`.
> - **Tests**:
>   - Add `TestFieldHasher` validating equivalence of byte-based and element-based hashing, and `SumElement`/`SumElements` behavior for all curves.
> - **Codegen**:
>   - Update templates (`internal/generator/.../mimc.go.tmpl`, tests) to generate the new API and behavior across curves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f87fe4a7e6bf6fdf454052c4d40b7f3ddc7969d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->