### PR TITLE
chore: use self hosted runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
           args: -v --timeout=5m
   
   test:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     needs: staticcheck
     permissions: 
       pull-requests: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x]
-        os: [gha-runner-scale-set-ubuntu-22.04-amd64-xxl, windows-latest, macos-latest]
+        os: [gha-runner-scale-set-ubuntu-24-amd64-xxl, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     needs:
       - staticcheck
@@ -64,11 +64,11 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test (windows / mac)
       # on macOS CI / Windows CI we avoid running the std/ tests (they are run on ubuntu CI)
-      if: startsWith(matrix.os, 'ubuntu') == false
+      if: startsWith(matrix.os, 'gha-runner-scale-set-ubuntu') == false
       run: |
         go test -short -v -timeout=60m ./...
     - name: Test (ubuntu - race and solc)
-      if: startsWith(matrix.os, 'ubuntu') == true
+      if: startsWith(matrix.os, 'gha-runner-scale-set-ubuntu') == true
       run: |
         set -euo pipefail
         go test -json -v -timeout=30m ./... 2>&1 | gotestfmt -hide=all | tee /tmp/gotest.log


### PR DESCRIPTION
This repo has been identified as a higher cost repo in our Org.

Move runners to self hosted runners to mitigate cost and increase performance.

Thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch PR and push workflows to self-hosted Ubuntu runners and update matrix/condition checks accordingly.
> 
> - **CI (GitHub Actions)**:
>   - **`pr.yml`**:
>     - Change `test` job `runs-on` to `gha-runner-scale-set-ubuntu-24-amd64-xxl`.
>   - **`push.yml`**:
>     - Update matrix `os` from `ubuntu-latest-128` to `gha-runner-scale-set-ubuntu-24-amd64-xxl`.
>     - Adjust conditional checks to `startsWith(matrix.os, 'gha-runner-scale-set-ubuntu')` for Linux-specific steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30074a7eb54dbf9ffcebf1fecfaa1c09bac91f57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->