### PR TITLE
perf: use NAF decomposition in `mulWindow`

### DIFF
--- a/ecc/bls12-377/g1.go
+++ b/ecc/bls12-377/g1.go
@@ -657,14 +657,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -672,75 +689,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls12-377/g2.go
+++ b/ecc/bls12-377/g2.go
@@ -657,14 +657,31 @@ func (p *G2Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -672,75 +689,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls12-381/g2.go
+++ b/ecc/bls12-381/g2.go
@@ -678,14 +678,31 @@ func GeneratePointNotInG2(f E2) G2Jac {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -693,75 +710,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls24-315/g1.go
+++ b/ecc/bls24-315/g1.go
@@ -659,14 +659,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -674,75 +691,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls24-315/g2.go
+++ b/ecc/bls24-315/g2.go
@@ -660,14 +660,31 @@ func (p *G2Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -675,75 +692,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls24-317/g1.go
+++ b/ecc/bls24-317/g1.go
@@ -660,14 +660,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -675,75 +692,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bls24-317/g2.go
+++ b/ecc/bls24-317/g2.go
@@ -660,14 +660,31 @@ func (p *G2Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -675,75 +692,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bn254/g1.go
+++ b/ecc/bn254/g1.go
@@ -644,14 +644,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -659,75 +676,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bn254/g2.go
+++ b/ecc/bn254/g2.go
@@ -695,14 +695,31 @@ func GeneratePointNotInG2(f E2) G2Jac {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -710,75 +727,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bw6-633/g1.go
+++ b/ecc/bw6-633/g1.go
@@ -658,14 +658,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -673,75 +690,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bw6-761/g1.go
+++ b/ecc/bw6-761/g1.go
@@ -662,14 +662,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -677,75 +694,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/bw6-761/g2.go
+++ b/ecc/bw6-761/g2.go
@@ -667,14 +667,31 @@ func (p *G2Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
+	var qAff G2Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
+	var res G2Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G2Jac) mulWindowedMixed(q *G2Affine, s *big.Int) *G2Jac {
 	if s.Sign() == 0 {
 		p.Set(&g2Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -682,75 +699,24 @@ func (p *G2Jac) mulWindowed(q *G2Jac, s *big.Int) *G2Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G2Jac
-	var qAff, qNegAff G2Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g2Infinity)
+	var qNeg G2Affine
+	qNeg.Neg(q)
+	p.Set(&g2Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G2Affine) mulWindowed(q *G2Affine, s *big.Int) *G2Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G2Jac
-	var qNegAff G2Affine
-	qNegAff.Neg(q)
-	res.Set(&g2Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/grumpkin/g1.go
+++ b/ecc/grumpkin/g1.go
@@ -645,14 +645,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -660,75 +677,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // mulBySeed multiplies the point q by the seed xGen in Jacobian coordinates

--- a/ecc/secp256k1/g1.go
+++ b/ecc/secp256k1/g1.go
@@ -645,14 +645,31 @@ func (p *G1Jac) IsInSubGroup() bool {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
+	var qAff G1Affine
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
+	var res G1Jac
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *G1Jac) mulWindowedMixed(q *G1Affine, s *big.Int) *G1Jac {
 	if s.Sign() == 0 {
 		p.Set(&g1Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -660,75 +677,24 @@ func (p *G1Jac) mulWindowed(q *G1Jac, s *big.Int) *G1Jac {
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res G1Jac
-	var qAff, qNegAff G1Affine
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&g1Infinity)
+	var qNeg G1Affine
+	qNeg.Neg(q)
+	p.Set(&g1Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *G1Affine) mulWindowed(q *G1Affine, s *big.Int) *G1Affine {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res G1Jac
-	var qNegAff G1Affine
-	qNegAff.Neg(q)
-	res.Set(&g1Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 // phi sets p to ϕ(a) where ϕ: (x,y) → (w x,y),

--- a/internal/generator/ecc/template/point.go.tmpl
+++ b/internal/generator/ecc/template/point.go.tmpl
@@ -1023,14 +1023,31 @@ func GeneratePointNotIn{{ toUpper .PointName}}(f E2) {{ $TJacobian }} {
 // mulWindowed computes a double-and-add scalar multiplication p=[s]q in
 // Jacobian coordinates and using NAF encoding.
 func (p *{{ $TJacobian }}) mulWindowed(q *{{ $TJacobian }}, s *big.Int) *{{ $TJacobian }} {
+	var qAff {{ $TAffine }}
+	qAff.FromJacobian(q)
+	return p.mulWindowedMixed(&qAff, s)
+}
 
+// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
+// affine coordinates and using NAF encoding.
+func (p *{{ $TAffine }}) mulWindowed(q *{{ $TAffine }}, s *big.Int) *{{ $TAffine }} {
+	var res {{ $TJacobian }}
+	res.mulWindowedMixed(q, s)
+	p.FromJacobian(&res)
+	return p
+}
+
+// mulWindowedMixed computes a double-and-add scalar multiplication p=[s]q
+// where q is in affine coordinates, using NAF encoding.
+func (p *{{ $TJacobian }}) mulWindowedMixed(q *{{ $TAffine }}, s *big.Int) *{{ $TJacobian }} {
 	if s.Sign() == 0 {
 		p.Set(&{{ toLower .PointName}}Infinity)
 		return p
 	}
 	var scalar big.Int
 	scalar.Set(s)
-	if scalar.Sign() < 0 {
+	negScalar := scalar.Sign() < 0
+	if negScalar {
 		scalar.Neg(&scalar)
 	}
 	if scalar.BitLen() > fr.Bits {
@@ -1038,75 +1055,24 @@ func (p *{{ $TJacobian }}) mulWindowed(q *{{ $TJacobian }}, s *big.Int) *{{ $TJa
 	}
 	var naf [fr.Bits + 1]int8
 	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	var res {{ $TJacobian }}
-	var qAff, qNegAff {{ $TAffine }}
-	qAff.FromJacobian(q)
-	qNegAff.Neg(&qAff)
-	res.Set(&{{ toLower .PointName}}Infinity)
+	var qNeg {{ $TAffine }}
+	qNeg.Neg(q)
+	p.Set(&{{ toLower .PointName}}Infinity)
 	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
+		p.DoubleAssign()
 		switch naf[i] {
 		case 0:
 			continue
 		case 1:
-			res.AddMixed(&qAff)
+			p.AddMixed(q)
 		case -1:
-			res.AddMixed(&qNegAff)
+			p.AddMixed(&qNeg)
 		}
 	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
+	if negScalar {
+		p.Neg(p)
 	}
-	p.Set(&res)
-
 	return p
-
-}
-
-// mulWindowed computes a double-and-add scalar multiplication p=[s]q in
-// affine coordinates and using NAF encoding.
-func (p *{{ $TAffine }}) mulWindowed(q *{{ $TAffine }}, s *big.Int) *{{ $TAffine }} {
-
-	if s.Sign() == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var scalar big.Int
-	scalar.Set(s)
-	if scalar.Sign() < 0 {
-		scalar.Neg(&scalar)
-	}
-	if scalar.BitLen() > fr.Bits {
-		scalar.Mod(&scalar, fr.Modulus())
-	}
-	var naf [fr.Bits + 1]int8
-	nafLen := ecc.NafDecomposition(&scalar, naf[:])
-	if nafLen == 0 {
-		p.SetInfinity()
-		return p
-	}
-	var res {{ $TJacobian }}
-	var qNegAff {{ $TAffine }}
-	qNegAff.Neg(q)
-	res.Set(&{{ toLower .PointName}}Infinity)
-	for i := nafLen - 1; i >= 0; i-- {
-		res.DoubleAssign()
-		switch naf[i] {
-		case 0:
-			continue
-		case 1:
-			res.AddMixed(q)
-		case -1:
-			res.AddMixed(&qNegAff)
-		}
-	}
-	if s.Sign() < 0 {
-		res.Neg(&res)
-	}
-	p.FromJacobian(&res)
-
-	return p
-
 }
 
 {{- if not (eq .Name "secp256k1")}}


### PR DESCRIPTION
# Description

Use `ecc.NafDecomposition` in `utils.go` in `mulWindowed`.

Fixes #132 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Same tests pass.

# How has this been benchmarked?

e.g. BLS12-377:

```
cpu: AMD EPYC 9R14
BenchmarkG1AffineScalarMultiplication/method=GLV-wNAF/w=5-32     129970        115066        -11.47%
BenchmarkG2AffineScalarMultiplication/method=GLV-wNAF/w=5-32     405302        333270        -17.77%
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements NAF-based scalar multiplication across all curves and updates codegen.
> 
> - Replaces old 2-bit windowed double-and-add with NAF-based `mulWindowed`, adding `mulWindowedMixed` (affine input) and an affine wrapper; handles zero/negative scalars and reduces scalars mod `fr` where needed
> - Adjusts `ScalarMultiplication`/`ScalarMultiplicationBase` to use new paths and return early, using affine generators (`*GenAff`) in non-GLV cases
> - Minor flow tweaks (e.g., moving `FromAffine` only when needed) and identical changes applied to G1/G2 for bls12-377, bls12-381, bls24-315/317, bn254, bw6-633/761, grumpkin, secp256k1
> - Updates `internal/generator/ecc/template/point.go.tmpl` to generate the new logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 833801bde0ba867707fe40bdb3283c3ce760ba76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->