### PR TITLE
perf: improve small size fft

### DIFF
--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -211,6 +211,12 @@ func difFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 		if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
+		} else if n == 512 {
+			kerDIFNP_512(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1024 {
+			kerDIFNP_1024(a, twiddles, stage-twiddlesStartStage)
+			return
 		}
 	}
 	m := n >> 1
@@ -290,6 +296,12 @@ func ditFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	} else if stage >= twiddlesStartStage {
 		if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 512 {
+			kerDITNP_512(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1024 {
+			kerDITNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
 	}
@@ -412,4 +424,51 @@ func kerDITNP_256generic(a []koalabear.Element, twiddles [][]koalabear.Element, 
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_512 is an optimized 512-element DIF kernel that avoids recursion overhead
+// by directly processing the outer butterfly layer and then calling the 256-element kernel.
+func kerDIFNP_512(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: butterfly with m=256
+	innerDIFWithTwiddles(a, twiddles[stage], 0, 256, 256)
+	// Process two halves with the 256-element kernel
+	kerDIFNP_256(a[:256], twiddles, stage+1)
+	kerDIFNP_256(a[256:], twiddles, stage+1)
+}
+
+// kerDITNP_512 is an optimized 512-element DIT kernel that avoids recursion overhead.
+func kerDITNP_512(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Process two halves with the 256-element kernel first (DIT order)
+	kerDITNP_256(a[:256], twiddles, stage+1)
+	kerDITNP_256(a[256:], twiddles, stage+1)
+	// Final stage: butterfly with m=256
+	innerDITWithTwiddles(a, twiddles[stage], 0, 256, 256)
+}
+
+// kerDIFNP_1024 is an optimized 1024-element DIF kernel that avoids recursion overhead.
+func kerDIFNP_1024(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: butterfly with m=512
+	innerDIFWithTwiddles(a, twiddles[stage], 0, 512, 512)
+	// Stage 1: butterfly with m=256 on both halves
+	innerDIFWithTwiddles(a[:512], twiddles[stage+1], 0, 256, 256)
+	innerDIFWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
+	// Process four quarters with the 256-element kernel
+	kerDIFNP_256(a[:256], twiddles, stage+2)
+	kerDIFNP_256(a[256:512], twiddles, stage+2)
+	kerDIFNP_256(a[512:768], twiddles, stage+2)
+	kerDIFNP_256(a[768:], twiddles, stage+2)
+}
+
+// kerDITNP_1024 is an optimized 1024-element DIT kernel that avoids recursion overhead.
+func kerDITNP_1024(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Process four quarters with the 256-element kernel first (DIT order)
+	kerDITNP_256(a[:256], twiddles, stage+2)
+	kerDITNP_256(a[256:512], twiddles, stage+2)
+	kerDITNP_256(a[512:768], twiddles, stage+2)
+	kerDITNP_256(a[768:], twiddles, stage+2)
+	// Stage 1: butterfly with m=256 on both halves
+	innerDITWithTwiddles(a[:512], twiddles[stage+1], 0, 256, 256)
+	innerDITWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
+	// Final stage: butterfly with m=512
+	innerDITWithTwiddles(a, twiddles[stage], 0, 512, 512)
 }

--- a/internal/generator/field/template/fft/fft.go.tmpl
+++ b/internal/generator/field/template/fft/fft.go.tmpl
@@ -218,7 +218,13 @@ func difFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 				kerDIFNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
 				return
 			}
-		{{- end }}
+		{{- end }}{{- if .HasASMKernel}} else if n == 512 {
+			kerDIFNP_512(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1024 {
+			kerDIFNP_1024(a, twiddles, stage-twiddlesStartStage)
+			return
+		}{{- end}}
 	}
 	m := n >> 1
 
@@ -312,7 +318,13 @@ func ditFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 				kerDITNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
 				return
 			}
-		{{- end }}
+		{{- end }}{{- if .HasASMKernel}} else if n == 512 {
+			kerDITNP_512(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1024 {
+			kerDITNP_1024(a, twiddles, stage-twiddlesStartStage)
+			return
+		}{{- end}}
 	}
 	
 	m := n >> 1
@@ -396,6 +408,55 @@ func innerDITWithoutTwiddles(a []{{ .FF }}.Element, at, w {{ .FF }}.Element, sta
 	{{$ksize := shl 1 $klog2}}
 	{{genKernel $.FF $ksize $klog2}}
 {{end}}
+
+{{- if .HasASMKernel}}
+// kerDIFNP_512 is an optimized 512-element DIF kernel that avoids recursion overhead
+// by directly processing the outer butterfly layer and then calling the 256-element kernel.
+func kerDIFNP_512(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Stage 0: butterfly with m=256
+	innerDIFWithTwiddles(a, twiddles[stage], 0, 256, 256)
+	// Process two halves with the 256-element kernel
+	kerDIFNP_256(a[:256], twiddles, stage+1)
+	kerDIFNP_256(a[256:], twiddles, stage+1)
+}
+
+// kerDITNP_512 is an optimized 512-element DIT kernel that avoids recursion overhead.
+func kerDITNP_512(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Process two halves with the 256-element kernel first (DIT order)
+	kerDITNP_256(a[:256], twiddles, stage+1)
+	kerDITNP_256(a[256:], twiddles, stage+1)
+	// Final stage: butterfly with m=256
+	innerDITWithTwiddles(a, twiddles[stage], 0, 256, 256)
+}
+
+// kerDIFNP_1024 is an optimized 1024-element DIF kernel that avoids recursion overhead.
+func kerDIFNP_1024(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Stage 0: butterfly with m=512
+	innerDIFWithTwiddles(a, twiddles[stage], 0, 512, 512)
+	// Stage 1: butterfly with m=256 on both halves
+	innerDIFWithTwiddles(a[:512], twiddles[stage+1], 0, 256, 256)
+	innerDIFWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
+	// Process four quarters with the 256-element kernel
+	kerDIFNP_256(a[:256], twiddles, stage+2)
+	kerDIFNP_256(a[256:512], twiddles, stage+2)
+	kerDIFNP_256(a[512:768], twiddles, stage+2)
+	kerDIFNP_256(a[768:], twiddles, stage+2)
+}
+
+// kerDITNP_1024 is an optimized 1024-element DIT kernel that avoids recursion overhead.
+func kerDITNP_1024(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Process four quarters with the 256-element kernel first (DIT order)
+	kerDITNP_256(a[:256], twiddles, stage+2)
+	kerDITNP_256(a[256:512], twiddles, stage+2)
+	kerDITNP_256(a[512:768], twiddles, stage+2)
+	kerDITNP_256(a[768:], twiddles, stage+2)
+	// Stage 1: butterfly with m=256 on both halves
+	innerDITWithTwiddles(a[:512], twiddles[stage+1], 0, 256, 256)
+	innerDITWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
+	// Final stage: butterfly with m=512
+	innerDITWithTwiddles(a, twiddles[stage], 0, 512, 512)
+}
+{{- end}}
 
 {{define "genKernel FF sizeKernel sizeKernelLog2"}}
 


### PR DESCRIPTION
# Description

Improve small size fft runtime (~50%) by avoiding overhead for small sizes (< 1024) .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes small FFT sizes by bypassing recursion for `n=512` and `n=1024`.
> 
> - Add `kerDIFNP_512`/`kerDITNP_512` and `kerDIFNP_1024`/`kerDITNP_1024` in `field/babybear/fft/fft.go` and `field/koalabear/fft/fft.go`
> - Update `difFFT`/`ditFFT` to directly call these kernels when `stage >= twiddlesStartStage` and `n ∈ {512,1024}`
> - Extend generator template `internal/generator/field/template/fft/fft.go.tmpl` to emit the same kernels and conditional dispatch (guarded by `HasASMKernel`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21ae715b9fe4bf403c0f52a7f276c15a9862fa57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->