### PR TITLE
feat(p256): add e2 and cardano solver

### DIFF
--- a/ecc/secp256r1/cardano.go
+++ b/ecc/secp256r1/cardano.go
@@ -1,0 +1,134 @@
+package secp256r1
+
+// Cardano solver for the depressed cubic x³ − 3x + c = 0 over secp256r1 Fp.
+// Requires q ≡ 3 mod 4 (for Fp2 sqrt) and q ≡ 4 mod 9 (for Fp cbrt).
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+	fp2 "github.com/consensys/gnark-crypto/ecc/secp256r1/internal/fptower"
+)
+
+var omegaFq fp.Element // primitive cube root of unity in Fp
+
+func init() {
+	q := fp.Modulus()
+	exp := new(big.Int).Sub(q, big.NewInt(1))
+	exp.Div(exp, big.NewInt(3))
+	var one fp.Element
+	one.SetOne()
+	for i := int64(2); ; i++ {
+		var g, w fp.Element
+		g.SetInt64(i)
+		w.Exp(g, exp)
+		if !w.Equal(&one) {
+			omegaFq = w
+			break
+		}
+	}
+}
+
+// CardanoRoots returns all roots in Fp of x³ − 3x + c = 0
+// using Cardano's formula.
+func CardanoRoots(c fp.Element) []fp.Element {
+	var a fp.Element
+	a.SetInt64(-3)
+
+	var zero fp.Element
+
+	// Δ = −4a³ − 27c²
+	var a3, neg4a3, k27c2, delta fp.Element
+	a3.Square(&a).Mul(&a3, &a)
+	neg4a3.Mul(&a3, new(fp.Element).SetInt64(4)).Neg(&neg4a3)
+	k27c2.Square(&c).Mul(&k27c2, new(fp.Element).SetInt64(27))
+	delta.Sub(&neg4a3, &k27c2)
+
+	// disc_D = c²/4 + a³/27
+	var inv4, inv27, discD fp.Element
+	inv4.SetInt64(4)
+	inv4.Inverse(&inv4)
+	inv27.SetInt64(27)
+	inv27.Inverse(&inv27)
+	discD.Square(&c).Mul(&discD, &inv4)
+	var a3over27 fp.Element
+	a3over27.Mul(&a3, &inv27)
+	discD.Add(&discD, &a3over27)
+
+	// −c/2
+	var inv2, negCHalf fp.Element
+	inv2.SetInt64(2)
+	inv2.Inverse(&inv2)
+	negCHalf.Mul(&c, &inv2).Neg(&negCHalf)
+
+	om := omegaFq
+	var om2 fp.Element
+	om2.Square(&om)
+	var one fp.Element
+	one.SetOne()
+	zetas := [3]fp.Element{one, om, om2}
+
+	// Case 1: Δ = 0 (repeated root)
+	if delta.Equal(&zero) {
+		var invA, r0, r1 fp.Element
+		invA.Inverse(&a)
+		r0.Mul(&c, &invA).Mul(&r0, new(fp.Element).SetInt64(3))
+		var twoA fp.Element
+		twoA.Double(&a)
+		r1.Inverse(&twoA).Mul(&r1, &c).Mul(&r1, new(fp.Element).SetInt64(3)).Neg(&r1)
+		return []fp.Element{r0, r1}
+	}
+
+	// Case 2: Δ non-square → one real root via Fp2
+	if delta.Legendre() == -1 {
+		var discDE2, D fp2.E2
+		discDE2.A0 = discD
+		D.Sqrt(&discDE2)
+
+		w := fp2.E2{A0: negCHalf, A1: D.A1}
+		if w.IsZero() {
+			w.A1.Neg(&D.A1)
+		}
+
+		var u fp2.E2
+		u.Cbrt(&w)
+
+		for _, zeta := range zetas {
+			var cand fp2.E2
+			cand.MulByElement(&u, &zeta)
+			var inv fp2.E2
+			inv.Inverse(&cand)
+			var rRe, rIm fp.Element
+			rRe.Add(&cand.A0, &inv.A0)
+			rIm.Add(&cand.A1, &inv.A1)
+			if rIm.Equal(&zero) {
+				return []fp.Element{rRe}
+			}
+		}
+		return []fp.Element{}
+	}
+
+	// Case 3: Δ square → 0 or 3 roots in Fp
+	var DFq, wFq fp.Element
+	DFq.Sqrt(&discD)
+	wFq.Add(&negCHalf, &DFq)
+	if wFq.Equal(&zero) {
+		wFq.Sub(&negCHalf, &DFq)
+	}
+
+	var uFq fp.Element
+	if uFq.Cbrt(&wFq) == nil {
+		return []fp.Element{}
+	}
+
+	var invU, r0, r1, r2, t1, t2 fp.Element
+	invU.Inverse(&uFq)
+	r0.Add(&uFq, &invU)
+	t1.Mul(&om, &uFq)
+	t2.Mul(&om2, &invU)
+	r1.Add(&t1, &t2)
+	t1.Mul(&om2, &uFq)
+	t2.Mul(&om, &invU)
+	r2.Add(&t1, &t2)
+	return []fp.Element{r0, r1, r2}
+}

--- a/ecc/secp256r1/cardano.go
+++ b/ecc/secp256r1/cardano.go
@@ -91,7 +91,9 @@ func CardanoRoots(c fp.Element) []fp.Element {
 		}
 
 		var u fp2.E2
-		u.Cbrt(&w)
+		if u.Cbrt(&w) == nil {
+			return []fp.Element{}
+		}
 
 		for _, zeta := range zetas {
 			var cand fp2.E2

--- a/ecc/secp256r1/cardano_test.go
+++ b/ecc/secp256r1/cardano_test.go
@@ -1,0 +1,34 @@
+package secp256r1
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+)
+
+func TestCardanoRoots(t *testing.T) {
+	// Test with c = b - y² for small y values on P-256 (y² = x³ - 3x + b)
+	var b fp.Element
+	// P-256 b = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
+	b.SetString("41058363725152142129326129780047268409114441015993725554835256314039467401291")
+
+	for y := int64(0); y < 256; y++ {
+		var yFp, y2, c fp.Element
+		yFp.SetInt64(y)
+		y2.Square(&yFp)
+		c.Sub(&b, &y2)
+
+		roots := CardanoRoots(c)
+		// verify each root satisfies x³ - 3x + c = 0
+		for _, r := range roots {
+			var r3, three, threex, lhs fp.Element
+			r3.Square(&r).Mul(&r3, &r)
+			three.SetInt64(3)
+			threex.Mul(&three, &r)
+			lhs.Sub(&r3, &threex).Add(&lhs, &c)
+			if !lhs.IsZero() {
+				t.Fatalf("y=%d: root %v does not satisfy x³ - 3x + c = 0", y, r)
+			}
+		}
+	}
+}

--- a/ecc/secp256r1/cardano_test.go
+++ b/ecc/secp256r1/cardano_test.go
@@ -1,9 +1,11 @@
 package secp256r1
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fr"
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/prop"
 )
@@ -39,36 +41,38 @@ func TestCardanoRoots(t *testing.T) {
 		GenFp(),
 	))
 
-	properties.Property("[SECP256R1] CardanoRoots from curve points should find at least one root", prop.ForAll(
-		func(a fp.Element) bool {
-			// construct c = b − y² so that x³ − 3x + c = 0 has at least one solution
-			// (any y that gives a valid curve point y² = x³ − 3x + b)
+	properties.Property("[SECP256R1] CardanoRoots from curve points should find at least one root matching x", prop.ForAll(
+		func(s fr.Element) bool {
+			// generate a real curve point by scalar multiplication
+			var sBig big.Int
+			s.BigInt(&sBig)
+			var p G1Jac
+			p.ScalarMultiplication(&g1Gen, &sBig)
+			var pAff G1Affine
+			pAff.FromJacobian(&p)
+
+			// c = b − y² so x³ − 3x + c = 0 must have pAff.X as a root
 			var b fp.Element
 			b.SetString("41058363725152142129326129780047268409114441015993725554835256314039467401291")
 			var y2, c fp.Element
-			y2.Square(&a)
+			y2.Square(&pAff.Y)
 			c.Sub(&b, &y2)
 
 			roots := CardanoRoots(c)
 			if len(roots) == 0 {
-				// not all c values yield roots; this is expected
-				return true
+				return false // must find at least one root
 			}
-			// verify returned roots
-			var three fp.Element
-			three.SetInt64(3)
+			// verify at least one root matches the known x
+			found := false
 			for _, r := range roots {
-				var r3, threex, lhs fp.Element
-				r3.Square(&r).Mul(&r3, &r)
-				threex.Mul(&three, &r)
-				lhs.Sub(&r3, &threex).Add(&lhs, &c)
-				if !lhs.IsZero() {
-					return false
+				if r.Equal(&pAff.X) {
+					found = true
+					break
 				}
 			}
-			return true
+			return found
 		},
-		GenFp(),
+		GenFr(),
 	))
 
 	properties.Property("[SECP256R1] CardanoRoots with c=0 should return roots of x³ − 3x = 0", prop.ForAll(

--- a/ecc/secp256r1/cardano_test.go
+++ b/ecc/secp256r1/cardano_test.go
@@ -4,31 +4,95 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/prop"
 )
 
 func TestCardanoRoots(t *testing.T) {
-	// Test with c = b - y² for small y values on P-256 (y² = x³ - 3x + b)
-	var b fp.Element
-	// P-256 b = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
-	b.SetString("41058363725152142129326129780047268409114441015993725554835256314039467401291")
-
-	for y := int64(0); y < 256; y++ {
-		var yFp, y2, c fp.Element
-		yFp.SetInt64(y)
-		y2.Square(&yFp)
-		c.Sub(&b, &y2)
-
-		roots := CardanoRoots(c)
-		// verify each root satisfies x³ - 3x + c = 0
-		for _, r := range roots {
-			var r3, three, threex, lhs fp.Element
-			r3.Square(&r).Mul(&r3, &r)
-			three.SetInt64(3)
-			threex.Mul(&three, &r)
-			lhs.Sub(&r3, &threex).Add(&lhs, &c)
-			if !lhs.IsZero() {
-				t.Fatalf("y=%d: root %v does not satisfy x³ - 3x + c = 0", y, r)
-			}
-		}
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
 	}
+
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property("[SECP256R1] CardanoRoots should return valid roots of x³ − 3x + c = 0", prop.ForAll(
+		func(c fp.Element) bool {
+			roots := CardanoRoots(c)
+			var three fp.Element
+			three.SetInt64(3)
+			for _, r := range roots {
+				// verify r³ − 3r + c = 0
+				var r3, threex, lhs fp.Element
+				r3.Square(&r).Mul(&r3, &r)
+				threex.Mul(&three, &r)
+				lhs.Sub(&r3, &threex).Add(&lhs, &c)
+				if !lhs.IsZero() {
+					return false
+				}
+			}
+			return true
+		},
+		GenFp(),
+	))
+
+	properties.Property("[SECP256R1] CardanoRoots from curve points should find at least one root", prop.ForAll(
+		func(a fp.Element) bool {
+			// construct c = b − y² so that x³ − 3x + c = 0 has at least one solution
+			// (any y that gives a valid curve point y² = x³ − 3x + b)
+			var b fp.Element
+			b.SetString("41058363725152142129326129780047268409114441015993725554835256314039467401291")
+			var y2, c fp.Element
+			y2.Square(&a)
+			c.Sub(&b, &y2)
+
+			roots := CardanoRoots(c)
+			if len(roots) == 0 {
+				// not all c values yield roots; this is expected
+				return true
+			}
+			// verify returned roots
+			var three fp.Element
+			three.SetInt64(3)
+			for _, r := range roots {
+				var r3, threex, lhs fp.Element
+				r3.Square(&r).Mul(&r3, &r)
+				threex.Mul(&three, &r)
+				lhs.Sub(&r3, &threex).Add(&lhs, &c)
+				if !lhs.IsZero() {
+					return false
+				}
+			}
+			return true
+		},
+		GenFp(),
+	))
+
+	properties.Property("[SECP256R1] CardanoRoots with c=0 should return roots of x³ − 3x = 0", prop.ForAll(
+		func(_ fp.Element) bool {
+			var c fp.Element // zero
+			roots := CardanoRoots(c)
+			if len(roots) == 0 {
+				return false
+			}
+			var three fp.Element
+			three.SetInt64(3)
+			for _, r := range roots {
+				var r3, threex, lhs fp.Element
+				r3.Square(&r).Mul(&r3, &r)
+				threex.Mul(&three, &r)
+				lhs.Sub(&r3, &threex)
+				if !lhs.IsZero() {
+					return false
+				}
+			}
+			return true
+		},
+		GenFp(),
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
 }

--- a/ecc/secp256r1/internal/fptower/e2.go
+++ b/ecc/secp256r1/internal/fptower/e2.go
@@ -1,0 +1,380 @@
+// Package fp2 implements Fp2 = Fp[u]/(u²+1) arithmetic for the P-256 (secp256r1) base field.
+// The non-residue is β = −1, valid since q ≡ 3 mod 4.
+package fp2
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+)
+
+// E2 is a degree-two extension of fp.Element: A0 + A1·u, u² = −1.
+type E2 struct {
+	A0, A1 fp.Element
+}
+
+// SetZero sets z to 0.
+func (z *E2) SetZero() *E2 { z.A0.SetZero(); z.A1.SetZero(); return z }
+
+// SetOne sets z to 1.
+func (z *E2) SetOne() *E2 { z.A0.SetOne(); z.A1.SetZero(); return z }
+
+// Set sets z to x.
+func (z *E2) Set(x *E2) *E2 { z.A0 = x.A0; z.A1 = x.A1; return z }
+
+// Equal returns true if z == x.
+func (z *E2) Equal(x *E2) bool { return z.A0.Equal(&x.A0) && z.A1.Equal(&x.A1) }
+
+// IsZero returns true if z == 0.
+func (z *E2) IsZero() bool { return z.A0.IsZero() && z.A1.IsZero() }
+
+// IsOne returns true if z == 1.
+func (z *E2) IsOne() bool { return z.A0.IsOne() && z.A1.IsZero() }
+
+// SetRandom sets z to a random element and returns z.
+func (z *E2) SetRandom() (*E2, error) {
+	if _, err := z.A0.SetRandom(); err != nil {
+		return nil, err
+	}
+	if _, err := z.A1.SetRandom(); err != nil {
+		return nil, err
+	}
+	return z, nil
+}
+
+// MustSetRandom sets z to a random element, panicking on error.
+func (z *E2) MustSetRandom() {
+	if _, err := z.SetRandom(); err != nil {
+		panic(err)
+	}
+}
+
+// String returns the string representation of z.
+func (z *E2) String() string {
+	return fmt.Sprintf("%s+(%s)*u", z.A0.String(), z.A1.String())
+}
+
+// SetString sets z from two decimal strings and returns z.
+func (z *E2) SetString(s1, s2 string) *E2 {
+	z.A0.SetString(s1)
+	z.A1.SetString(s2)
+	return z
+}
+
+// Legendre returns the Legendre symbol of z in Fp2.
+// Returns 1 if z is a non-zero square, -1 if z is not a square, 0 if z is zero.
+func (z *E2) Legendre() int {
+	var n fp.Element
+	z.Norm(&n)
+	return n.Legendre()
+}
+
+// Neg sets z = −x.
+func (z *E2) Neg(x *E2) *E2 {
+	z.A0.Neg(&x.A0)
+	z.A1.Neg(&x.A1)
+	return z
+}
+
+// Conjugate sets z = x̄ = A0 − A1·u.
+func (z *E2) Conjugate(x *E2) *E2 {
+	z.A0 = x.A0
+	z.A1.Neg(&x.A1)
+	return z
+}
+
+// Add sets z = x + y.
+func (z *E2) Add(x, y *E2) *E2 {
+	z.A0.Add(&x.A0, &y.A0)
+	z.A1.Add(&x.A1, &y.A1)
+	return z
+}
+
+// Sub sets z = x − y.
+func (z *E2) Sub(x, y *E2) *E2 {
+	z.A0.Sub(&x.A0, &y.A0)
+	z.A1.Sub(&x.A1, &y.A1)
+	return z
+}
+
+// Double sets z = 2·x.
+func (z *E2) Double(x *E2) *E2 {
+	z.A0.Double(&x.A0)
+	z.A1.Double(&x.A1)
+	return z
+}
+
+// MulByElement sets z = x·y for y ∈ Fp.
+func (z *E2) MulByElement(x *E2, y *fp.Element) *E2 {
+	z.A0.Mul(&x.A0, y)
+	z.A1.Mul(&x.A1, y)
+	return z
+}
+
+// Mul sets z = x·y using Karatsuba (3 Fp muls).
+// (a+bu)(c+du) = (ac−bd) + (ad+bc)u  with β = −1.
+func (z *E2) Mul(x, y *E2) *E2 {
+	var a, b, c fp.Element
+	a.Add(&x.A0, &x.A1)
+	b.Add(&y.A0, &y.A1)
+	a.Mul(&a, &b)
+	b.Mul(&x.A0, &y.A0)
+	c.Mul(&x.A1, &y.A1)
+	z.A1.Sub(&a, &b).Sub(&z.A1, &c)
+	z.A0.Sub(&b, &c)
+	return z
+}
+
+// Square sets z = x² using complex squaring (2 Fp muls + 1 add).
+func (z *E2) Square(x *E2) *E2 {
+	var a, b fp.Element
+	a.Add(&x.A0, &x.A1)
+	b.Sub(&x.A0, &x.A1)
+	a.Mul(&a, &b)
+	b.Mul(&x.A0, &x.A1).Double(&b)
+	z.A0.Set(&a)
+	z.A1.Set(&b)
+	return z
+}
+
+// Inverse sets z = 1/x via norm: N(x) = x0² + x1².
+func (z *E2) Inverse(x *E2) *E2 {
+	var t0, t1 fp.Element
+	t0.Square(&x.A0)
+	t1.Square(&x.A1)
+	t0.Add(&t0, &t1)
+	t1.Inverse(&t0)
+	z.A0.Mul(&x.A0, &t1)
+	z.A1.Mul(&x.A1, &t1).Neg(&z.A1)
+	return z
+}
+
+// Norm sets x = N(z) = z.A0² + z.A1².
+func (z *E2) Norm(x *fp.Element) {
+	var tmp fp.Element
+	x.Square(&z.A0)
+	tmp.Square(&z.A1)
+	x.Add(x, &tmp)
+}
+
+// Exp sets z = x^k using square-and-multiply (big-endian).
+func (z *E2) Exp(x E2, k *big.Int) *E2 {
+	if k.IsUint64() && k.Uint64() == 0 {
+		return z.SetOne()
+	}
+	e := k
+	if k.Sign() == -1 {
+		x.Inverse(&x)
+		e = new(big.Int).Neg(k)
+	}
+	z.SetOne()
+	b := e.Bytes()
+	for i := 0; i < len(b); i++ {
+		w := b[i]
+		for j := 0; j < 8; j++ {
+			z.Square(z)
+			if (w & (0b10000000 >> j)) != 0 {
+				z.Mul(z, &x)
+			}
+		}
+	}
+	return z
+}
+
+// Sqrt sets z = √x in Fp2 using Scott §6.3, valid for q ≡ 3 mod 4.
+func (z *E2) Sqrt(x *E2) *E2 {
+	var a1, alpha, x0, minusOne E2
+	minusOne.SetOne().Neg(&minusOne)
+
+	a1.expBySqrtHelper(x)
+	alpha.Square(&a1).Mul(&alpha, x)
+	x0.Mul(x, &a1)
+
+	if alpha.Equal(&minusOne) {
+		c := x0.A0
+		z.A0.Neg(&x0.A1)
+		z.A1.Set(&c)
+		return z
+	}
+	var b E2
+	b.SetOne()
+	b.A0.Add(&b.A0, &alpha.A0)
+	b.A1.Add(&b.A1, &alpha.A1)
+	b.Exp(b, &sqrtExp2).Mul(&b, &x0)
+	return z.Set(&b)
+}
+
+var sqrtExp2 big.Int
+
+func init() {
+	q := fp.Modulus()
+	sqrtExp2.Sub(q, big.NewInt(1))
+	sqrtExp2.Rsh(&sqrtExp2, 1) // (q-1)/2
+}
+
+// expBySqrtHelper sets z = x^{(q-3)/4} in Fp2 using a short addition chain.
+// (q-3)/4 = 0x3fffffffc00000004000000000000000000000003fffffffffffffffffffffff
+// Addition chain: cost 264 = 253 sq + 11 mul.
+func (z *E2) expBySqrtHelper(x *E2) *E2 {
+	var t0, t1, t2, t3, t4, t5, t6, t7, t8 E2
+
+	t0.Square(x)
+	t1.Mul(x, &t0)
+	t2.Square(&t1)
+	t3.Mul(x, &t2)
+	t4.Square(&t3)
+	t4.Square(&t4)
+	t4.Square(&t4)
+	t5.Mul(&t3, &t4)
+	t8.Square(&t5)
+	for k := 0; k < 5; k++ {
+		t8.Square(&t8)
+	}
+	t8.Mul(&t8, &t5)
+	t6.Square(&t8)
+	t6.Square(&t6)
+	t6.Square(&t6)
+	t6.Mul(&t6, &t3)
+	t7.Square(&t6)
+	t7.Mul(&t7, x)
+	t8.Square(&t7)
+	for k := 0; k < 15; k++ {
+		t8.Square(&t8)
+	}
+	t8.Mul(&t8, &t7)
+	for k := 0; k < 15; k++ {
+		t8.Square(&t8)
+	}
+	t5.Mul(&t6, &t8)
+	for k := 0; k < 17; k++ {
+		t8.Square(&t8)
+	}
+	t8.Mul(&t8, x)
+	for k := 0; k < 143; k++ {
+		t8.Square(&t8)
+	}
+	t8.Mul(&t8, &t5)
+	for k := 0; k < 47; k++ {
+		t8.Square(&t8)
+	}
+	z.Mul(&t5, &t8)
+	return z
+}
+
+// Cbrt sets z = ∛x in Fp2 using the algebraic torus T₂(Fp).
+// For q ≡ 4 mod 9 and β = −1: v₃(q+1) = 0 ensures every element of T₂ has a
+// unique cube root. Returns z, or nil if x is not a cubic residue in Fp2.
+func (z *E2) Cbrt(x *E2) *E2 {
+	if x.A1.IsZero() {
+		if x.A0.Cbrt(&x.A0) == nil {
+			return nil
+		}
+		z.A0.Set(&x.A0)
+		z.A1.SetZero()
+		return z
+	}
+
+	if x.A0.IsZero() {
+		var negA1 fp.Element
+		negA1.Neg(&x.A1)
+		if negA1.Cbrt(&negA1) == nil {
+			return nil
+		}
+		z.A0.SetZero()
+		z.A1.Set(&negA1)
+		return z.cbrtVerify(x)
+	}
+
+	var x0sq, x1sq, norm fp.Element
+	x0sq.Square(&x.A0)
+	x1sq.Square(&x.A1)
+	norm.Add(&x0sq, &x1sq)
+
+	m, normInv, ok := cbrtAndNormInverse(&norm)
+	if !ok {
+		return nil
+	}
+
+	// τ = 2·(A0² − A1²)/N
+	var tau fp.Element
+	tau.Sub(&x0sq, &x1sq)
+	tau.Double(&tau)
+	tau.Mul(&tau, &normInv)
+
+	sigma := lucasV(&tau)
+
+	// z₀ = A0/(m·(σ−1)), z₁ = A1/(m·(σ+1))
+	var one, d0, d1, d0d1, d0d1Inv fp.Element
+	one.SetOne()
+	d0.Sub(&sigma, &one)
+	d0.Mul(&m, &d0)
+	d1.Add(&sigma, &one)
+	d1.Mul(&m, &d1)
+
+	d0d1.Mul(&d0, &d1)
+	d0d1Inv.Inverse(&d0d1)
+
+	z.A0.Mul(&d1, &d0d1Inv).Mul(&z.A0, &x.A0)
+	z.A1.Mul(&d0, &d0d1Inv).Mul(&z.A1, &x.A1)
+
+	return z.cbrtVerify(x)
+}
+
+func (z *E2) cbrtVerify(x *E2) *E2 {
+	var c E2
+	c.Square(z).Mul(&c, z)
+	if !c.Equal(x) {
+		return nil
+	}
+	return z
+}
+
+func cbrtAndNormInverse(norm *fp.Element) (m, normInv fp.Element, ok bool) {
+	var t, t2, t4, t8, t9, n2, n3 fp.Element
+	t.ExpByCbrtHelperQMinus4Div9(*norm)
+	t2.Square(&t)
+	t4.Square(&t2)
+	t8.Square(&t4)
+	t9.Mul(&t8, &t)
+	n2.Square(norm)
+	n3.Mul(&n2, norm)
+	m.Mul(&t8, &n3)
+	normInv.Mul(&t9, &n2)
+
+	var c fp.Element
+	c.Square(&m).Mul(&c, &m)
+	if !c.Equal(norm) {
+		return m, normInv, false
+	}
+	return m, normInv, true
+}
+
+// lucasExponent is e = 3⁻¹ mod (q+1) as little-endian uint64 limbs.
+var lucasExponent = [4]uint64{
+	12297829382473034411,
+	6148914692668172970,
+	6148914691236517205,
+	6148914689804861440,
+}
+
+func lucasV(alpha *fp.Element) fp.Element {
+	var v0, v1, two, prod fp.Element
+	two.SetUint64(2)
+	v0.Set(alpha)
+	v1.Square(alpha).Sub(&v1, &two)
+
+	for i := 253; i >= 1; i-- {
+		bit := (lucasExponent[i/64] >> uint(i%64)) & 1
+		prod.Mul(&v0, &v1).Sub(&prod, alpha)
+		if bit == 0 {
+			v1.Set(&prod)
+			v0.Square(&v0).Sub(&v0, &two)
+		} else {
+			v0.Set(&prod)
+			v1.Square(&v1).Sub(&v1, &two)
+		}
+	}
+	v0.Mul(&v0, &v1).Sub(&v0, alpha)
+	return v0
+}

--- a/ecc/secp256r1/internal/fptower/e2.go
+++ b/ecc/secp256r1/internal/fptower/e2.go
@@ -1,6 +1,6 @@
-// Package fp2 implements Fp2 = Fp[u]/(u²+1) arithmetic for the P-256 (secp256r1) base field.
+// Package fptower implements Fp2 = Fp[u]/(u²+1) arithmetic for the P-256 (secp256r1) base field.
 // The non-residue is β = −1, valid since q ≡ 3 mod 4.
-package fp2
+package fptower
 
 import (
 	"fmt"
@@ -267,22 +267,23 @@ func (z *E2) expBySqrtHelper(x *E2) *E2 {
 // unique cube root. Returns z, or nil if x is not a cubic residue in Fp2.
 func (z *E2) Cbrt(x *E2) *E2 {
 	if x.A1.IsZero() {
-		if x.A0.Cbrt(&x.A0) == nil {
+		var tmp fp.Element
+		if tmp.Cbrt(&x.A0) == nil {
 			return nil
 		}
-		z.A0.Set(&x.A0)
+		z.A0.Set(&tmp)
 		z.A1.SetZero()
 		return z
 	}
 
 	if x.A0.IsZero() {
-		var negA1 fp.Element
+		var negA1, tmp fp.Element
 		negA1.Neg(&x.A1)
-		if negA1.Cbrt(&negA1) == nil {
+		if tmp.Cbrt(&negA1) == nil {
 			return nil
 		}
 		z.A0.SetZero()
-		z.A1.Set(&negA1)
+		z.A1.Set(&tmp)
 		return z.cbrtVerify(x)
 	}
 

--- a/ecc/secp256r1/internal/fptower/e2.go
+++ b/ecc/secp256r1/internal/fptower/e2.go
@@ -267,23 +267,20 @@ func (z *E2) expBySqrtHelper(x *E2) *E2 {
 // unique cube root. Returns z, or nil if x is not a cubic residue in Fp2.
 func (z *E2) Cbrt(x *E2) *E2 {
 	if x.A1.IsZero() {
-		var tmp fp.Element
-		if tmp.Cbrt(&x.A0) == nil {
+		if z.A0.Cbrt(&x.A0) == nil {
 			return nil
 		}
-		z.A0.Set(&tmp)
 		z.A1.SetZero()
 		return z
 	}
 
 	if x.A0.IsZero() {
-		var negA1, tmp fp.Element
+		var negA1 fp.Element
 		negA1.Neg(&x.A1)
-		if tmp.Cbrt(&negA1) == nil {
+		if z.A1.Cbrt(&negA1) == nil {
 			return nil
 		}
 		z.A0.SetZero()
-		z.A1.Set(&tmp)
 		return z.cbrtVerify(x)
 	}
 

--- a/ecc/secp256r1/internal/fptower/e2.go
+++ b/ecc/secp256r1/internal/fptower/e2.go
@@ -266,86 +266,149 @@ func (z *E2) expBySqrtHelper(x *E2) *E2 {
 // For q ≡ 4 mod 9 and β = −1: v₃(q+1) = 0 ensures every element of T₂ has a
 // unique cube root. Returns z, or nil if x is not a cubic residue in Fp2.
 func (z *E2) Cbrt(x *E2) *E2 {
+	// Use a local variable to avoid aliasing issues when z == x.
+	var y E2
+
 	if x.A1.IsZero() {
-		if z.A0.Cbrt(&x.A0) == nil {
+		if y.A0.Cbrt(&x.A0) == nil {
 			return nil
 		}
-		z.A1.SetZero()
+		y.A1.SetZero()
+		z.Set(&y)
 		return z
 	}
 
 	if x.A0.IsZero() {
 		var negA1 fp.Element
 		negA1.Neg(&x.A1)
-		if z.A1.Cbrt(&negA1) == nil {
+		if y.A1.Cbrt(&negA1) == nil {
 			return nil
 		}
-		z.A0.SetZero()
-		return z.cbrtVerify(x)
+		y.A0.SetZero()
+		return z.cbrtVerify(x, &y)
 	}
 
-	var x0sq, x1sq, norm fp.Element
+	var x0sq, x1sq fp.Element
 	x0sq.Square(&x.A0)
 	x1sq.Square(&x.A1)
+	// N = x₀² + x₁² (norm of x, since β = -1)
+	var norm fp.Element
 	norm.Add(&x0sq, &x1sq)
 
-	m, normInv, ok := cbrtAndNormInverse(&norm)
-	if !ok {
-		return nil
-	}
+	var x0x1 fp.Element
+	x0x1.Mul(&x.A0, &x.A1)
 
-	// τ = 2·(A0² − A1²)/N
-	var tau fp.Element
-	tau.Sub(&x0sq, &x1sq)
-	tau.Double(&tau)
-	tau.Mul(&tau, &normInv)
+	// U = -16·|β|·N·(x₀x₁)²  (|β| = 1 for secp256r1)
+	var U fp.Element
+	U.Square(&x0x1)
+	U.Mul(&U, &norm)
+	U.Double(&U)
+	U.Double(&U)
+	U.Double(&U)
+	U.Double(&U)
+	U.Neg(&U)
 
-	sigma := lucasV(&tau)
+	// w = U³·N; single exponentiation yields cbrt(w), 1/N, 1/U
+	var U2, U3, w fp.Element
+	U2.Square(&U)
+	U3.Mul(&U2, &U)
+	w.Mul(&U3, &norm)
 
-	// z₀ = A0/(m·(σ−1)), z₁ = A1/(m·(σ+1))
-	var one, d0, d1, d0d1, d0d1Inv fp.Element
-	one.SetOne()
-	d0.Sub(&sigma, &one)
-	d0.Mul(&m, &d0)
-	d1.Add(&sigma, &one)
-	d1.Mul(&m, &d1)
+	// t = w^{(q-4)/9}
+	var t fp.Element
+	t.ExpByCbrtHelperQMinus4Div9(w)
 
-	d0d1.Mul(&d0, &d1)
-	d0d1Inv.Inverse(&d0d1)
-
-	z.A0.Mul(&d1, &d0d1Inv).Mul(&z.A0, &x.A0)
-	z.A1.Mul(&d0, &d0d1Inv).Mul(&z.A1, &x.A1)
-
-	return z.cbrtVerify(x)
-}
-
-func (z *E2) cbrtVerify(x *E2) *E2 {
-	var c E2
-	c.Square(z).Mul(&c, z)
-	if !c.Equal(x) {
-		return nil
-	}
-	return z
-}
-
-func cbrtAndNormInverse(norm *fp.Element) (m, normInv fp.Element, ok bool) {
-	var t, t2, t4, t8, t9, n2, n3 fp.Element
-	t.ExpByCbrtHelperQMinus4Div9(*norm)
+	// cbrtW = t⁸·w³ = w^{(8q-5)/9}; wInv = t⁹·w² = w^{q-2} = 1/w
+	var t2, t4, t8, t9, w2, w3 fp.Element
 	t2.Square(&t)
 	t4.Square(&t2)
 	t8.Square(&t4)
 	t9.Mul(&t8, &t)
-	n2.Square(norm)
-	n3.Mul(&n2, norm)
-	m.Mul(&t8, &n3)
-	normInv.Mul(&t9, &n2)
+	w2.Square(&w)
+	w3.Mul(&w2, &w)
+	var cbrtW, wInv fp.Element
+	cbrtW.Mul(&t8, &w3)
+	wInv.Mul(&t9, &w2)
 
+	// Recover: UInv = U²·N·wInv, m = cbrtW·UInv = cbrt(N), normInv = U³·wInv = 1/N
+	var UInv, normInv, m fp.Element
+	UInv.Mul(&U2, &norm)
+	UInv.Mul(&UInv, &wInv)
+	m.Mul(&cbrtW, &UInv)
+	normInv.Mul(&U3, &wInv)
+
+	// Verify m³ = N (for q ≡ 4 mod 9, no ζ-adjustment needed)
 	var c fp.Element
 	c.Square(&m).Mul(&c, &m)
-	if !c.Equal(norm) {
-		return m, normInv, false
+	if !c.Equal(&norm) {
+		return nil
 	}
-	return m, normInv, true
+
+	// DeltaInv = N³·UInv
+	var n2, n3, deltaInv fp.Element
+	n2.Square(&norm)
+	n3.Mul(&n2, &norm)
+	deltaInv.Mul(&n3, &UInv)
+
+	// τ = 2·(x₀² - x₁²)/N  (trace of x^{q-1} on T₂; |β|=1)
+	var halfTau, tau fp.Element
+	halfTau.Sub(&x0sq, &x1sq)
+	halfTau.Mul(&halfTau, &normInv)
+	tau.Double(&halfTau)
+
+	// Te = V_e(τ), Te1 = V_{e+1}(τ) from the Lucas V-ladder
+	Te, Te1 := lucasV(&tau)
+
+	// imY = 2·x₀x₁/N (imaginary part of x^{q-1} on T₂)
+	var imY fp.Element
+	imY.Double(&x0x1)
+	imY.Mul(&imY, &normInv)
+
+	// WA0 = Te1 - halfTau·Te, WA1 = imY·Te
+	var WA0, WA1 fp.Element
+	WA0.Mul(&halfTau, &Te)
+	WA0.Sub(&Te1, &WA0)
+	WA1.Mul(&imY, &Te)
+
+	// k = 2·imY·DeltaInv
+	var sIm, k fp.Element
+	sIm.Double(&imY)
+	k.Mul(&sIm, &deltaInv)
+
+	// gamma = (-WA1·k, WA0·k)  (conjugate of torus element scaled by k; |β|=1)
+	var gamma E2
+	gamma.A0.Mul(&WA1, &k)
+	gamma.A0.Neg(&gamma.A0)
+	gamma.A1.Mul(&WA0, &k)
+
+	// mInv = m²·normInv = 1/m
+	var mInv fp.Element
+	mInv.Square(&m)
+	mInv.Mul(&mInv, &normInv)
+
+	// y = x · conj(gamma) · mInv
+	// y.A0 = (x₀·γ₀ + x₁·γ₁) · mInv  (|β|=1)
+	// y.A1 = (x₁·γ₀ - x₀·γ₁) · mInv
+	var r1, r2 fp.Element
+	r1.Mul(&x.A0, &gamma.A0)
+	r2.Mul(&x.A1, &gamma.A1)
+	y.A0.Add(&r1, &r2)
+	y.A0.Mul(&y.A0, &mInv)
+	r1.Mul(&x.A1, &gamma.A0)
+	r2.Mul(&x.A0, &gamma.A1)
+	y.A1.Sub(&r1, &r2)
+	y.A1.Mul(&y.A1, &mInv)
+
+	return z.cbrtVerify(x, &y)
+}
+
+func (z *E2) cbrtVerify(x *E2, y *E2) *E2 {
+	var c E2
+	c.Square(y).Mul(&c, y)
+	if !c.Equal(x) {
+		return nil
+	}
+	return z.Set(y)
 }
 
 // lucasExponent is e = 3⁻¹ mod (q+1) as little-endian uint64 limbs.
@@ -356,7 +419,9 @@ var lucasExponent = [4]uint64{
 	6148914689804861440,
 }
 
-func lucasV(alpha *fp.Element) fp.Element {
+// lucasV returns (V_e(alpha, 1), V_{e+1}(alpha, 1)) where e = 3⁻¹ mod (q+1),
+// using the Lucas V-sequence with Q=1 and a Montgomery ladder.
+func lucasV(alpha *fp.Element) (fp.Element, fp.Element) {
 	var v0, v1, two, prod fp.Element
 	two.SetUint64(2)
 	v0.Set(alpha)
@@ -373,6 +438,8 @@ func lucasV(alpha *fp.Element) fp.Element {
 			v1.Square(&v1).Sub(&v1, &two)
 		}
 	}
-	v0.Mul(&v0, &v1).Sub(&v0, alpha)
-	return v0
+	// bit 0 is always 1
+	prod.Mul(&v0, &v1).Sub(&prod, alpha)
+	v1.Square(&v1).Sub(&v1, &two)
+	return prod, v1
 }

--- a/ecc/secp256r1/internal/fptower/e2_test.go
+++ b/ecc/secp256r1/internal/fptower/e2_test.go
@@ -1,0 +1,386 @@
+package fp2
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/prop"
+)
+
+const (
+	nbFuzzShort = 10
+	nbFuzz      = 50
+)
+
+func TestE2ReceiverIsOperand(t *testing.T) {
+
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := GenE2()
+	genB := GenE2()
+	genfp := GenFp()
+
+	properties.Property("[P256] Having the receiver as operand (addition) should output the same result", prop.ForAll(
+		func(a, b *E2) bool {
+			var c, d E2
+			d.Set(a)
+			c.Add(a, b)
+			a.Add(a, b)
+			b.Add(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (sub) should output the same result", prop.ForAll(
+		func(a, b *E2) bool {
+			var c, d E2
+			d.Set(a)
+			c.Sub(a, b)
+			a.Sub(a, b)
+			b.Sub(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (mul) should output the same result", prop.ForAll(
+		func(a, b *E2) bool {
+			var c, d E2
+			d.Set(a)
+			c.Mul(a, b)
+			a.Mul(a, b)
+			b.Mul(&d, b)
+			return a.Equal(b) && a.Equal(&c) && b.Equal(&c)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (square) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Square(a)
+			a.Square(a)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (neg) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Neg(a)
+			a.Neg(a)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (double) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Double(a)
+			a.Double(a)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (Inverse) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Inverse(a)
+			a.Inverse(a)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (Conjugate) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Conjugate(a)
+			a.Conjugate(a)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (mul by element) should output the same result", prop.ForAll(
+		func(a *E2, b fp.Element) bool {
+			var c E2
+			c.MulByElement(a, &b)
+			a.MulByElement(a, &b)
+			return a.Equal(&c)
+		},
+		genA,
+		genfp,
+	))
+
+	properties.Property("[P256] Having the receiver as operand (Sqrt) should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b, c, d, s E2
+
+			s.Square(a)
+			a.Set(&s)
+			b.Set(&s)
+
+			a.Sqrt(a)
+			b.Sqrt(&b)
+
+			c.Square(a)
+			d.Square(&b)
+			return c.Equal(&d)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+func TestE2Ops(t *testing.T) {
+
+	t.Parallel()
+	parameters := gopter.DefaultTestParameters()
+	if testing.Short() {
+		parameters.MinSuccessfulTests = nbFuzzShort
+	} else {
+		parameters.MinSuccessfulTests = nbFuzz
+	}
+
+	properties := gopter.NewProperties(parameters)
+
+	genA := GenE2()
+	genB := GenE2()
+	genfp := GenFp()
+
+	properties.Property("[P256] sub & add should leave an element invariant", prop.ForAll(
+		func(a, b *E2) bool {
+			var c E2
+			c.Set(a)
+			c.Add(&c, b).Sub(&c, b)
+			return c.Equal(a)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("[P256] mul & inverse should leave an element invariant", prop.ForAll(
+		func(a, b *E2) bool {
+			var c, d E2
+			d.Inverse(b)
+			c.Set(a)
+			c.Mul(&c, b).Mul(&c, &d)
+			return c.Equal(a)
+		},
+		genA,
+		genB,
+	))
+
+	properties.Property("[P256] inverse twice should leave an element invariant", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Inverse(a).Inverse(&b)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] neg twice should leave an element invariant", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Neg(a).Neg(&b)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] square and mul should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b, c E2
+			b.Mul(a, a)
+			c.Square(a)
+			return b.Equal(&c)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] MulByElement MulByElement inverse should leave an element invariant", prop.ForAll(
+		func(a *E2, b fp.Element) bool {
+			var c E2
+			var d fp.Element
+			d.Inverse(&b)
+			c.MulByElement(a, &b).MulByElement(&c, &d)
+			return c.Equal(a)
+		},
+		genA,
+		genfp,
+	))
+
+	properties.Property("[P256] Double and mul by 2 should output the same result", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			var c fp.Element
+			c.SetUint64(2)
+			b.Double(a)
+			a.MulByElement(a, &c)
+			return a.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] a + pi(a), a-pi(a) should be real", prop.ForAll(
+		func(a *E2) bool {
+			var b, c, d E2
+			var e, f fp.Element
+			b.Conjugate(a)
+			c.Add(a, &b)
+			d.Sub(a, &b)
+			e.Double(&a.A0)
+			f.Double(&a.A1)
+			return c.A1.IsZero() && d.A0.IsZero() && e.Equal(&c.A0) && f.Equal(&d.A1)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] Legendre on square should output 1", prop.ForAll(
+		func(a *E2) bool {
+			var b E2
+			b.Square(a)
+			c := b.Legendre()
+			return c == 1
+		},
+		genA,
+	))
+
+	properties.Property("[P256] square(sqrt) should leave an element invariant", prop.ForAll(
+		func(a *E2) bool {
+			var b, c, d, e E2
+			b.Square(a)
+			c.Sqrt(&b)
+			d.Square(&c)
+			e.Neg(a)
+			return (c.Equal(a) || c.Equal(&e)) && d.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] cube(cbrt) should leave an element invariant", prop.ForAll(
+		func(a *E2) bool {
+			var b, c, d E2
+			b.Square(a).Mul(&b, a) // b = a³
+			result := c.Cbrt(&b)
+			if result == nil {
+				return false
+			}
+			d.Square(&c).Mul(&d, &c) // d = c³
+			return d.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.Property("[P256] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
+		func(a *E2) bool {
+			var b, c E2
+			b.Neg(a)
+			c.A0.Neg(&a.A0)
+			c.A1.Neg(&a.A1)
+			return c.Equal(&b)
+		},
+		genA,
+	))
+
+	properties.TestingRun(t, gopter.ConsoleReporter(false))
+}
+
+// ------------------------------------------------------------
+// benches
+
+func BenchmarkE2Add(b *testing.B) {
+	var a, c E2
+	a.MustSetRandom()
+	c.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		a.Add(&a, &c)
+	}
+}
+
+func BenchmarkE2Sub(b *testing.B) {
+	var a, c E2
+	a.MustSetRandom()
+	c.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		a.Sub(&a, &c)
+	}
+}
+
+func BenchmarkE2Mul(b *testing.B) {
+	var a, c E2
+	a.MustSetRandom()
+	c.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		a.Mul(&a, &c)
+	}
+}
+
+func BenchmarkE2Square(b *testing.B) {
+	var a E2
+	a.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		a.Square(&a)
+	}
+}
+
+func BenchmarkE2Inverse(b *testing.B) {
+	var a E2
+	a.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		a.Inverse(&a)
+	}
+}
+
+func BenchmarkE2Sqrt(b *testing.B) {
+	var a E2
+	a.MustSetRandom()
+	a.Square(&a)
+	b.ResetTimer()
+	for range b.N {
+		a.Sqrt(&a)
+	}
+}
+
+func BenchmarkE2Cbrt(b *testing.B) {
+	var a, c E2
+	a.MustSetRandom()
+	c.Square(&a).Mul(&c, &a)
+	b.ResetTimer()
+	for range b.N {
+		a.Cbrt(&c)
+	}
+}
+
+func BenchmarkE2Exp(b *testing.B) {
+	var x E2
+	x.MustSetRandom()
+	b.ResetTimer()
+	for range b.N {
+		x.Exp(x, fp.Modulus())
+	}
+}

--- a/ecc/secp256r1/internal/fptower/e2_test.go
+++ b/ecc/secp256r1/internal/fptower/e2_test.go
@@ -1,4 +1,4 @@
-package fp2
+package fptower
 
 import (
 	"testing"

--- a/ecc/secp256r1/internal/fptower/generators_test.go
+++ b/ecc/secp256r1/internal/fptower/generators_test.go
@@ -1,4 +1,4 @@
-package fp2
+package fptower
 
 import (
 	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"

--- a/ecc/secp256r1/internal/fptower/generators_test.go
+++ b/ecc/secp256r1/internal/fptower/generators_test.go
@@ -1,0 +1,23 @@
+package fp2
+
+import (
+	"github.com/consensys/gnark-crypto/ecc/secp256r1/fp"
+	"github.com/leanovate/gopter"
+)
+
+func GenFp() gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		var elmt fp.Element
+		elmt.MustSetRandom()
+		return gopter.NewGenResult(elmt, gopter.NoShrinker)
+	}
+}
+
+func GenE2() gopter.Gen {
+	return gopter.CombineGens(
+		GenFp(),
+		GenFp(),
+	).Map(func(values []any) *E2 {
+		return &E2{A0: values[0].(fp.Element), A1: values[1].(fp.Element)}
+	})
+}


### PR DESCRIPTION
# Description

Add Fp2 arithmetic and Cardano cubic solver for secp256r1 (P-256), used by the increment-and-check map-to-curve construction in gnark.

P-256 has a ≠ 0 (y² = x³ − 3x + b), so the y-increment method requires solving the depressed cubic x³ − 3x + c = 0 to recover x from a candidate y. This PR implements:

- **`ecc/secp256r1/internal/fptower/`**: Fp2 = Fp[u]/(u²+1) arithmetic (valid since q ≡ 3 mod 4), including:
  - Basic operations: Add, Sub, Mul (Karatsuba), Square (complex squaring), Inverse, Conjugate, Double, Neg, Exp
  - Sqrt via Scott method with optimized addition chain for x^{(q-3)/4} following https://eprint.iacr.org/2020/1497.pdf.
  - Cbrt via algebraic torus T₂(Fp) with Lucas V-sequence following https://eprint.iacr.org/2026/392.
  - The Fp exponentiation `expByCbrtHelper` for x^{(q-4)/9} reuses `fp.ExpByCbrtHelperQMinus4Div9`

- **`ecc/secp256r1/cardano.go`**: `CardanoRoots(c)` — solves x³ − 3x + c = 0 over Fp handling all three discriminant cases:
  - Δ = 0: repeated roots via direct formula
  - Δ non-square: one real root via Fp2 cube root
  - Δ square: up to 3 roots via Fp cube root and primitive cube root of unity

Companion PR in gnark: gnark uses `CardanoRoots` in the map-to-curve hint for P-256 y-increment witness generation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] `TestCardanoRoots` — verifies roots satisfy x³ − 3x + c = 0 for 256 test values derived from P-256 curve points
- [x] `TestE2ReceiverIsOperand` — aliasing safety for all E2 operations (Add, Sub, Mul, Square, Neg, Double, Inverse, Conjugate, MulByElement, Sqrt)
- [x] `TestE2Ops` — algebraic identity tests via gopter property-based fuzzing (50 random inputs each): add/sub inverse, mul/inverse, double inverse, neg inverse, square==mul, MulByElement inverse, conjugate properties, Legendre on squares, sqrt correctness, cbrt correctness

```bash
go test -v ./ecc/secp256r1/...
go test -v ./ecc/secp256r1/internal/fptower/
```

# How has this been benchmarked?

- [x] E2 operation benchmarks (Add, Sub, Mul, Square, Inverse, Sqrt, Cbrt, Exp), on Macbook Pro M5

```bash
go test -bench=. ./ecc/secp256r1/internal/fptower/
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new finite-field extension arithmetic and a cubic root/solver used in elliptic-curve mapping; subtle math or corner-case bugs could break correctness even though changes are additive and well-tested.
> 
> **Overview**
> Adds a new `ecc/secp256r1/internal/fptower` `Fp2` implementation (`E2`) for P-256, including core arithmetic plus `Sqrt` and `Cbrt` routines needed for higher-level algebra.
> 
> Introduces `CardanoRoots` in `ecc/secp256r1/cardano.go` to compute roots of `x³ − 3x + c = 0` over `Fp`, handling discriminant cases (including an `Fp2` fallback when the discriminant is a non-square) and precomputing a cube root of unity for the 3-root case.
> 
> Adds property-based tests for both `E2` operations and `CardanoRoots` (including checks derived from real curve points), plus micro-benchmarks for `E2` primitives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c33f2d1c64fc21628260cce13d0aac6d5ecb45d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->