### PR TITLE
perf: 4-bit sliding window exponentiation for all fields

### DIFF
--- a/ecc/bls12-377/fp/element.go
+++ b/ecc/bls12-377/fp/element.go
@@ -904,8 +904,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -920,14 +920,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls12-377/fr/element.go
+++ b/ecc/bls12-377/fr/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls12-377/fr/exp_test.go
+++ b/ecc/bls12-377/fr/exp_test.go
@@ -1,0 +1,363 @@
+package fr
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+)
+
+// expBinary is the old binary square-and-multiply implementation for reference comparison.
+func expBinary(z *Element, x Element, k *big.Int) *Element {
+	if k.IsUint64() && k.Uint64() == 0 {
+		return z.SetOne()
+	}
+
+	e := k
+	if k.Sign() == -1 {
+		x.Inverse(&x)
+		e = new(big.Int).Neg(k)
+	}
+
+	z.Set(&x)
+
+	for i := e.BitLen() - 2; i >= 0; i-- {
+		z.Square(z)
+		if e.Bit(i) == 1 {
+			z.Mul(z, &x)
+		}
+	}
+
+	return z
+}
+
+// TestExpWindowedCorrectnessExhaustiveSmall tests all uint64 exponents 0..1024
+func TestExpWindowedCorrectnessExhaustiveSmall(t *testing.T) {
+	t.Parallel()
+	var x Element
+	x.MustSetRandom()
+
+	for k := uint64(0); k <= 1024; k++ {
+		kBig := new(big.Int).SetUint64(k)
+		var got, want Element
+		got.Exp(x, kBig)
+		expBinary(&want, x, kBig)
+		if !got.Equal(&want) {
+			t.Fatalf("mismatch at k=%d", k)
+		}
+	}
+}
+
+// TestExpWindowedCorrectnessRandomUint64 tests random uint64 exponents
+func TestExpWindowedCorrectnessRandomUint64(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < 500; i++ {
+		var x Element
+		x.MustSetRandom()
+
+		kBig, _ := rand.Int(rand.Reader, new(big.Int).SetUint64(^uint64(0)))
+
+		var got, want Element
+		got.Exp(x, kBig)
+		expBinary(&want, x, kBig)
+		if !got.Equal(&want) {
+			t.Fatalf("mismatch at iteration %d, k=%s", i, kBig.String())
+		}
+	}
+}
+
+// TestExpWindowedCorrectnessRandomBig tests random big.Int exponents of various bit lengths
+func TestExpWindowedCorrectnessRandomBig(t *testing.T) {
+	t.Parallel()
+	bitSizes := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 200, 253, 254, 255, 256, 384, 512, 1024}
+	for _, bits := range bitSizes {
+		for i := 0; i < 50; i++ {
+			var x Element
+			x.MustSetRandom()
+
+			kBig, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), uint(bits)))
+
+			var got, want Element
+			got.Exp(x, kBig)
+			expBinary(&want, x, kBig)
+			if !got.Equal(&want) {
+				t.Fatalf("mismatch at bits=%d iteration=%d, k=%s", bits, i, kBig.String())
+			}
+		}
+	}
+}
+
+// TestExpWindowedEdgeCases tests specific edge cases
+func TestExpWindowedEdgeCases(t *testing.T) {
+	t.Parallel()
+	var x, got, want Element
+	x.MustSetRandom()
+
+	// k = 0
+	got.Exp(x, big.NewInt(0))
+	if !got.IsOne() {
+		t.Fatal("Exp(x, 0) should be 1")
+	}
+
+	// k = 1
+	got.Exp(x, big.NewInt(1))
+	if !got.Equal(&x) {
+		t.Fatal("Exp(x, 1) should be x")
+	}
+
+	// k = 2
+	got.Exp(x, big.NewInt(2))
+	want.Square(&x)
+	if !got.Equal(&want) {
+		t.Fatal("Exp(x, 2) should be x²")
+	}
+
+	// k = 3
+	got.Exp(x, big.NewInt(3))
+	want.Mul(&want, &x)
+	if !got.Equal(&want) {
+		t.Fatal("Exp(x, 3) should be x³")
+	}
+
+	// powers of 2
+	for p := 1; p <= 64; p++ {
+		k := new(big.Int).Lsh(big.NewInt(1), uint(p))
+		got.Exp(x, k)
+		expBinary(&want, x, k)
+		if !got.Equal(&want) {
+			t.Fatalf("Exp(x, 2^%d) mismatch", p)
+		}
+	}
+
+	// 2^k - 1 (all ones in binary)
+	for p := 1; p <= 64; p++ {
+		k := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(p)), big.NewInt(1))
+		got.Exp(x, k)
+		expBinary(&want, x, k)
+		if !got.Equal(&want) {
+			t.Fatalf("Exp(x, 2^%d - 1) mismatch", p)
+		}
+	}
+
+	// x = 0
+	var zero Element
+	got.Exp(zero, big.NewInt(42))
+	if !got.IsZero() {
+		t.Fatal("Exp(0, 42) should be 0")
+	}
+
+	// x = 1
+	var one Element
+	one.SetOne()
+	kBig, _ := rand.Int(rand.Reader, Modulus())
+	got.Exp(one, kBig)
+	if !got.IsOne() {
+		t.Fatal("Exp(1, k) should be 1")
+	}
+
+	// negative exponent
+	got.Exp(x, big.NewInt(-1))
+	want.Inverse(&x)
+	if !got.Equal(&want) {
+		t.Fatal("Exp(x, -1) should be x⁻¹")
+	}
+
+	// Exp(x, q-1) should be 1 (Fermat's little theorem)
+	qm1 := new(big.Int).Sub(Modulus(), big.NewInt(1))
+	got.Exp(x, qm1)
+	if !got.IsOne() {
+		t.Fatal("Exp(x, q-1) should be 1")
+	}
+
+	// aliasing: z == &x
+	got.Set(&x)
+	got.Exp(got, big.NewInt(7))
+	expBinary(&want, x, big.NewInt(7))
+	if !got.Equal(&want) {
+		t.Fatal("aliased Exp(x, 7) mismatch")
+	}
+}
+
+// TestExpWindowedNegativeExponents tests negative exponents of various sizes
+func TestExpWindowedNegativeExponents(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < 200; i++ {
+		var x Element
+		x.MustSetRandom()
+
+		kBig, _ := rand.Int(rand.Reader, Modulus())
+		negK := new(big.Int).Neg(kBig)
+
+		var got, want Element
+		got.Exp(x, negK)
+		expBinary(&want, x, negK)
+		if !got.Equal(&want) {
+			t.Fatalf("negative exp mismatch at iteration %d", i)
+		}
+	}
+}
+
+// TestExpWindowedConsistency verifies Exp with big.Int matches repeated multiplication
+func TestExpWindowedConsistency(t *testing.T) {
+	t.Parallel()
+	var x Element
+	x.MustSetRandom()
+
+	// verify by repeated multiplication for small k
+	for k := uint64(0); k <= 128; k++ {
+		var got, want Element
+		got.Exp(x, new(big.Int).SetUint64(k))
+
+		want.SetOne()
+		for j := uint64(0); j < k; j++ {
+			want.Mul(&want, &x)
+		}
+		if !got.Equal(&want) {
+			t.Fatalf("Exp(x, %d) != x*x*...*x (%d times)", k, k)
+		}
+	}
+}
+
+// Benchmarks with various exponent sizes
+func BenchmarkExpBinary(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, Modulus())
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}
+
+func BenchmarkExpWindowed(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, Modulus())
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpUint64Small(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k := new(big.Int).SetUint64(7)
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpUint64Medium(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k := new(big.Int).SetUint64(1<<32 - 1)
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpUint64Large(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k := new(big.Int).SetUint64(^uint64(0))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpBig128(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpBig256(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 256))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+func BenchmarkExpBigModulus(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, Modulus())
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		z.Exp(x, k)
+	}
+}
+
+// Binary baseline benchmarks for comparison
+func BenchmarkExpBinarySmall(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k := new(big.Int).SetUint64(7)
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}
+
+func BenchmarkExpBinaryUint64Large(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k := new(big.Int).SetUint64(^uint64(0))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}
+
+func BenchmarkExpBinaryBig128(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}
+
+func BenchmarkExpBinaryBig256(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 256))
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}
+
+func BenchmarkExpBinaryModulus(b *testing.B) {
+	var x Element
+	x.MustSetRandom()
+	k, _ := rand.Int(rand.Reader, Modulus())
+	b.ResetTimer()
+	var z Element
+	for i := 0; i < b.N; i++ {
+		expBinary(&z, x, k)
+	}
+}

--- a/ecc/bls12-381/fp/element.go
+++ b/ecc/bls12-381/fp/element.go
@@ -903,8 +903,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -919,14 +919,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls12-381/fr/element.go
+++ b/ecc/bls12-381/fr/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls24-315/fp/element.go
+++ b/ecc/bls24-315/fp/element.go
@@ -822,8 +822,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -838,14 +838,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls24-315/fr/element.go
+++ b/ecc/bls24-315/fr/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls24-317/fp/element.go
+++ b/ecc/bls24-317/fp/element.go
@@ -821,8 +821,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -837,14 +837,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bls24-317/fr/element.go
+++ b/ecc/bls24-317/fr/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bn254/fp/element.go
+++ b/ecc/bn254/fp/element.go
@@ -745,8 +745,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -761,14 +761,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bn254/fr/element.go
+++ b/ecc/bn254/fr/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bw6-633/fp/element.go
+++ b/ecc/bw6-633/fp/element.go
@@ -1291,8 +1291,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -1307,14 +1307,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bw6-633/fr/element.go
+++ b/ecc/bw6-633/fr/element.go
@@ -822,8 +822,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -838,14 +838,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bw6-761/fp/element.go
+++ b/ecc/bw6-761/fp/element.go
@@ -1521,8 +1521,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -1537,14 +1537,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/bw6-761/fr/element.go
+++ b/ecc/bw6-761/fr/element.go
@@ -904,8 +904,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -920,14 +920,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/grumpkin/fp/element.go
+++ b/ecc/grumpkin/fp/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/grumpkin/fr/element.go
+++ b/ecc/grumpkin/fr/element.go
@@ -745,8 +745,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -761,14 +761,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/secp256k1/fp/element.go
+++ b/ecc/secp256k1/fp/element.go
@@ -773,8 +773,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -789,14 +789,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/secp256k1/fr/element.go
+++ b/ecc/secp256k1/fr/element.go
@@ -773,8 +773,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -789,14 +789,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/secp256r1/fp/element.go
+++ b/ecc/secp256r1/fp/element.go
@@ -773,8 +773,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -789,14 +789,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/secp256r1/fr/element.go
+++ b/ecc/secp256r1/fr/element.go
@@ -773,8 +773,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -789,14 +789,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/stark-curve/fp/element.go
+++ b/ecc/stark-curve/fp/element.go
@@ -746,8 +746,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -762,14 +762,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/ecc/stark-curve/fr/element.go
+++ b/ecc/stark-curve/fr/element.go
@@ -745,8 +745,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -761,14 +761,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/field/babybear/element.go
+++ b/field/babybear/element.go
@@ -498,7 +498,6 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
-
 	z.Set(&x)
 
 	for i := e.BitLen() - 2; i >= 0; i-- {

--- a/field/goldilocks/element.go
+++ b/field/goldilocks/element.go
@@ -507,8 +507,8 @@ func Hash(msg, dst []byte, count int) ([]Element, error) {
 
 // Exp z = xᵏ (mod q)
 func (z *Element) Exp(x Element, k *big.Int) *Element {
-	if k.IsUint64() && k.Uint64() == 0 {
-		return z.SetOne()
+	if k.IsUint64() {
+		return z.expUint64(x, k.Uint64())
 	}
 
 	e := k
@@ -523,14 +523,144 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
+	return z.expWindowed(x, e)
+}
 
-	z.Set(&x)
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize]>>(uint(pos)%bits.UintSize)) & 1
+}
 
-	for i := e.BitLen() - 2; i >= 0; i-- {
-		z.Square(z)
-		if e.Bit(i) == 1 {
-			z.Mul(z, &x)
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx+uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *Element) expWindowed(x Element, k *big.Int) *Element {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
 		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *Element) expUint64(x Element, k uint64) *Element {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]Element
+	var x2 Element
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
 	}
 
 	return z

--- a/field/koalabear/element.go
+++ b/field/koalabear/element.go
@@ -498,7 +498,6 @@ func (z *Element) Exp(x Element, k *big.Int) *Element {
 		defer pool.BigInt.Put(e)
 		e.Neg(k)
 	}
-
 	z.Set(&x)
 
 	for i := e.BitLen() - 2; i >= 0; i-- {

--- a/internal/generator/field/template/element/exp.go.tmpl
+++ b/internal/generator/field/template/element/exp.go.tmpl
@@ -3,10 +3,10 @@ func (z *{{.ElementName}}) Exp(x {{.ElementName}}, k *big.Int) *{{.ElementName}}
 	{{- if .F31}}
 		if k.IsInt64() {
 			return z.ExpInt64(x, k.Int64())
-		}	
+		}
 	{{- else}}
-		if k.IsUint64() && k.Uint64() == 0 {
-			return z.SetOne()
+		if k.IsUint64() {
+			return z.expUint64(x, k.Uint64())
 		}
 	{{- end}}
 
@@ -23,6 +23,7 @@ func (z *{{.ElementName}}) Exp(x {{.ElementName}}, k *big.Int) *{{.ElementName}}
 		e.Neg(k)
 	}
 
+	{{- if .F31}}
 	z.Set(&x)
 
 	for i := e.BitLen() - 2; i >= 0; i-- {
@@ -33,7 +34,153 @@ func (z *{{.ElementName}}) Exp(x {{.ElementName}}, k *big.Int) *{{.ElementName}}
 	}
 
 	return z
+	{{- else}}
+	return z.expWindowed(x, e)
+	{{- end}}
 }
+
+{{- if not .F31}}
+
+// getBitUint extracts bit at position pos from a little-endian word slice.
+func getBitUint(words []big.Word, pos int) uint {
+	return uint(words[pos/bits.UintSize] >> (uint(pos) % bits.UintSize)) & 1
+}
+
+// getWindowUint extracts a window of windowSize bits starting at position pos (MSB)
+// down to pos-windowSize+1 (LSB) from a little-endian word slice.
+// windowSize must be between 1 and bits.UintSize.
+func getWindowUint(words []big.Word, pos, windowSize int) uint {
+	low := pos - windowSize + 1
+	wIdx := low / bits.UintSize
+	bIdx := uint(low) % bits.UintSize
+
+	// extract from one word
+	win := uint(words[wIdx] >> bIdx)
+
+	// if the window spans two words, include bits from the next word
+	if bIdx + uint(windowSize) > uint(bits.UintSize) {
+		win |= uint(words[wIdx+1]) << (uint(bits.UintSize) - bIdx)
+	}
+
+	return win & ((1 << windowSize) - 1)
+}
+
+// expWindowed computes z = xᵏ (mod q) using a 4-bit sliding window method.
+// It accesses the exponent via big.Int.Bits() for direct word-level access.
+func (z *{{.ElementName}}) expWindowed(x {{.ElementName}}, k *big.Int) *{{.ElementName}} {
+	el := k.BitLen()
+	if el == 0 {
+		return z.SetOne()
+	}
+	if el == 1 {
+		z.Set(&x)
+		return z
+	}
+
+	// precompute table: table[i] = x^(2i+1) for i = 0..7
+	// i.e., odd powers x^1, x^3, x^5, ..., x^15
+	const w = 4 // window size
+	var table [1 << (w - 1)]{{.ElementName}}
+	var x2 {{.ElementName}}
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	words := k.Bits()
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if getBitUint(words, i) == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		// collect up to w bits starting from position i (MSB), ending at a 1-bit
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := getWindowUint(words, i, windowSize)
+
+		// trim trailing zeros to get an odd lookup value
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+
+// expUint64 computes z = xᵏ (mod q) for a uint64 exponent.
+// Uses binary method for small exponents and 4-bit windowed method for larger ones.
+func (z *{{.ElementName}}) expUint64(x {{.ElementName}}, k uint64) *{{.ElementName}} {
+	if k == 0 {
+		return z.SetOne()
+	}
+	el := bits.Len64(k)
+	if el <= 8 {
+		// small exponent: binary method avoids precompute overhead
+		z.Set(&x)
+		for i := el - 2; i >= 0; i-- {
+			z.Square(z)
+			if (k>>i)&1 == 1 {
+				z.Mul(z, &x)
+			}
+		}
+		return z
+	}
+
+	const w = 4
+	var table [1 << (w - 1)]{{.ElementName}}
+	var x2 {{.ElementName}}
+	table[0].Set(&x)
+	x2.Square(&x)
+	for i := 1; i < len(table); i++ {
+		table[i].Mul(&table[i-1], &x2)
+	}
+
+	z.SetOne()
+
+	for i := el - 1; i >= 0; {
+		if (k>>i)&1 == 0 {
+			z.Square(z)
+			i--
+			continue
+		}
+		windowSize := w
+		if i+1 < windowSize {
+			windowSize = i + 1
+		}
+		winVal := uint((k >> (i - windowSize + 1)) & ((1 << windowSize) - 1))
+
+		trailingZeros := bits.TrailingZeros(winVal)
+		winVal >>= trailingZeros
+		effectiveSize := windowSize - trailingZeros
+
+		for j := 0; j < effectiveSize; j++ {
+			z.Square(z)
+		}
+		z.Mul(z, &table[(winVal-1)>>1])
+		for j := 0; j < trailingZeros; j++ {
+			z.Square(z)
+		}
+		i -= windowSize
+	}
+
+	return z
+}
+{{- end}}
 
 {{- if .F31}}
 // ExpInt64 z = xᵏ (mod q)


### PR DESCRIPTION
## Summary

- Replace bit-by-bit binary square-and-multiply `Exp` with a 4-bit sliding window method for all non-F31 fields
- Add `expUint64` fast path that avoids `big.Int` overhead entirely for uint64 exponents
- Use `big.Int.Bits()` for direct word-level access instead of per-bit `Bit()` calls
- Precompute table of 8 odd powers (x^1, x^3, ..., x^15), zero heap allocations

## Benchmark Results

### bls12-377/fr (4-word, 253-bit modulus) — modulus-size random exponent

| Implementation | ns/op | vs baseline |
|---|---|---|
| Binary (baseline) | 5,016 | — |
| **Windowed** | **4,221** | **-15.8%** |

### bls12-377/fp (6-word, 377-bit modulus) — modulus-size random exponent

| Implementation | ns/op | vs baseline |
|---|---|---|
| Binary (baseline) | 12,726 | — |
| **Windowed** | **10,464** | **-17.8%** |

### uint64 fast path (bls12-377/fr)

| Exponent size | Windowed | Binary | Speedup |
|---|---|---|---|
| Small (k=7) | 54 ns | 52 ns | ~parity (falls back to binary) |
| Medium (k=2^32-1) | 669 ns | — | new path |
| Large (k=2^64-1) | 1,217 ns | 1,685 ns | **-27.8%** |

### big.Int exponents at various bit lengths (bls12-377/fr)

| Exponent bits | Windowed | Binary | Speedup |
|---|---|---|---|
| 128 | 2,213 ns | 2,543 ns | **-13.0%** |
| 256 | 4,301 ns | 5,098 ns | **-15.6%** |
| 253 (modulus) | 4,221 ns | 5,016 ns | **-15.8%** |

Zero allocations across all paths and exponent sizes.

## Test plan

- [x] Exhaustive correctness: all exponents 0–1024 compared against reference binary implementation
- [x] Random uint64 exponents (500 iterations)
- [x] Random big.Int exponents at 23 bit sizes (1–1024 bits, 50 iterations each)
- [x] Edge cases: k=0, k=1, k=2, powers of 2, 2^k-1, x=0, x=1, negative exponents, q-1 (Fermat), aliasing
- [x] Negative exponents (200 random iterations)
- [x] Consistency with repeated multiplication for k=0..128
- [x] Existing gopter property tests pass across all curves (bn254, bls12-377, bls12-381, bw6-761, etc.)
- [x] F31 fields (babybear, koalabear) unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core finite-field `Exp` across many curves/fields, so any subtle bug would impact cryptographic correctness even though the change is algorithmically straightforward and adds targeted tests/benchmarks.
> 
> **Overview**
> **Speeds up finite-field exponentiation** by replacing the bit-by-bit square-and-multiply `Exp` implementation with a **4-bit sliding-window** method for all non-`F31` generated fields (fp/fr across multiple curves).
> 
> Adds helper routines (`getBitUint`, `getWindowUint`), an `expWindowed` implementation that reads exponents via `big.Int.Bits()`, and an `expUint64` fast path (binary for very small exponents, windowed otherwise) when `k.IsUint64()`.
> 
> Updates the field code generator template accordingly and adds a comprehensive `fr` exponentiation correctness+benchmark suite (`ecc/bls12-377/fr/exp_test.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4105b9d429d306b955afa8e8acee16560b192841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->