### PR TITLE
Fix: Affine twisted Edwards scalar multiplication edge case

### DIFF
--- a/ecc/bls12-377/twistededwards/point.go
+++ b/ecc/bls12-377/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bls12-377/twistededwards/point_test.go
+++ b/ecc/bls12-377/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bls12-381/bandersnatch/point_test.go
+++ b/ecc/bls12-381/bandersnatch/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -652,6 +739,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bls12-381/twistededwards/point.go
+++ b/ecc/bls12-381/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bls12-381/twistededwards/point_test.go
+++ b/ecc/bls12-381/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bls24-315/twistededwards/point.go
+++ b/ecc/bls24-315/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bls24-315/twistededwards/point_test.go
+++ b/ecc/bls24-315/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bls24-317/twistededwards/point.go
+++ b/ecc/bls24-317/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bls24-317/twistededwards/point_test.go
+++ b/ecc/bls24-317/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bn254/twistededwards/point.go
+++ b/ecc/bn254/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,38 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	initOnce.Do(initCurveParams)
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.T, &p2.X).
-		Mul(&C, &p2.Y).
-		Mul(&C, &curveParams.D)
-	D.Set(&p1.Z)
-	tmp.Add(&p1.X, &p1.Y)
-	E.Add(&p2.X, &p2.Y).
-		Mul(&E, &tmp).
-		Sub(&E, &A).
-		Sub(&E, &B)
-	F.Sub(&D, &C)
-	G.Add(&D, &C)
-	H.Set(&A)
-	mulByA(&H)
-	H.Sub(&B, &H)
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -611,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bn254/twistededwards/point_test.go
+++ b/ecc/bn254/twistededwards/point_test.go
@@ -23,102 +23,6 @@ const (
 	nbFuzz      = 100
 )
 
-func TestBug(t *testing.T) {
-	t.Parallel()
-	parameters := gopter.DefaultTestParameters()
-	if testing.Short() {
-		parameters.MinSuccessfulTests = nbFuzzShort
-	} else {
-		parameters.MinSuccessfulTests = nbFuzz
-	}
-
-	properties := gopter.NewProperties(parameters)
-	genS1 := GenBigInt()
-
-	properties.Property("[random](0,1) == (0,1)", prop.ForAll(
-		func(s1 big.Int) bool {
-			var p1 PointAffine
-			p1.setInfinity()
-			p1.ScalarMultiplication(&p1, &s1)
-
-			return p1.IsZero()
-		},
-		genS1,
-	))
-
-	properties.Property("[2](0,1) == (0,1)", prop.ForAll(
-		func() bool {
-			var p1 PointAffine
-			p1.setInfinity()
-			p1.Double(&p1)
-
-			return p1.IsZero()
-		},
-	))
-
-	properties.Property("(0,1)+(0,1) == (0,1)", prop.ForAll(
-		func() bool {
-			var p1, p2 PointAffine
-			p1.setInfinity()
-			p2.setInfinity()
-			p1.Add(&p1, &p2)
-
-			return p1.IsZero()
-		},
-	))
-
-	properties.Property("(0,1)+(x,y) == (x,y)", prop.ForAll(
-		func(s1 big.Int) bool {
-			params := GetEdwardsCurve()
-			var p1, p2 PointAffine
-			p1.setInfinity()
-			p2.ScalarMultiplication(&params.Base, &s1)
-			p1.Add(&p1, &p2)
-
-			return p1.Equal(&p2)
-		},
-		genS1,
-	))
-
-	properties.Property("(0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
-		func(s1 big.Int) bool {
-			params := GetEdwardsCurve()
-			var p1 PointAffine
-			p1.setInfinity()
-			var p2 PointExtended
-			p2.FromAffine(&params.Base)
-			p2.ScalarMultiplication(&p2, &s1)
-			var res PointExtended
-			res.MixedAdd(&p2, &p1)
-
-			var p2Aff, resAff PointAffine
-			p2Aff.FromExtended(&p2)
-			resAff.FromExtended(&res)
-
-			return resAff.Equal(&p2Aff)
-		},
-		genS1,
-	))
-
-	properties.Property("(0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
-		func() bool {
-			var p1 PointAffine
-			p1.setInfinity()
-			var p2 PointExtended
-			p2.setInfinity()
-			var res PointExtended
-			res.MixedAdd(&p2, &p1)
-
-			var resAff PointAffine
-			resAff.FromExtended(&res)
-
-			return resAff.IsZero()
-		},
-	))
-
-	properties.TestingRun(t, gopter.ConsoleReporter(false))
-}
-
 func TestReceiverIsOperand(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
@@ -526,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -716,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bw6-633/twistededwards/point.go
+++ b/ecc/bw6-633/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bw6-633/twistededwards/point_test.go
+++ b/ecc/bw6-633/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/ecc/bw6-761/twistededwards/point.go
+++ b/ecc/bw6-761/twistededwards/point.go
@@ -177,6 +177,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -209,6 +211,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -360,59 +364,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -435,6 +389,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -526,7 +533,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -552,37 +560,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -610,32 +589,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/ecc/bw6-761/twistededwards/point_test.go
+++ b/ecc/bw6-761/twistededwards/point_test.go
@@ -430,6 +430,93 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -620,6 +707,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 

--- a/internal/generator/edwards/template/point.go.tmpl
+++ b/internal/generator/edwards/template/point.go.tmpl
@@ -232,6 +232,8 @@ func (p *PointAffine) Neg(p1 *PointAffine) *PointAffine {
 
 // Add adds two points (x,y), (u,v) on a twisted Edwards curve with parameters a, d
 // modifies p
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 	initOnce.Do(initCurveParams)
@@ -265,6 +267,8 @@ func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
 // Double doubles point (x,y) on a twisted Edwards curve with parameters a, d
 // modifies p
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
 func (p *PointAffine) Double(p1 *PointAffine) *PointAffine {
 
 	var A, B, C, D, E, F, G, H fr.Element
@@ -416,59 +420,9 @@ func (p *PointProj) FromAffine(p1 *PointAffine) *PointProj {
 	return p
 }
 
-// MixedAdd adds a point in projective to a point in affine coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
-func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
-	initOnce.Do(initCurveParams)
-
-	var B, C, D, E, F, G, H, I fr.Element
-	B.Square(&p1.Z)
-	C.Mul(&p1.X, &p2.X)
-	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&curveParams.D, &C).Mul(&E, &D)
-	F.Sub(&B, &E)
-	G.Add(&B, &E)
-	H.Add(&p1.X, &p1.Y)
-	I.Add(&p2.X, &p2.Y)
-	p.X.Mul(&H, &I).
-		Sub(&p.X, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &p1.Z).
-		Mul(&p.X, &F)
-	mulByA(&C)
-	p.Y.Sub(&D, &C).
-		Mul(&p.Y, &p1.Z).
-		Mul(&p.Y, &G)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
-// Double adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
-func (p *PointProj) Double(p1 *PointProj) *PointProj {
-
-	var B, C, D, E, F, H, J fr.Element
-
-	B.Add(&p1.X, &p1.Y).Square(&B)
-	C.Square(&p1.X)
-	D.Square(&p1.Y)
-	E.Set(&C)
-	mulByA(&E)
-	F.Add(&E, &D)
-	H.Square(&p1.Z)
-	J.Sub(&F, &H).Sub(&J, &H)
-	p.X.Sub(&B, &C).
-		Sub(&p.X, &D).
-		Mul(&p.X, &J)
-	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
-	p.Z.Mul(&F, &J)
-
-	return p
-}
-
 // Add adds points in projective coordinates
-// cf https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
+// Unified Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-add-2008-bbjlp
 func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	initOnce.Do(initCurveParams)
 
@@ -491,6 +445,59 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 	C.Neg(&C)
 	p.Y.Add(&D, &C).
 		Mul(&p.Y, &A).
+		Mul(&p.Y, &G)
+	p.Z.Mul(&F, &G)
+
+	return p
+}
+
+// Double adds points in projective coordinates
+// (Dedicated) Doubling from https://eprint.iacr.org/2008/013.pdf
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp
+func (p *PointProj) Double(p1 *PointProj) *PointProj {
+
+	var B, C, D, E, F, H, J fr.Element
+
+	B.Add(&p1.X, &p1.Y).Square(&B)
+	C.Square(&p1.X)
+	D.Square(&p1.Y)
+	E.Set(&C)
+	mulByA(&E)
+	F.Add(&E, &D)
+	H.Square(&p1.Z)
+	J.Sub(&F, &H).Sub(&J, &H)
+	p.X.Sub(&B, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &J)
+	p.Y.Sub(&E, &D).Mul(&p.Y, &F)
+	p.Z.Mul(&F, &J)
+
+	return p
+}
+
+// MixedAdd adds a point in projective to a point in affine coordinates
+// Mixed Addition from http://eprint.iacr.org/2008/013.pdf (Sec. 6)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#addition-madd-2008-bbjlp
+func (p *PointProj) MixedAdd(p1 *PointProj, p2 *PointAffine) *PointProj {
+	initOnce.Do(initCurveParams)
+
+	var B, C, D, E, F, G, H, I fr.Element
+	B.Square(&p1.Z)
+	C.Mul(&p1.X, &p2.X)
+	D.Mul(&p1.Y, &p2.Y)
+	E.Mul(&curveParams.D, &C).Mul(&E, &D)
+	F.Sub(&B, &E)
+	G.Add(&B, &E)
+	H.Add(&p1.X, &p1.Y)
+	I.Add(&p2.X, &p2.Y)
+	p.X.Mul(&H, &I).
+		Sub(&p.X, &C).
+		Sub(&p.X, &D).
+		Mul(&p.X, &p1.Z).
+		Mul(&p.X, &F)
+	mulByA(&C)
+	p.Y.Sub(&D, &C).
+		Mul(&p.Y, &p1.Z).
 		Mul(&p.Y, &G)
 	p.Z.Mul(&F, &G)
 
@@ -586,7 +593,8 @@ func (p *PointExtended) FromAffine(p1 *PointAffine) *PointExtended {
 }
 
 // Add adds points in extended coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
+// Unified Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-add-2008-hwcd
 func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	var A, B, C, D, E, F, G, H, tmp fr.Element
 	A.Mul(&p1.X, &p2.X)
@@ -612,37 +620,8 @@ func (p *PointExtended) Add(p1, p2 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedAdd adds a point in extended coordinates to a point in affine coordinates
-// See https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
-func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
-	var A, B, C, D, E, F, G, H, tmp fr.Element
-
-	A.Mul(&p1.X, &p2.X)
-	B.Mul(&p1.Y, &p2.Y)
-	C.Mul(&p1.Z, &p2.X).
-		Mul(&C, &p2.Y)
-	D.Set(&p1.T)
-	E.Add(&D, &C)
-	tmp.Sub(&p1.X, &p1.Y)
-	F.Add(&p2.X, &p2.Y).
-		Mul(&F, &tmp).
-		Add(&F, &B).
-		Sub(&F, &A)
-	G.Set(&A)
-	mulByA(&G)
-	G.Add(&G, &B)
-	H.Sub(&D, &C)
-
-	p.X.Mul(&E, &F)
-	p.Y.Mul(&G, &H)
-	p.T.Mul(&E, &H)
-	p.Z.Mul(&F, &G)
-
-	return p
-}
-
 // Double adds points in extended coordinates
-// Dedicated doubling
+// (Dedicated) doubling from https://eprint.iacr.org/2008/522.pdf (Sec. 3.3)
 // https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-dbl-2008-hwcd
 func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 
@@ -670,32 +649,33 @@ func (p *PointExtended) Double(p1 *PointExtended) *PointExtended {
 	return p
 }
 
-// MixedDouble adds points in extended coordinates
-// Dedicated mixed doubling
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html#doubling-mdbl-2008-hwcd
-func (p *PointExtended) MixedDouble(p1 *PointExtended) *PointExtended {
+// MixedAdd adds a point in extended coordinates to a point in affine coordinates
+// Unified Mixed Addition from https://eprint.iacr.org/2008/522.pdf (Sec. 3.1)
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
+func (p *PointExtended) MixedAdd(p1 *PointExtended, p2 *PointAffine) *PointExtended {
+	initOnce.Do(initCurveParams)
+	var A, B, C, D, E, F, G, H, tmp fr.Element
 
-	var A, B, D, E, G, H, two fr.Element
-	two.SetUint64(2)
-
-	A.Square(&p1.X)
-	B.Square(&p1.Y)
-	D.Set(&A)
-	mulByA(&D)
-	E.Add(&p1.X, &p1.Y).
-		Square(&E).
+	A.Mul(&p1.X, &p2.X)
+	B.Mul(&p1.Y, &p2.Y)
+	C.Mul(&p1.T, &p2.X).
+		Mul(&C, &p2.Y).
+		Mul(&C, &curveParams.D)
+	D.Set(&p1.Z)
+	tmp.Add(&p1.X, &p1.Y)
+	E.Add(&p2.X, &p2.Y).
+		Mul(&E, &tmp).
 		Sub(&E, &A).
 		Sub(&E, &B)
-	G.Add(&D, &B)
-	H.Sub(&D, &B)
-
-	p.X.Sub(&G, &two).
-		Mul(&p.X, &E)
+	F.Sub(&D, &C)
+	G.Add(&D, &C)
+	H.Set(&A)
+	mulByA(&H)
+	H.Sub(&B, &H)
+	p.X.Mul(&E, &F)
 	p.Y.Mul(&G, &H)
-	p.T.Mul(&H, &E)
-	p.Z.Square(&G).
-		Sub(&p.Z, &G).
-		Sub(&p.Z, &G)
+	p.T.Mul(&E, &H)
+	p.Z.Mul(&F, &G)
 
 	return p
 }

--- a/internal/generator/edwards/template/tests/point.go.tmpl
+++ b/internal/generator/edwards/template/tests/point.go.tmpl
@@ -423,6 +423,94 @@ func TestOps(t *testing.T) {
 		genS1,
 	))
 
+	properties.Property("(affine) [random](0,1) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.ScalarMultiplication(&p1, &s1)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [0](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			zero := big.NewInt(0)
+			p1.ScalarMultiplication(&p1, zero)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [1](x,y) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			one := big.NewInt(1)
+			p2.ScalarMultiplication(&p1, one)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](x,y) == Double(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			two := big.NewInt(2)
+			p2.ScalarMultiplication(&p1, two)
+			p1.Double(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [-1](x,y) == Neg(x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1, p2 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			mone := big.NewInt(-1)
+			p2.ScalarMultiplication(&p1, mone)
+			p1.Neg(&p1)
+
+			return p1.Equal(&p2)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine) [2](0,1) == (0,1)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			p1.Double(&p1)
+
+			return p1.IsZero()
+		},
+	))
+
+	properties.Property("(affine) [order](x,y) == (0,1)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			p1.ScalarMultiplication(&p1, &curveParams.Order)
+
+			return p1.IsZero()
+		},
+		genS1,
+	))
+
+
 	// projective
 	properties.Property("(projective) 0+0=2*0=0", prop.ForAll(
 		func(s1 big.Int) bool {
@@ -653,6 +741,60 @@ func TestOps(t *testing.T) {
 	))
 
 	// mixed affine+projective
+	properties.Property("(affine/extended) (0,1)+(x,y,z,t) == (x,y,z,t)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.FromAffine(&params.Base)
+			p2.ScalarMultiplication(&p2, &s1)
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var p2Aff, resAff PointAffine
+			p2Aff.FromExtended(&p2)
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p2Aff)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (x,y)+(0,1,1,0) == (x,y)", prop.ForAll(
+		func(s1 big.Int) bool {
+			params := GetEdwardsCurve()
+			var p1 PointAffine
+			p1.ScalarMultiplication(&params.Base, &s1)
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.Equal(&p1)
+		},
+		genS1,
+	))
+
+	properties.Property("(affine/extended) (0,1)+(0,1,1,0) == (0,1,1,0)", prop.ForAll(
+		func() bool {
+			var p1 PointAffine
+			p1.setInfinity()
+			var p2 PointExtended
+			p2.setInfinity()
+			var res PointExtended
+			res.MixedAdd(&p2, &p1)
+
+			var resAff PointAffine
+			resAff.FromExtended(&res)
+
+			return resAff.IsZero()
+		},
+	))
+
 	properties.Property("(mixed affine+proj) P+(-P)=O", prop.ForAll(
 		func(s big.Int) bool {
 


### PR DESCRIPTION
# Description

The bug was introduced in https://github.com/Consensys/gnark-crypto/pull/743. Basically the edge case `[random](0,1)` was incorrectly handled in that PR. Affine twisted Edwards scalar multiplication should use unified Extended/Affine mixed addition instead of dedicated addition to cover all edge cases.

Fixes #773 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Added many edge cases tests in `TestOps`

# How has this been benchmarked?

NA

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix affine Edwards scalar multiplication by using unified Extended/Affine mixed addition; update Add/Double formulas and add comprehensive edge‑case tests across curves.
> 
> - **Core fix (Affine scalar multiplication)**:
>   - Switch `PointAffine.scalarMulWindowed` to accumulate in `PointExtended` via unified mixed addition (`resExtended.MixedAdd(&resExtended, p)`), addressing edge cases when starting from `(0,1)` and for small/negative scalars.
> - **Formulas and implementations**:
>   - Update `PointProj.Add` and `PointProj.MixedAdd` to the unified formulas (adjust `A/B` terms, sign handling, and multipliers) per EFD/2008 references.
>   - Replace `PointExtended.MixedAdd` with the unified mixed-add formula; remove dedicated `MixedDouble` paths; annotate `Add/Double` with correct references.
> - **Tests**:
>   - Add property tests for affine edge cases: `[random](0,1)`, `[0]P`, `[1]P`, `[2]P`, `[-1]P`, `[order]P`, and identity interactions in mixed affine/extended.
>   - Mirror tests across curves: `bls12-377`, `bls12-381` (bandersnatch and twistededwards), `bls24-315`, `bls24-317`, `bn254`, `bw6-633`, `bw6-761`.
> - **Code generation**:
>   - Update Edwards templates to emit the new unified `Add`/`MixedAdd`/`Double` implementations and the new tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2664bc9fbf97102f2dc9b579da9742ae72ca24d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->