### PR TITLE
perf(bw6): faster direct Fp6 mul

### DIFF
--- a/ecc/bw6-761/internal/fptower/e6_direct_test.go
+++ b/ecc/bw6-761/internal/fptower/e6_direct_test.go
@@ -163,6 +163,18 @@ func TestE6DOps(t *testing.T) {
 		genB,
 	))
 
+	properties.Property("[(direct) BW6-761] tower square and direct square are the same", prop.ForAll(
+		func(a *E6D) bool {
+			var c E6D
+			c.Square(a)
+			var _c E6
+			_a := ToTower(a)
+			_c.Square(_a)
+			return c.Equal(FromTower(&_c))
+		},
+		genA,
+	))
+
 	properties.Property("[(direct) BW6-761] mul & inverse should leave an element invariant", prop.ForAll(
 		func(a, b *E6D) bool {
 			var c, d E6D
@@ -215,5 +227,22 @@ func BenchmarkE6DMulMontgomery6(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.mulMontgomery6(&a, &c)
+	}
+}
+func BenchmarkE6DSquareTower(b *testing.B) {
+	var a E6D
+	a.MustSetRandom()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.squareTower(&a)
+	}
+}
+
+func BenchmarkE6DSquareMontgomery6(b *testing.B) {
+	var a E6D
+	a.MustSetRandom()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.squareMontgomery6(&a)
 	}
 }


### PR DESCRIPTION
# Description

Montgomery in [[1]] presented a formula for multiplying quintic polynomials that needs one less multiplication than Karatsuba, but not much was said about the number of additions. In [[2]] the authors adapt this formula to compute the multiplication in direct sextic extensions Fp6. They report in Appendix A.1  a cost of `17M + 143A + 5B`, where `M`, `A`, `B` stand for multiplication, addition and multiplication by the sextic non-residue β. In the case of BW6-761 β=4 so `B=2A` and the overall cost is `17M + 153A`. The previous gnark-crypto implementation was using `17M + 222A`. In this PR we implement the product in `17M + 130A`.

[1]: https://ieeexplore.ieee.org/document/1388200
[2]: https://eprint.iacr.org/2006/471.pdf

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Consistency between direct extension and 2-3 tower multiplications.

# How has this been benchmarked?

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkE6DMulMontgomery6-8     5142          3181          -38.14%
```
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces E6D.Mul with an optimized Montgomery-6 implementation and introduces a direct Montgomery-6 squaring routine, with corresponding property tests and benchmarks.
> 
> - **Fp6 (direct) arithmetic (`ecc/bw6-761/internal/fptower/e6_direct.go`)**:
>   - **Mul**: Switch default to `mulMontgomery6` and reimplement with a staged, 17M/low-additions Montgomery-6 algorithm.
>   - **Square**: Add `squareMontgomery6` (direct Montgomery-6 squaring) plus `squareTower` helper; `Square` currently uses tower path.
>   - Minor: adjust `SetOne` comment.
> - **Tests (`ecc/bw6-761/internal/fptower/e6_direct_test.go`)**:
>   - Property: direct square matches tower square.
>   - Benchmarks: add `BenchmarkE6DSquareTower` and `BenchmarkE6DSquareMontgomery6`; keep mul benchmark using Montgomery-6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 029b8feed2bd9ae2b508becbf6eaab27e18e1e85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->