### PR TITLE
fix: remove duplicate import

### DIFF
--- a/ecc/bls12-377/fp/vector_test.go
+++ b/ecc/bls12-377/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls12-377/fr/vector_test.go
+++ b/ecc/bls12-377/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls12-381/fp/vector_test.go
+++ b/ecc/bls12-381/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls12-381/fr/vector_test.go
+++ b/ecc/bls12-381/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls24-315/fp/vector_test.go
+++ b/ecc/bls24-315/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls24-315/fr/vector_test.go
+++ b/ecc/bls24-315/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls24-317/fp/vector_test.go
+++ b/ecc/bls24-317/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bls24-317/fr/vector_test.go
+++ b/ecc/bls24-317/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bn254/fp/vector_test.go
+++ b/ecc/bn254/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bn254/fr/vector_test.go
+++ b/ecc/bn254/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bw6-633/fp/vector_test.go
+++ b/ecc/bw6-633/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bw6-633/fr/vector_test.go
+++ b/ecc/bw6-633/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bw6-761/fp/vector_test.go
+++ b/ecc/bw6-761/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/bw6-761/fr/vector_test.go
+++ b/ecc/bw6-761/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/grumpkin/fp/vector_test.go
+++ b/ecc/grumpkin/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/grumpkin/fr/vector_test.go
+++ b/ecc/grumpkin/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/secp256k1/fp/vector_test.go
+++ b/ecc/secp256k1/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/secp256k1/fr/vector_test.go
+++ b/ecc/secp256k1/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/stark-curve/fp/vector_test.go
+++ b/ecc/stark-curve/fp/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/ecc/stark-curve/fr/vector_test.go
+++ b/ecc/stark-curve/fr/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/field/babybear/vector_test.go
+++ b/field/babybear/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/field/goldilocks/vector_test.go
+++ b/field/goldilocks/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"

--- a/field/koalabear/vector_test.go
+++ b/field/koalabear/vector_test.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Fixes merge conflict between #759 and #760 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant `github.com/stretchr/testify/require` import across multiple `vector_test.go` files in ECC and field packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23433e9090eb6a8261ef7e27801de361559b696b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->