### PR TITLE
style: use blank identifier for unused parameter in mulWordN

### DIFF
--- a/field/generator/asm/amd64/element_mul.go
+++ b/field/generator/asm/amd64/element_mul.go
@@ -95,7 +95,7 @@ func (f *FFAmd64) MulADX(registers *amd64.Registers, x, y func(int) string, t []
 		divShift()
 	}, true)
 
-	mulWordN := f.Define("MUL_WORD_N", 0, func(args ...any) {
+	mulWordN := f.Define("MUL_WORD_N", 0, func(_ ...any) {
 		f.XORQ(amd64.AX, amd64.AX)
 		// for j=0 to N-1
 		//    (A,t[j])  := t[j] + x[j]*y[i] + A


### PR DESCRIPTION
Replace unused 'args' parameter with '_' in mulWordN function definition to match the coding style used in divShift and mulWord0 within the same file. This explicitly indicates the parameter is intentionally ignored.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace unused args parameter with _ in MUL_WORD_N function definition in amd64 element_mul to indicate intentional ignore.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f10dc7702b96f012428bbecfce61409384e8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->