### PR TITLE
 perf(koalabear): unrolled FFT kernels and SIS LimbIterator optimization                                                                                                                                                                                                                                                                                 

### DIFF
--- a/ecc/bls12-377/fr/fft/fft.go
+++ b/ecc/bls12-377/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bls12-377/fr/sis/sis.go
+++ b/ecc/bls12-377/fr/sis/sis.go
@@ -161,7 +161,7 @@ func (r *RSis) Hash(v, res []fr.Element) error {
 	k := make([]fr.Element, r.Degree)
 	it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 	for i := range len(r.Ag) {
-		r.InnerHash(it, res, k, r.kz, i, mask)
+		r.InnerHash(&it, res, k, r.kz, i, mask)
 	}
 
 	// reduces mod Xᵈ+1
@@ -257,79 +257,77 @@ func (vi *VectorIterator) Next() (fr.Element, bool) {
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
 type LimbIterator struct {
-	it  ElementIterator
-	buf [fr.Bytes]byte
-
-	j int // position in buf
-
-	next func(buf []byte, pos *int) uint64
+	v        fr.Vector
+	vi       int
+	buf      [fr.Bytes]byte
+	j        int // position in buf
+	limbSize int
 }
 
 // NewLimbIterator creates a new LimbIterator
 // it is an iterator over a stream of field elements
 // The elements are interpreted in little endian.
 // The limb is also in little endian.
-func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
-	var next func(buf []byte, pos *int) uint64
+func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 	switch limbSize {
-	case 1:
-		next = nextUint8
-	case 2:
-		next = nextUint16
+	case 1, 2:
 
-	case 4:
-		next = nextUint32
-	case 8:
-		next = nextUint64
+	case 4, 8:
 	default:
 		panic("unsupported limb size")
 	}
-	return &LimbIterator{
-		it:   it,
-		j:    fr.Bytes,
-		next: next,
+
+	// Keep the hot iterator state concrete and return by value: storing the
+	// ElementIterator interface here makes VectorIterator escape to the heap.
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+
+	return LimbIterator{
+		v:        vi.v,
+		vi:       vi.i,
+		j:        fr.Bytes,
+		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
 func (vr *LimbIterator) NextLimb() (uint64, bool) {
 	if vr.j == fr.Bytes {
-		next, ok := vr.it.Next()
-		if !ok {
+		if vr.vi == len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
-		fr.LittleEndian.PutElement(&vr.buf, next)
+		fr.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
+		vr.vi++
 	}
-	return vr.next(vr.buf[:], &vr.j), true
+
+	var r uint64
+	switch vr.limbSize {
+	case 1:
+		r = uint64(vr.buf[vr.j])
+	case 2:
+		r = uint64(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+
+	case 4:
+		r = uint64(binary.LittleEndian.Uint32(vr.buf[vr.j:]))
+	case 8:
+		r = uint64(binary.LittleEndian.Uint64(vr.buf[vr.j:]))
+	default:
+		panic("unsupported limb size")
+	}
+	vr.j += vr.limbSize
+	return r, true
 }
 
 // Reset resets the iterator with a new ElementIterator.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vr.it = it
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+	vr.v = vi.v
+	vr.vi = vi.i
 	vr.j = fr.Bytes
-}
-
-func nextUint8(buf []byte, pos *int) uint64 {
-	r := uint64(buf[*pos])
-	*pos++
-	return r
-}
-
-func nextUint16(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint16(buf[*pos:]))
-	*pos += 2
-	return r
-}
-
-func nextUint32(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint32(buf[*pos:]))
-	*pos += 4
-	return r
-}
-
-func nextUint64(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint64(buf[*pos:]))
-	*pos += 8
-	return r
 }

--- a/ecc/bls12-381/fr/fft/fft.go
+++ b/ecc/bls12-381/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bls24-315/fr/fft/fft.go
+++ b/ecc/bls24-315/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bls24-317/fr/fft/fft.go
+++ b/ecc/bls24-317/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bn254/fr/fft/fft.go
+++ b/ecc/bn254/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bw6-633/fr/fft/fft.go
+++ b/ecc/bw6-633/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/ecc/bw6-761/fr/fft/fft.go
+++ b/ecc/bw6-761/fr/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []fr.Element, w fr.Element, twiddles [][]fr.Element, twiddlesStart
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []fr.Element, twiddles [][]fr.Element, stage int) {
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		fr.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			fr.Butterfly(&a[offset], &a[offset+2])
+			fr.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+4])
+			fr.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+4])
+				fr.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			fr.Butterfly(&a[o1], &a[o1+8])
+			fr.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				fr.Butterfly(&a[o1+i], &a[o1+i+8])
+				fr.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []fr.Element, twiddles [][]fr.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/field/babybear/fft/fft.go
+++ b/field/babybear/fft/fft.go
@@ -67,11 +67,17 @@ func (domain *Domain) FFT(a []babybear.Element, decimation Decimation, opts ...O
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
-			v1 := babybear.Vector(a[start:end])
-			v2 := babybear.Vector(cosetTable[start:end])
+		if opt.nbTasks <= 1 {
+			v1 := babybear.Vector(a)
+			v2 := babybear.Vector(cosetTable[:len(a)])
 			v1.Mul(v1, v2)
-		}, opt.nbTasks)
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v1 := babybear.Vector(a[start:end])
+				v2 := babybear.Vector(cosetTable[start:end])
+				v1.Mul(v1, v2)
+			}, opt.nbTasks)
+		}
 	}
 
 	twiddles := domain.twiddles
@@ -136,11 +142,16 @@ func (domain *Domain) FFTInverse(a []babybear.Element, decimation Decimation, op
 
 	// scale by CardinalityInv
 	if !opt.coset {
-		// Use vectorized scalar multiply instead of element-by-element loop
-		parallel.Execute(len(a), func(start, end int) {
-			v := babybear.Vector(a[start:end])
+		// Use vectorized scalar multiply instead of element-by-element loop.
+		if opt.nbTasks <= 1 {
+			v := babybear.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
-		}, opt.nbTasks)
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v := babybear.Vector(a[start:end])
+				v.ScalarMul(v, &domain.CardinalityInv)
+			}, opt.nbTasks)
+		}
 		return
 	}
 	var cosetTableInv []babybear.Element
@@ -166,11 +177,17 @@ func (domain *Domain) FFTInverse(a []babybear.Element, decimation Decimation, op
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
-		v := babybear.Vector(a[start:end])
-		v.Mul(v, babybear.Vector(cosetTableInv[start:end]))
+	if opt.nbTasks <= 1 {
+		v := babybear.Vector(a)
+		v.Mul(v, babybear.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
-	}, opt.nbTasks)
+	} else {
+		parallel.Execute(len(a), func(start, end int) {
+			v := babybear.Vector(a[start:end])
+			v.Mul(v, babybear.Vector(cosetTableInv[start:end]))
+			v.ScalarMul(v, &domain.CardinalityInv)
+		}, opt.nbTasks)
+	}
 
 }
 
@@ -183,13 +200,20 @@ func difFFT(a []babybear.Element, w babybear.Element, twiddles [][]babybear.Elem
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 512 {
+		case 512:
 			kerDIFNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDIFNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -269,13 +293,20 @@ func ditFFT(a []babybear.Element, w babybear.Element, twiddles [][]babybear.Elem
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 512 {
+		case 512:
 			kerDITNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDITNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -399,6 +430,139 @@ func kerDITNP_256generic(a []babybear.Element, twiddles [][]babybear.Element, st
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []babybear.Element, twiddles [][]babybear.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			babybear.Butterfly(&a[o1], &a[o1+8])
+			babybear.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				babybear.Butterfly(&a[o1+i], &a[o1+i+8])
+				babybear.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			babybear.Butterfly(&a[o1], &a[o1+4])
+			babybear.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				babybear.Butterfly(&a[o1+i], &a[o1+i+4])
+				babybear.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			babybear.Butterfly(&a[offset], &a[offset+2])
+			babybear.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		babybear.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []babybear.Element, twiddles [][]babybear.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		babybear.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			babybear.Butterfly(&a[offset], &a[offset+2])
+			babybear.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			babybear.Butterfly(&a[o1], &a[o1+4])
+			babybear.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				babybear.Butterfly(&a[o1+i], &a[o1+i+4])
+				babybear.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			babybear.Butterfly(&a[o1], &a[o1+8])
+			babybear.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				babybear.Butterfly(&a[o1+i], &a[o1+i+8])
+				babybear.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []babybear.Element, twiddles [][]babybear.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []babybear.Element, twiddles [][]babybear.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }
 
 // kerDIFNP_512 is an optimized 512-element DIF kernel that avoids recursion overhead

--- a/field/babybear/sis/sis.go
+++ b/field/babybear/sis/sis.go
@@ -187,7 +187,7 @@ func (r *RSis) Hash(v, res []babybear.Element) error {
 		k := make([]babybear.Element, r.Degree)
 		it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 		for i := range len(r.Ag) {
-			r.InnerHash(it, res, k, r.kz, i, mask)
+			r.InnerHash(&it, res, k, r.kz, i, mask)
 		}
 	}
 
@@ -282,63 +282,72 @@ func (vi *VectorIterator) Next() (babybear.Element, bool) {
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
 type LimbIterator struct {
-	it  ElementIterator
-	buf [babybear.Bytes]byte
-
-	j int // position in buf
-
-	next func(buf []byte, pos *int) uint32
+	v        babybear.Vector
+	vi       int
+	buf      [babybear.Bytes]byte
+	j        int // position in buf
+	limbSize int
 }
 
 // NewLimbIterator creates a new LimbIterator
 // it is an iterator over a stream of field elements
 // The elements are interpreted in little endian.
 // The limb is also in little endian.
-func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
-	var next func(buf []byte, pos *int) uint32
+func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 	switch limbSize {
-	case 1:
-		next = nextUint8
-	case 2:
-		next = nextUint16
+	case 1, 2:
 
 	default:
 		panic("unsupported limb size")
 	}
-	return &LimbIterator{
-		it:   it,
-		j:    babybear.Bytes,
-		next: next,
+
+	// Keep the hot iterator state concrete and return by value: storing the
+	// ElementIterator interface here makes VectorIterator escape to the heap.
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+
+	return LimbIterator{
+		v:        vi.v,
+		vi:       vi.i,
+		j:        babybear.Bytes,
+		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
 func (vr *LimbIterator) NextLimb() (uint32, bool) {
 	if vr.j == babybear.Bytes {
-		next, ok := vr.it.Next()
-		if !ok {
+		if vr.vi == len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
-		babybear.LittleEndian.PutElement(&vr.buf, next)
+		babybear.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
+		vr.vi++
 	}
-	return vr.next(vr.buf[:], &vr.j), true
+
+	var r uint32
+	switch vr.limbSize {
+	case 1:
+		r = uint32(vr.buf[vr.j])
+	case 2:
+		r = uint32(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+
+	default:
+		panic("unsupported limb size")
+	}
+	vr.j += vr.limbSize
+	return r, true
 }
 
 // Reset resets the iterator with a new ElementIterator.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vr.it = it
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+	vr.v = vi.v
+	vr.vi = vi.i
 	vr.j = babybear.Bytes
-}
-
-func nextUint8(buf []byte, pos *int) uint32 {
-	r := uint32(buf[*pos])
-	*pos++
-	return r
-}
-
-func nextUint16(buf []byte, pos *int) uint32 {
-	r := uint32(binary.LittleEndian.Uint16(buf[*pos:]))
-	*pos += 2
-	return r
 }

--- a/field/goldilocks/fft/fft.go
+++ b/field/goldilocks/fft/fft.go
@@ -202,10 +202,17 @@ func difFFT(a []goldilocks.Element, w goldilocks.Element, twiddles [][]goldilock
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDIFNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,10 +298,17 @@ func ditFFT(a []goldilocks.Element, w goldilocks.Element, twiddles [][]goldilock
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<5 { // nolint QF1003
+		switch n {
+		case 64:
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 128:
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		case 1 << 5:
 			kerDITNP_32(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -460,4 +474,137 @@ func kerDITNP_256generic(a []goldilocks.Element, twiddles [][]goldilocks.Element
 		innerDITWithTwiddlesGeneric(a[offset:offset+128], twiddles[stage+1], 0, 64, 64)
 	}
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []goldilocks.Element, twiddles [][]goldilocks.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			goldilocks.Butterfly(&a[o1], &a[o1+8])
+			goldilocks.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				goldilocks.Butterfly(&a[o1+i], &a[o1+i+8])
+				goldilocks.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			goldilocks.Butterfly(&a[o1], &a[o1+4])
+			goldilocks.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				goldilocks.Butterfly(&a[o1+i], &a[o1+i+4])
+				goldilocks.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			goldilocks.Butterfly(&a[offset], &a[offset+2])
+			goldilocks.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		goldilocks.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []goldilocks.Element, twiddles [][]goldilocks.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		goldilocks.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			goldilocks.Butterfly(&a[offset], &a[offset+2])
+			goldilocks.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			goldilocks.Butterfly(&a[o1], &a[o1+4])
+			goldilocks.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				goldilocks.Butterfly(&a[o1+i], &a[o1+i+4])
+				goldilocks.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			goldilocks.Butterfly(&a[o1], &a[o1+8])
+			goldilocks.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				goldilocks.Butterfly(&a[o1+i], &a[o1+i+8])
+				goldilocks.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []goldilocks.Element, twiddles [][]goldilocks.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []goldilocks.Element, twiddles [][]goldilocks.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/field/goldilocks/sis/sis.go
+++ b/field/goldilocks/sis/sis.go
@@ -144,7 +144,7 @@ func (r *RSis) Hash(v, res []goldilocks.Element) error {
 	k := make([]goldilocks.Element, r.Degree)
 	it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 	for i := range len(r.Ag) {
-		r.InnerHash(it, res, k, r.kz, i, mask)
+		r.InnerHash(&it, res, k, r.kz, i, mask)
 	}
 
 	// reduces mod Xᵈ+1
@@ -238,79 +238,77 @@ func (vi *VectorIterator) Next() (goldilocks.Element, bool) {
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
 type LimbIterator struct {
-	it  ElementIterator
-	buf [goldilocks.Bytes]byte
-
-	j int // position in buf
-
-	next func(buf []byte, pos *int) uint64
+	v        goldilocks.Vector
+	vi       int
+	buf      [goldilocks.Bytes]byte
+	j        int // position in buf
+	limbSize int
 }
 
 // NewLimbIterator creates a new LimbIterator
 // it is an iterator over a stream of field elements
 // The elements are interpreted in little endian.
 // The limb is also in little endian.
-func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
-	var next func(buf []byte, pos *int) uint64
+func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 	switch limbSize {
-	case 1:
-		next = nextUint8
-	case 2:
-		next = nextUint16
+	case 1, 2:
 
-	case 4:
-		next = nextUint32
-	case 8:
-		next = nextUint64
+	case 4, 8:
 	default:
 		panic("unsupported limb size")
 	}
-	return &LimbIterator{
-		it:   it,
-		j:    goldilocks.Bytes,
-		next: next,
+
+	// Keep the hot iterator state concrete and return by value: storing the
+	// ElementIterator interface here makes VectorIterator escape to the heap.
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+
+	return LimbIterator{
+		v:        vi.v,
+		vi:       vi.i,
+		j:        goldilocks.Bytes,
+		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
 func (vr *LimbIterator) NextLimb() (uint64, bool) {
 	if vr.j == goldilocks.Bytes {
-		next, ok := vr.it.Next()
-		if !ok {
+		if vr.vi == len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
-		goldilocks.LittleEndian.PutElement(&vr.buf, next)
+		goldilocks.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
+		vr.vi++
 	}
-	return vr.next(vr.buf[:], &vr.j), true
+
+	var r uint64
+	switch vr.limbSize {
+	case 1:
+		r = uint64(vr.buf[vr.j])
+	case 2:
+		r = uint64(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+
+	case 4:
+		r = uint64(binary.LittleEndian.Uint32(vr.buf[vr.j:]))
+	case 8:
+		r = uint64(binary.LittleEndian.Uint64(vr.buf[vr.j:]))
+	default:
+		panic("unsupported limb size")
+	}
+	vr.j += vr.limbSize
+	return r, true
 }
 
 // Reset resets the iterator with a new ElementIterator.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vr.it = it
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+	vr.v = vi.v
+	vr.vi = vi.i
 	vr.j = goldilocks.Bytes
-}
-
-func nextUint8(buf []byte, pos *int) uint64 {
-	r := uint64(buf[*pos])
-	*pos++
-	return r
-}
-
-func nextUint16(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint16(buf[*pos:]))
-	*pos += 2
-	return r
-}
-
-func nextUint32(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint32(buf[*pos:]))
-	*pos += 4
-	return r
-}
-
-func nextUint64(buf []byte, pos *int) uint64 {
-	r := uint64(binary.LittleEndian.Uint64(buf[*pos:]))
-	*pos += 8
-	return r
 }

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -489,28 +489,39 @@ func kerDIFNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage in
 	// Stages 2-4 inlined: avoids innerDIFWithTwiddlesGeneric function call overhead,
 	// Vector type conversion, and Vector.Mul dispatch (AVX-512 check on <16 elements).
 	{
-		// Stage 2: m=8
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
 		tw := twiddles[stage+2]
-		for offset := 0; offset < 64; offset += 16 {
-			koalabear.Butterfly(&a[offset], &a[offset+8])
+		// Process 2 blocks at a time (0,16 and 16,32 then 32,48 and 48,64)
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			// All butterflies first (both blocks)
+			koalabear.Butterfly(&a[o1], &a[o1+8])
+			koalabear.Butterfly(&a[o2], &a[o2+8])
 			for i := 1; i < 8; i++ {
-				koalabear.Butterfly(&a[offset+i], &a[offset+i+8])
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
 			}
+			// Interleaved twiddle multiplies — two independent chains for ILP
 			for i := 1; i < 8; i++ {
-				a[offset+i+8].Mul(&a[offset+i+8], &tw[i])
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
 			}
 		}
 	}
 	{
-		// Stage 3: m=4
+		// Stage 3: m=4, 2x unrolled
 		tw := twiddles[stage+3]
-		for offset := 0; offset < 64; offset += 8 {
-			koalabear.Butterfly(&a[offset], &a[offset+4])
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			koalabear.Butterfly(&a[o1], &a[o1+4])
+			koalabear.Butterfly(&a[o2], &a[o2+4])
 			for i := 1; i < 4; i++ {
-				koalabear.Butterfly(&a[offset+i], &a[offset+i+4])
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
 			}
 			for i := 1; i < 4; i++ {
-				a[offset+i+4].Mul(&a[offset+i+4], &tw[i])
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
 			}
 		}
 	}
@@ -546,28 +557,36 @@ func kerDITNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage in
 		}
 	}
 	{
-		// Stage 3: m=4
+		// Stage 3: m=4, 2x unrolled (DIT: multiply first, then butterfly)
 		tw := twiddles[stage+3]
-		for offset := 0; offset < 64; offset += 8 {
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
 			for i := 1; i < 4; i++ {
-				a[offset+i+4].Mul(&a[offset+i+4], &tw[i])
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
 			}
-			koalabear.Butterfly(&a[offset], &a[offset+4])
+			koalabear.Butterfly(&a[o1], &a[o1+4])
+			koalabear.Butterfly(&a[o2], &a[o2+4])
 			for i := 1; i < 4; i++ {
-				koalabear.Butterfly(&a[offset+i], &a[offset+i+4])
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
 			}
 		}
 	}
 	{
-		// Stage 2: m=8
+		// Stage 2: m=8, 2x unrolled (DIT: multiply first, then butterfly)
 		tw := twiddles[stage+2]
-		for offset := 0; offset < 64; offset += 16 {
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
 			for i := 1; i < 8; i++ {
-				a[offset+i+8].Mul(&a[offset+i+8], &tw[i])
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
 			}
-			koalabear.Butterfly(&a[offset], &a[offset+8])
+			koalabear.Butterfly(&a[o1], &a[o1+8])
+			koalabear.Butterfly(&a[o2], &a[o2+8])
 			for i := 1; i < 8; i++ {
-				koalabear.Butterfly(&a[offset+i], &a[offset+i+8])
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
 			}
 		}
 	}

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -470,17 +470,42 @@ func kerDIFNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage in
 	for offset := 0; offset < 64; offset += 32 {
 		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
 	}
-	// Stage 2: m=8 (generic)
-	for offset := 0; offset < 64; offset += 16 {
-		innerDIFWithTwiddlesGeneric(a[offset:offset+16], twiddles[stage+2], 0, 8, 8)
+	// Stages 2-4 inlined: avoids innerDIFWithTwiddlesGeneric function call overhead,
+	// Vector type conversion, and Vector.Mul dispatch (AVX-512 check on <16 elements).
+	{
+		// Stage 2: m=8
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 16 {
+			koalabear.Butterfly(&a[offset], &a[offset+8])
+			for i := 1; i < 8; i++ {
+				koalabear.Butterfly(&a[offset+i], &a[offset+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[offset+i+8].Mul(&a[offset+i+8], &tw[i])
+			}
+		}
 	}
-	// Stage 3: m=4 (generic)
-	for offset := 0; offset < 64; offset += 8 {
-		innerDIFWithTwiddlesGeneric(a[offset:offset+8], twiddles[stage+3], 0, 4, 4)
+	{
+		// Stage 3: m=4
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 8 {
+			koalabear.Butterfly(&a[offset], &a[offset+4])
+			for i := 1; i < 4; i++ {
+				koalabear.Butterfly(&a[offset+i], &a[offset+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[offset+i+4].Mul(&a[offset+i+4], &tw[i])
+			}
+		}
 	}
-	// Stage 4: m=2 (generic)
-	for offset := 0; offset < 64; offset += 4 {
-		innerDIFWithTwiddlesGeneric(a[offset:offset+4], twiddles[stage+4], 0, 2, 2)
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply)
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			koalabear.Butterfly(&a[offset], &a[offset+2])
+			koalabear.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
 	}
 	// Stage 5: m=1 (butterfly only)
 	for offset := 0; offset < 64; offset += 2 {
@@ -494,17 +519,41 @@ func kerDITNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage in
 	for offset := 0; offset < 64; offset += 2 {
 		koalabear.Butterfly(&a[offset], &a[offset+1])
 	}
-	// Stage 4: m=2 (generic)
-	for offset := 0; offset < 64; offset += 4 {
-		innerDITWithTwiddlesGeneric(a[offset:offset+4], twiddles[stage+4], 0, 2, 2)
+	// Stages 4-2 inlined (DIT: multiply first, then butterfly)
+	{
+		// Stage 4: m=2 (DIT: multiply first, then all butterflies)
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			koalabear.Butterfly(&a[offset], &a[offset+2])
+			koalabear.Butterfly(&a[offset+1], &a[offset+3])
+		}
 	}
-	// Stage 3: m=4 (generic)
-	for offset := 0; offset < 64; offset += 8 {
-		innerDITWithTwiddlesGeneric(a[offset:offset+8], twiddles[stage+3], 0, 4, 4)
+	{
+		// Stage 3: m=4
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 8 {
+			for i := 1; i < 4; i++ {
+				a[offset+i+4].Mul(&a[offset+i+4], &tw[i])
+			}
+			koalabear.Butterfly(&a[offset], &a[offset+4])
+			for i := 1; i < 4; i++ {
+				koalabear.Butterfly(&a[offset+i], &a[offset+i+4])
+			}
+		}
 	}
-	// Stage 2: m=8 (generic)
-	for offset := 0; offset < 64; offset += 16 {
-		innerDITWithTwiddlesGeneric(a[offset:offset+16], twiddles[stage+2], 0, 8, 8)
+	{
+		// Stage 2: m=8
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 16 {
+			for i := 1; i < 8; i++ {
+				a[offset+i+8].Mul(&a[offset+i+8], &tw[i])
+			}
+			koalabear.Butterfly(&a[offset], &a[offset+8])
+			for i := 1; i < 8; i++ {
+				koalabear.Butterfly(&a[offset+i], &a[offset+i+8])
+			}
+		}
 	}
 	// Stage 1: m=16 (AVX-512 eligible)
 	for offset := 0; offset < 64; offset += 32 {

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -183,7 +183,13 @@ func difFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 { // nolint QF1003
+		if n == 64 {
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 128 {
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1<<8 { // nolint QF1003
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		} else if n == 512 {
@@ -269,7 +275,13 @@ func ditFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 1<<8 { // nolint QF1003
+		if n == 64 {
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 128 {
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 1<<8 { // nolint QF1003
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
 		} else if n == 512 {
@@ -446,4 +458,76 @@ func kerDITNP_1024(a []koalabear.Element, twiddles [][]koalabear.Element, stage 
 	innerDITWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
 	// Final stage: butterfly with m=512
 	innerDITWithTwiddles(a, twiddles[stage], 0, 512, 512)
+}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that eliminates recursion
+// overhead (~63 function calls per FFT). For SIS with logTwoDegree=6, this
+// kernel is called 32768 times per benchmark iteration.
+func kerDIFNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: m=32 (AVX-512 eligible)
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16 (AVX-512 eligible)
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 2: m=8 (generic)
+	for offset := 0; offset < 64; offset += 16 {
+		innerDIFWithTwiddlesGeneric(a[offset:offset+16], twiddles[stage+2], 0, 8, 8)
+	}
+	// Stage 3: m=4 (generic)
+	for offset := 0; offset < 64; offset += 8 {
+		innerDIFWithTwiddlesGeneric(a[offset:offset+8], twiddles[stage+3], 0, 4, 4)
+	}
+	// Stage 4: m=2 (generic)
+	for offset := 0; offset < 64; offset += 4 {
+		innerDIFWithTwiddlesGeneric(a[offset:offset+4], twiddles[stage+4], 0, 2, 2)
+	}
+	// Stage 5: m=1 (butterfly only)
+	for offset := 0; offset < 64; offset += 2 {
+		koalabear.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64 (stages in reverse order).
+func kerDITNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 5: m=1 (butterfly only)
+	for offset := 0; offset < 64; offset += 2 {
+		koalabear.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stage 4: m=2 (generic)
+	for offset := 0; offset < 64; offset += 4 {
+		innerDITWithTwiddlesGeneric(a[offset:offset+4], twiddles[stage+4], 0, 2, 2)
+	}
+	// Stage 3: m=4 (generic)
+	for offset := 0; offset < 64; offset += 8 {
+		innerDITWithTwiddlesGeneric(a[offset:offset+8], twiddles[stage+3], 0, 4, 4)
+	}
+	// Stage 2: m=8 (generic)
+	for offset := 0; offset < 64; offset += 16 {
+		innerDITWithTwiddlesGeneric(a[offset:offset+16], twiddles[stage+2], 0, 8, 8)
+	}
+	// Stage 1: m=16 (AVX-512 eligible)
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32 (AVX-512 eligible)
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: m=64 (AVX-512)
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	// Stage 1: two halves via 64-element kernel
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Two halves via 64-element kernel first (DIT order)
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64 (AVX-512)
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -67,11 +67,17 @@ func (domain *Domain) FFT(a []koalabear.Element, decimation Decimation, opts ...
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
-			v1 := koalabear.Vector(a[start:end])
-			v2 := koalabear.Vector(cosetTable[start:end])
-			v1.Mul(v1, v2)
-		}, opt.nbTasks)
+		// Avoid parallel.Execute closure overhead for single-threaded case.
+		if opt.nbTasks <= 1 {
+			v := koalabear.Vector(a)
+			v.Mul(v, koalabear.Vector(cosetTable[:len(a)]))
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v1 := koalabear.Vector(a[start:end])
+				v2 := koalabear.Vector(cosetTable[start:end])
+				v1.Mul(v1, v2)
+			}, opt.nbTasks)
+		}
 	}
 
 	twiddles := domain.twiddles
@@ -136,11 +142,15 @@ func (domain *Domain) FFTInverse(a []koalabear.Element, decimation Decimation, o
 
 	// scale by CardinalityInv
 	if !opt.coset {
-		// Use vectorized scalar multiply instead of element-by-element loop
-		parallel.Execute(len(a), func(start, end int) {
-			v := koalabear.Vector(a[start:end])
+		if opt.nbTasks <= 1 {
+			v := koalabear.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
-		}, opt.nbTasks)
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v := koalabear.Vector(a[start:end])
+				v.ScalarMul(v, &domain.CardinalityInv)
+			}, opt.nbTasks)
+		}
 		return
 	}
 	var cosetTableInv []koalabear.Element
@@ -166,11 +176,17 @@ func (domain *Domain) FFTInverse(a []koalabear.Element, decimation Decimation, o
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
-		v := koalabear.Vector(a[start:end])
-		v.Mul(v, koalabear.Vector(cosetTableInv[start:end]))
+	if opt.nbTasks <= 1 {
+		v := koalabear.Vector(a)
+		v.Mul(v, koalabear.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
-	}, opt.nbTasks)
+	} else {
+		parallel.Execute(len(a), func(start, end int) {
+			v := koalabear.Vector(a[start:end])
+			v.Mul(v, koalabear.Vector(cosetTableInv[start:end]))
+			v.ScalarMul(v, &domain.CardinalityInv)
+		}, opt.nbTasks)
+	}
 
 }
 

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -67,10 +67,10 @@ func (domain *Domain) FFT(a []koalabear.Element, decimation Decimation, opts ...
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		// Avoid parallel.Execute closure overhead for single-threaded case.
 		if opt.nbTasks <= 1 {
-			v := koalabear.Vector(a)
-			v.Mul(v, koalabear.Vector(cosetTable[:len(a)]))
+			v1 := koalabear.Vector(a)
+			v2 := koalabear.Vector(cosetTable[:len(a)])
+			v1.Mul(v1, v2)
 		} else {
 			parallel.Execute(len(a), func(start, end int) {
 				v1 := koalabear.Vector(a[start:end])
@@ -142,6 +142,7 @@ func (domain *Domain) FFTInverse(a []koalabear.Element, decimation Decimation, o
 
 	// scale by CardinalityInv
 	if !opt.coset {
+		// Use vectorized scalar multiply instead of element-by-element loop.
 		if opt.nbTasks <= 1 {
 			v := koalabear.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
@@ -199,19 +200,20 @@ func difFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 64 {
+		switch n {
+		case 64:
 			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 128 {
+		case 128:
 			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDIFNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 512 {
+		case 512:
 			kerDIFNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDIFNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -291,19 +293,20 @@ func ditFFT(a []koalabear.Element, w koalabear.Element, twiddles [][]koalabear.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 64 {
+		switch n {
+		case 64:
 			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 128 {
+		case 128:
 			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1<<8 { // nolint QF1003
+		case 1 << 8:
 			kerDITNP_256(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 512 {
+		case 512:
 			kerDITNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDITNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
 		}
@@ -429,6 +432,139 @@ func kerDITNP_256generic(a []koalabear.Element, twiddles [][]koalabear.Element, 
 	innerDITWithTwiddlesGeneric(a[:256], twiddles[stage+0], 0, 128, 128)
 }
 
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			koalabear.Butterfly(&a[o1], &a[o1+8])
+			koalabear.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			koalabear.Butterfly(&a[o1], &a[o1+4])
+			koalabear.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			koalabear.Butterfly(&a[offset], &a[offset+2])
+			koalabear.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		koalabear.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		koalabear.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			koalabear.Butterfly(&a[offset], &a[offset+2])
+			koalabear.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			koalabear.Butterfly(&a[o1], &a[o1+4])
+			koalabear.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			koalabear.Butterfly(&a[o1], &a[o1+8])
+			koalabear.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
+				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+}
+
 // kerDIFNP_512 is an optimized 512-element DIF kernel that avoids recursion overhead
 // by directly processing the outer butterfly layer and then calling the 256-element kernel.
 func kerDIFNP_512(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
@@ -474,144 +610,4 @@ func kerDITNP_1024(a []koalabear.Element, twiddles [][]koalabear.Element, stage 
 	innerDITWithTwiddles(a[512:], twiddles[stage+1], 0, 256, 256)
 	// Final stage: butterfly with m=512
 	innerDITWithTwiddles(a, twiddles[stage], 0, 512, 512)
-}
-
-// kerDIFNP_64 is an unrolled 64-element DIF kernel that eliminates recursion
-// overhead (~63 function calls per FFT). For SIS with logTwoDegree=6, this
-// kernel is called 32768 times per benchmark iteration.
-func kerDIFNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
-	// Stage 0: m=32 (AVX-512 eligible)
-	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
-	// Stage 1: m=16 (AVX-512 eligible)
-	for offset := 0; offset < 64; offset += 32 {
-		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
-	}
-	// Stages 2-4 inlined: avoids innerDIFWithTwiddlesGeneric function call overhead,
-	// Vector type conversion, and Vector.Mul dispatch (AVX-512 check on <16 elements).
-	{
-		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
-		tw := twiddles[stage+2]
-		// Process 2 blocks at a time (0,16 and 16,32 then 32,48 and 48,64)
-		for offset := 0; offset < 64; offset += 32 {
-			o1, o2 := offset, offset+16
-			// All butterflies first (both blocks)
-			koalabear.Butterfly(&a[o1], &a[o1+8])
-			koalabear.Butterfly(&a[o2], &a[o2+8])
-			for i := 1; i < 8; i++ {
-				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
-				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
-			}
-			// Interleaved twiddle multiplies — two independent chains for ILP
-			for i := 1; i < 8; i++ {
-				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
-				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
-			}
-		}
-	}
-	{
-		// Stage 3: m=4, 2x unrolled
-		tw := twiddles[stage+3]
-		for offset := 0; offset < 64; offset += 16 {
-			o1, o2 := offset, offset+8
-			koalabear.Butterfly(&a[o1], &a[o1+4])
-			koalabear.Butterfly(&a[o2], &a[o2+4])
-			for i := 1; i < 4; i++ {
-				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
-				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
-			}
-			for i := 1; i < 4; i++ {
-				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
-				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
-			}
-		}
-	}
-	{
-		// Stage 4: m=2 (DIF: all butterflies first, then multiply)
-		tw := twiddles[stage+4]
-		for offset := 0; offset < 64; offset += 4 {
-			koalabear.Butterfly(&a[offset], &a[offset+2])
-			koalabear.Butterfly(&a[offset+1], &a[offset+3])
-			a[offset+3].Mul(&a[offset+3], &tw[1])
-		}
-	}
-	// Stage 5: m=1 (butterfly only)
-	for offset := 0; offset < 64; offset += 2 {
-		koalabear.Butterfly(&a[offset], &a[offset+1])
-	}
-}
-
-// kerDITNP_64 is the DIT counterpart of kerDIFNP_64 (stages in reverse order).
-func kerDITNP_64(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
-	// Stage 5: m=1 (butterfly only)
-	for offset := 0; offset < 64; offset += 2 {
-		koalabear.Butterfly(&a[offset], &a[offset+1])
-	}
-	// Stages 4-2 inlined (DIT: multiply first, then butterfly)
-	{
-		// Stage 4: m=2 (DIT: multiply first, then all butterflies)
-		tw := twiddles[stage+4]
-		for offset := 0; offset < 64; offset += 4 {
-			a[offset+3].Mul(&a[offset+3], &tw[1])
-			koalabear.Butterfly(&a[offset], &a[offset+2])
-			koalabear.Butterfly(&a[offset+1], &a[offset+3])
-		}
-	}
-	{
-		// Stage 3: m=4, 2x unrolled (DIT: multiply first, then butterfly)
-		tw := twiddles[stage+3]
-		for offset := 0; offset < 64; offset += 16 {
-			o1, o2 := offset, offset+8
-			for i := 1; i < 4; i++ {
-				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
-				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
-			}
-			koalabear.Butterfly(&a[o1], &a[o1+4])
-			koalabear.Butterfly(&a[o2], &a[o2+4])
-			for i := 1; i < 4; i++ {
-				koalabear.Butterfly(&a[o1+i], &a[o1+i+4])
-				koalabear.Butterfly(&a[o2+i], &a[o2+i+4])
-			}
-		}
-	}
-	{
-		// Stage 2: m=8, 2x unrolled (DIT: multiply first, then butterfly)
-		tw := twiddles[stage+2]
-		for offset := 0; offset < 64; offset += 32 {
-			o1, o2 := offset, offset+16
-			for i := 1; i < 8; i++ {
-				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
-				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
-			}
-			koalabear.Butterfly(&a[o1], &a[o1+8])
-			koalabear.Butterfly(&a[o2], &a[o2+8])
-			for i := 1; i < 8; i++ {
-				koalabear.Butterfly(&a[o1+i], &a[o1+i+8])
-				koalabear.Butterfly(&a[o2+i], &a[o2+i+8])
-			}
-		}
-	}
-	// Stage 1: m=16 (AVX-512 eligible)
-	for offset := 0; offset < 64; offset += 32 {
-		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
-	}
-	// Stage 0: m=32 (AVX-512 eligible)
-	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
-}
-
-// kerDIFNP_128 is an unrolled 128-element DIF kernel.
-func kerDIFNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
-	// Stage 0: m=64 (AVX-512)
-	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
-	// Stage 1: two halves via 64-element kernel
-	kerDIFNP_64(a[:64], twiddles, stage+1)
-	kerDIFNP_64(a[64:], twiddles, stage+1)
-}
-
-// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
-func kerDITNP_128(a []koalabear.Element, twiddles [][]koalabear.Element, stage int) {
-	// Two halves via 64-element kernel first (DIT order)
-	kerDITNP_64(a[:64], twiddles, stage+1)
-	kerDITNP_64(a[64:], twiddles, stage+1)
-	// Final stage: m=64 (AVX-512)
-	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
 }

--- a/field/koalabear/sis/sis.go
+++ b/field/koalabear/sis/sis.go
@@ -187,7 +187,7 @@ func (r *RSis) Hash(v, res []koalabear.Element) error {
 		k := make([]koalabear.Element, r.Degree)
 		it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 		for i := range len(r.Ag) {
-			r.InnerHash(it, res, k, r.kz, i, mask)
+			r.InnerHash(&it, res, k, r.kz, i, mask)
 		}
 	}
 
@@ -281,39 +281,44 @@ func (vi *VectorIterator) Next() (koalabear.Element, bool) {
 }
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
+// Embeds a direct vector reference instead of an ElementIterator interface
+// to avoid heap-escaping the VectorIterator through the interface.
 type LimbIterator struct {
-	it       ElementIterator
+	v        koalabear.Vector        // direct slice — no interface dispatch, no heap escape
+	vi       int                     // position in v
 	buf      [koalabear.Bytes]byte
 	j        int // position in buf
 	limbSize int // 1 or 2 bytes per limb
 }
 
-// NewLimbIterator creates a new LimbIterator
-// it is an iterator over a stream of field elements
-// The elements are interpreted in little endian.
-// The limb is also in little endian.
-func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
+// NewLimbIterator creates a new LimbIterator from a vector and limb size.
+// Returns by value to avoid heap allocation.
+func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 	if limbSize != 1 && limbSize != 2 {
 		panic("unsupported limb size")
 	}
-	return &LimbIterator{
-		it:       it,
+	// Extract the vector from the interface to embed directly.
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("LimbIterator requires *VectorIterator")
+	}
+	return LimbIterator{
+		v:        vi.v,
+		vi:       vi.i,
 		j:        koalabear.Bytes,
 		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
-// Uses a branch on limbSize instead of an indirect function pointer call
-// to avoid the ~3-5 cycle overhead per indirect call.
 func (vr *LimbIterator) NextLimb() (uint32, bool) {
 	if vr.j >= koalabear.Bytes {
-		next, ok := vr.it.Next()
-		if !ok {
+		if vr.vi >= len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
-		koalabear.LittleEndian.PutElement(&vr.buf, next)
+		koalabear.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
+		vr.vi++
 	}
 	if vr.limbSize == 2 {
 		r := uint32(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
@@ -325,9 +330,11 @@ func (vr *LimbIterator) NextLimb() (uint32, bool) {
 	return r, true
 }
 
-// Reset resets the iterator with a new ElementIterator.
+// Reset resets the iterator with a new vector.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vr.it = it
+	vi := it.(*VectorIterator)
+	vr.v = vi.v
+	vr.vi = vi.i
 	vr.j = koalabear.Bytes
 }
 

--- a/field/koalabear/sis/sis.go
+++ b/field/koalabear/sis/sis.go
@@ -337,15 +337,3 @@ func (vr *LimbIterator) Reset(it ElementIterator) {
 	vr.vi = vi.i
 	vr.j = koalabear.Bytes
 }
-
-func nextUint8(buf []byte, pos *int) uint32 {
-	r := uint32(buf[*pos])
-	*pos++
-	return r
-}
-
-func nextUint16(buf []byte, pos *int) uint32 {
-	r := uint32(binary.LittleEndian.Uint16(buf[*pos:]))
-	*pos += 2
-	return r
-}

--- a/field/koalabear/sis/sis.go
+++ b/field/koalabear/sis/sis.go
@@ -282,12 +282,10 @@ func (vi *VectorIterator) Next() (koalabear.Element, bool) {
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
 type LimbIterator struct {
-	it  ElementIterator
-	buf [koalabear.Bytes]byte
-
-	j int // position in buf
-
-	next func(buf []byte, pos *int) uint32
+	it       ElementIterator
+	buf      [koalabear.Bytes]byte
+	j        int // position in buf
+	limbSize int // 1 or 2 bytes per limb
 }
 
 // NewLimbIterator creates a new LimbIterator
@@ -295,26 +293,21 @@ type LimbIterator struct {
 // The elements are interpreted in little endian.
 // The limb is also in little endian.
 func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
-	var next func(buf []byte, pos *int) uint32
-	switch limbSize {
-	case 1:
-		next = nextUint8
-	case 2:
-		next = nextUint16
-
-	default:
+	if limbSize != 1 && limbSize != 2 {
 		panic("unsupported limb size")
 	}
 	return &LimbIterator{
-		it:   it,
-		j:    koalabear.Bytes,
-		next: next,
+		it:       it,
+		j:        koalabear.Bytes,
+		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
+// Uses a branch on limbSize instead of an indirect function pointer call
+// to avoid the ~3-5 cycle overhead per indirect call.
 func (vr *LimbIterator) NextLimb() (uint32, bool) {
-	if vr.j == koalabear.Bytes {
+	if vr.j >= koalabear.Bytes {
 		next, ok := vr.it.Next()
 		if !ok {
 			return 0, false
@@ -322,7 +315,14 @@ func (vr *LimbIterator) NextLimb() (uint32, bool) {
 		vr.j = 0
 		koalabear.LittleEndian.PutElement(&vr.buf, next)
 	}
-	return vr.next(vr.buf[:], &vr.j), true
+	if vr.limbSize == 2 {
+		r := uint32(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+		vr.j += 2
+		return r, true
+	}
+	r := uint32(vr.buf[vr.j])
+	vr.j++
+	return r, true
 }
 
 // Reset resets the iterator with a new ElementIterator.

--- a/field/koalabear/sis/sis.go
+++ b/field/koalabear/sis/sis.go
@@ -281,27 +281,33 @@ func (vi *VectorIterator) Next() (koalabear.Element, bool) {
 }
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
-// Embeds a direct vector reference instead of an ElementIterator interface
-// to avoid heap-escaping the VectorIterator through the interface.
 type LimbIterator struct {
-	v        koalabear.Vector        // direct slice — no interface dispatch, no heap escape
-	vi       int                     // position in v
+	v        koalabear.Vector
+	vi       int
 	buf      [koalabear.Bytes]byte
 	j        int // position in buf
-	limbSize int // 1 or 2 bytes per limb
+	limbSize int
 }
 
-// NewLimbIterator creates a new LimbIterator from a vector and limb size.
-// Returns by value to avoid heap allocation.
+// NewLimbIterator creates a new LimbIterator
+// it is an iterator over a stream of field elements
+// The elements are interpreted in little endian.
+// The limb is also in little endian.
 func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
-	if limbSize != 1 && limbSize != 2 {
+	switch limbSize {
+	case 1, 2:
+
+	default:
 		panic("unsupported limb size")
 	}
-	// Extract the vector from the interface to embed directly.
+
+	// Keep the hot iterator state concrete and return by value: storing the
+	// ElementIterator interface here makes VectorIterator escape to the heap.
 	vi, ok := it.(*VectorIterator)
 	if !ok {
-		panic("LimbIterator requires *VectorIterator")
+		panic("unsupported element iterator")
 	}
+
 	return LimbIterator{
 		v:        vi.v,
 		vi:       vi.i,
@@ -312,27 +318,35 @@ func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 
 // NextLimb returns the next limb of the vector.
 func (vr *LimbIterator) NextLimb() (uint32, bool) {
-	if vr.j >= koalabear.Bytes {
-		if vr.vi >= len(vr.v) {
+	if vr.j == koalabear.Bytes {
+		if vr.vi == len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
 		koalabear.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
 		vr.vi++
 	}
-	if vr.limbSize == 2 {
-		r := uint32(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
-		vr.j += 2
-		return r, true
+
+	var r uint32
+	switch vr.limbSize {
+	case 1:
+		r = uint32(vr.buf[vr.j])
+	case 2:
+		r = uint32(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+
+	default:
+		panic("unsupported limb size")
 	}
-	r := uint32(vr.buf[vr.j])
-	vr.j++
+	vr.j += vr.limbSize
 	return r, true
 }
 
-// Reset resets the iterator with a new vector.
+// Reset resets the iterator with a new ElementIterator.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vi := it.(*VectorIterator)
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
 	vr.v = vi.v
 	vr.vi = vi.i
 	vr.j = koalabear.Bytes

--- a/internal/generator/field/template/fft/fft.go.tmpl
+++ b/internal/generator/field/template/fft/fft.go.tmpl
@@ -287,26 +287,27 @@ func difFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 	if n == 1 {
 		return
 	} else if  stage >= twiddlesStartStage {
-		if n == 64 {
+		switch n {
+		case 64:
 			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 128 {
+		case 128:
 			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else
 		{{- range $ki, $klog2 :=  $.Kernels}}
-			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} {	// nolint QF1003
-				{{- $ksize := shl 1 $klog2}}
-				kerDIFNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
-				return
-			}
-		{{- end }}{{- if .HasASMKernel}} else if n == 512 {
+		case 1 << {{$klog2}}:
+			{{- $ksize := shl 1 $klog2}}
+			kerDIFNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
+			return
+		{{- end }}{{- if .HasASMKernel}}
+		case 512:
 			kerDIFNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDIFNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
-		}{{- end}}
+		{{- end}}
+		}
 	}
 	m := n >> 1
 
@@ -394,26 +395,27 @@ func ditFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
-		if n == 64 {
+		switch n {
+		case 64:
 			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 128 {
+		case 128:
 			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else
 		{{- range $ki, $klog2 :=  $.Kernels}}
-			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} { // nolint QF1003
-				{{- $ksize := shl 1 $klog2}}
-				kerDITNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
-				return
-			}
-		{{- end }}{{- if .HasASMKernel}} else if n == 512 {
+		case 1 << {{$klog2}}:
+			{{- $ksize := shl 1 $klog2}}
+			kerDITNP_{{$ksize}}(a, twiddles, stage-twiddlesStartStage)
+			return
+		{{- end }}{{- if .HasASMKernel}}
+		case 512:
 			kerDITNP_512(a, twiddles, stage-twiddlesStartStage)
 			return
-		} else if n == 1024 {
+		case 1024:
 			kerDITNP_1024(a, twiddles, stage-twiddlesStartStage)
 			return
-		}{{- end}}
+		{{- end}}
+		}
 	}
 	
 	m := n >> 1

--- a/internal/generator/field/template/fft/fft.go.tmpl
+++ b/internal/generator/field/template/fft/fft.go.tmpl
@@ -62,11 +62,17 @@ func (domain *Domain) FFT(a []{{ .FF }}.Element, decimation Decimation, opts ...
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
-			v1 := {{ .FF }}.Vector(a[start:end])
-			v2 := {{ .FF }}.Vector(cosetTable[start:end])
+		if opt.nbTasks <= 1 {
+			v1 := {{ .FF }}.Vector(a)
+			v2 := {{ .FF }}.Vector(cosetTable[:len(a)])
 			v1.Mul(v1, v2)
-		}, opt.nbTasks)
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v1 := {{ .FF }}.Vector(a[start:end])
+				v2 := {{ .FF }}.Vector(cosetTable[start:end])
+				v1.Mul(v1, v2)
+			}, opt.nbTasks)
+		}
 		{{- else}}
 		if decimation == DIT {
 			// scale by coset table (in bit reversed order)
@@ -172,11 +178,16 @@ func (domain *Domain) FFTInverse(a []{{ .FF }}.Element, decimation Decimation, o
 	// scale by CardinalityInv
 	if !opt.coset {
 		{{- if .F31}}
-		// Use vectorized scalar multiply instead of element-by-element loop
-		parallel.Execute(len(a), func(start, end int) {
-			v := {{ .FF }}.Vector(a[start:end])
+		// Use vectorized scalar multiply instead of element-by-element loop.
+		if opt.nbTasks <= 1 {
+			v := {{ .FF }}.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
-		}, opt.nbTasks)
+		} else {
+			parallel.Execute(len(a), func(start, end int) {
+				v := {{ .FF }}.Vector(a[start:end])
+				v.ScalarMul(v, &domain.CardinalityInv)
+			}, opt.nbTasks)
+		}
 		{{- else}}
 		parallel.Execute(len(a), func(start, end int) {
 			for i := start; i < end; i++ {
@@ -211,11 +222,17 @@ func (domain *Domain) FFTInverse(a []{{ .FF }}.Element, decimation Decimation, o
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
-		v := {{ .FF }}.Vector(a[start:end])
-		v.Mul(v, {{ .FF }}.Vector(cosetTableInv[start:end]))
+	if opt.nbTasks <= 1 {
+		v := {{ .FF }}.Vector(a)
+		v.Mul(v, {{ .FF }}.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
-	}, opt.nbTasks)
+	} else {
+		parallel.Execute(len(a), func(start, end int) {
+			v := {{ .FF }}.Vector(a[start:end])
+			v.Mul(v, {{ .FF }}.Vector(cosetTableInv[start:end]))
+			v.ScalarMul(v, &domain.CardinalityInv)
+		}, opt.nbTasks)
+	}
 	{{- else}}
 
 	if decimation == DIT {
@@ -270,6 +287,13 @@ func difFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 	if n == 1 {
 		return
 	} else if  stage >= twiddlesStartStage {
+		if n == 64 {
+			kerDIFNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 128 {
+			kerDIFNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else
 		{{- range $ki, $klog2 :=  $.Kernels}}
 			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} {	// nolint QF1003
 				{{- $ksize := shl 1 $klog2}}
@@ -370,6 +394,13 @@ func ditFFT(a []{{ .FF }}.Element, w {{ .FF }}.Element, twiddles [][]{{ .FF }}.E
 	if n == 1 {
 		return
 	} else if stage >= twiddlesStartStage {
+		if n == 64 {
+			kerDITNP_64(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else if n == 128 {
+			kerDITNP_128(a, twiddles, stage-twiddlesStartStage)
+			return
+		} else
 		{{- range $ki, $klog2 :=  $.Kernels}}
 			{{- if ne $ki 0}} else {{- end}} if n == 1 << {{$klog2}} { // nolint QF1003
 				{{- $ksize := shl 1 $klog2}}
@@ -466,6 +497,139 @@ func innerDITWithoutTwiddles(a []{{ .FF }}.Element, at, w {{ .FF }}.Element, sta
 	{{$ksize := shl 1 $klog2}}
 	{{genKernel $.FF $ksize $klog2}}
 {{end}}
+
+// kerDIFNP_64 is an unrolled 64-element DIF kernel that avoids recursion overhead
+// for workloads dominated by small FFTs.
+func kerDIFNP_64(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Stage 0: m=32
+	innerDIFWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+	// Stage 1: m=16
+	for offset := 0; offset < 64; offset += 32 {
+		innerDIFWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stages 2-4 are inlined to avoid function call and Vector dispatch overhead.
+	{
+		// Stage 2: m=8, 2x unrolled for ILP across Montgomery multiply chains.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			{{ .FF }}.Butterfly(&a[o1], &a[o1+8])
+			{{ .FF }}.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				{{ .FF }}.Butterfly(&a[o1+i], &a[o1+i+8])
+				{{ .FF }}.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			{{ .FF }}.Butterfly(&a[o1], &a[o1+4])
+			{{ .FF }}.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				{{ .FF }}.Butterfly(&a[o1+i], &a[o1+i+4])
+				{{ .FF }}.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+		}
+	}
+	{
+		// Stage 4: m=2 (DIF: all butterflies first, then multiply).
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			{{ .FF }}.Butterfly(&a[offset], &a[offset+2])
+			{{ .FF }}.Butterfly(&a[offset+1], &a[offset+3])
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+		}
+	}
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		{{ .FF }}.Butterfly(&a[offset], &a[offset+1])
+	}
+}
+
+// kerDITNP_64 is the DIT counterpart of kerDIFNP_64.
+func kerDITNP_64(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Stage 5: m=1 (butterfly only).
+	for offset := 0; offset < 64; offset += 2 {
+		{{ .FF }}.Butterfly(&a[offset], &a[offset+1])
+	}
+	// Stages 4-2 are inlined (DIT: multiply first, then butterfly).
+	{
+		// Stage 4: m=2.
+		tw := twiddles[stage+4]
+		for offset := 0; offset < 64; offset += 4 {
+			a[offset+3].Mul(&a[offset+3], &tw[1])
+			{{ .FF }}.Butterfly(&a[offset], &a[offset+2])
+			{{ .FF }}.Butterfly(&a[offset+1], &a[offset+3])
+		}
+	}
+	{
+		// Stage 3: m=4, 2x unrolled.
+		tw := twiddles[stage+3]
+		for offset := 0; offset < 64; offset += 16 {
+			o1, o2 := offset, offset+8
+			for i := 1; i < 4; i++ {
+				a[o1+i+4].Mul(&a[o1+i+4], &tw[i])
+				a[o2+i+4].Mul(&a[o2+i+4], &tw[i])
+			}
+			{{ .FF }}.Butterfly(&a[o1], &a[o1+4])
+			{{ .FF }}.Butterfly(&a[o2], &a[o2+4])
+			for i := 1; i < 4; i++ {
+				{{ .FF }}.Butterfly(&a[o1+i], &a[o1+i+4])
+				{{ .FF }}.Butterfly(&a[o2+i], &a[o2+i+4])
+			}
+		}
+	}
+	{
+		// Stage 2: m=8, 2x unrolled.
+		tw := twiddles[stage+2]
+		for offset := 0; offset < 64; offset += 32 {
+			o1, o2 := offset, offset+16
+			for i := 1; i < 8; i++ {
+				a[o1+i+8].Mul(&a[o1+i+8], &tw[i])
+				a[o2+i+8].Mul(&a[o2+i+8], &tw[i])
+			}
+			{{ .FF }}.Butterfly(&a[o1], &a[o1+8])
+			{{ .FF }}.Butterfly(&a[o2], &a[o2+8])
+			for i := 1; i < 8; i++ {
+				{{ .FF }}.Butterfly(&a[o1+i], &a[o1+i+8])
+				{{ .FF }}.Butterfly(&a[o2+i], &a[o2+i+8])
+			}
+		}
+	}
+	// Stage 1: m=16.
+	for offset := 0; offset < 64; offset += 32 {
+		innerDITWithTwiddles(a[offset:offset+32], twiddles[stage+1], 0, 16, 16)
+	}
+	// Stage 0: m=32.
+	innerDITWithTwiddles(a[:64], twiddles[stage+0], 0, 32, 32)
+}
+
+// kerDIFNP_128 is an unrolled 128-element DIF kernel.
+func kerDIFNP_128(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	// Stage 0: m=64.
+	innerDIFWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+	kerDIFNP_64(a[:64], twiddles, stage+1)
+	kerDIFNP_64(a[64:], twiddles, stage+1)
+}
+
+// kerDITNP_128 is the DIT counterpart of kerDIFNP_128.
+func kerDITNP_128(a []{{ .FF }}.Element, twiddles [][]{{ .FF }}.Element, stage int) {
+	kerDITNP_64(a[:64], twiddles, stage+1)
+	kerDITNP_64(a[64:], twiddles, stage+1)
+	// Final stage: m=64.
+	innerDITWithTwiddles(a[:128], twiddles[stage+0], 0, 64, 64)
+}
 
 {{- if .HasASMKernel}}
 // kerDIFNP_512 is an optimized 512-element DIF kernel that avoids recursion overhead
@@ -574,5 +738,3 @@ func kerDITNP_{{.sizeKernel}}generic(a []{{ .FF }}.Element, twiddles [][]{{ .FF 
 }
 
 {{end}}
-
-

--- a/internal/generator/field/template/sis/sis.go.tmpl
+++ b/internal/generator/field/template/sis/sis.go.tmpl
@@ -359,6 +359,8 @@ func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 		panic("unsupported limb size")
 	}
 
+	// Keep the hot iterator state concrete and return by value: storing the
+	// ElementIterator interface here makes VectorIterator escape to the heap.
 	vi, ok := it.(*VectorIterator)
 	if !ok {
 		panic("unsupported element iterator")

--- a/internal/generator/field/template/sis/sis.go.tmpl
+++ b/internal/generator/field/template/sis/sis.go.tmpl
@@ -217,7 +217,7 @@ func (r *RSis) Hash(v, res []{{ .FF }}.Element) error {
 			k := make([]{{ .FF }}.Element, r.Degree)
 			it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 			for i := range len(r.Ag) {
-				r.InnerHash(it, res, k, r.kz, i, mask)
+				r.InnerHash(&it, res, k, r.kz, i, mask)
 			}
 		}
 	{{- else}}
@@ -231,7 +231,7 @@ func (r *RSis) Hash(v, res []{{ .FF }}.Element) error {
 		k := make([]{{ .FF }}.Element, r.Degree)
 		it := NewLimbIterator(&VectorIterator{v: v}, r.LogTwoBound/8)
 		for i := range len(r.Ag) {
-			r.InnerHash(it, res, k, r.kz, i, mask)
+			r.InnerHash(&it, res, k, r.kz, i, mask)
 		}
 	{{- end}}
 
@@ -338,82 +338,77 @@ func (vi *VectorIterator) Next() ({{ .FF }}.Element, bool) {
 
 // LimbIterator iterates over a stream of field elements, limb by limb.
 type LimbIterator struct {
-	it ElementIterator
-	buf [{{ .FF }}.Bytes]byte
-
-	j int // position in buf
-
-	next func(buf []byte, pos *int) {{$tReturn}}
+	v        {{ .FF }}.Vector
+	vi       int
+	buf      [{{ .FF }}.Bytes]byte
+	j        int // position in buf
+	limbSize int
 }
 
 // NewLimbIterator creates a new LimbIterator
 // it is an iterator over a stream of field elements
 // The elements are interpreted in little endian.
 // The limb is also in little endian.
-func NewLimbIterator(it ElementIterator, limbSize int) *LimbIterator {
-	var next func(buf []byte, pos *int) {{$tReturn}}
+func NewLimbIterator(it ElementIterator, limbSize int) LimbIterator {
 	switch limbSize {
-	case 1:
-		next = nextUint8
-	case 2:
-		next = nextUint16
+	case 1, 2:
 	{{if not .F31 }}
-	case 4:
-		next = nextUint32
-	case 8:
-		next = nextUint64
+	case 4, 8:
 	{{- end}}
 	default:
 		panic("unsupported limb size")
 	}
-	return &LimbIterator{
-		it: it,
-		j: {{ .FF }}.Bytes,
-		next: next,
+
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+
+	return LimbIterator{
+		v:        vi.v,
+		vi:       vi.i,
+		j:        {{ .FF }}.Bytes,
+		limbSize: limbSize,
 	}
 }
 
 // NextLimb returns the next limb of the vector.
 func (vr *LimbIterator) NextLimb() ({{$tReturn}}, bool) {
 	if vr.j == {{ .FF }}.Bytes {
-		next, ok := vr.it.Next()
-		if !ok {
+		if vr.vi == len(vr.v) {
 			return 0, false
 		}
 		vr.j = 0
-		{{.FF}}.LittleEndian.PutElement(&vr.buf, next)
+		{{.FF}}.LittleEndian.PutElement(&vr.buf, vr.v[vr.vi])
+		vr.vi++
 	}
-	return vr.next(vr.buf[:], &vr.j), true
+
+	var r {{$tReturn}}
+	switch vr.limbSize {
+	case 1:
+		r = {{$tReturn}}(vr.buf[vr.j])
+	case 2:
+		r = {{$tReturn}}(binary.LittleEndian.Uint16(vr.buf[vr.j:]))
+	{{if not .F31 }}
+	case 4:
+		r = {{$tReturn}}(binary.LittleEndian.Uint32(vr.buf[vr.j:]))
+	case 8:
+		r = {{$tReturn}}(binary.LittleEndian.Uint64(vr.buf[vr.j:]))
+	{{- end}}
+	default:
+		panic("unsupported limb size")
+	}
+	vr.j += vr.limbSize
+	return r, true
 }
 
 // Reset resets the iterator with a new ElementIterator.
 func (vr *LimbIterator) Reset(it ElementIterator) {
-	vr.it = it
+	vi, ok := it.(*VectorIterator)
+	if !ok {
+		panic("unsupported element iterator")
+	}
+	vr.v = vi.v
+	vr.vi = vi.i
 	vr.j = {{ .FF }}.Bytes
 }
-
-
-func nextUint8(buf []byte, pos *int) {{$tReturn}} {
-	r := {{$tReturn}} (buf[*pos])
-	*pos++
-	return r
-}
-
-func nextUint16(buf []byte, pos *int) {{$tReturn}} {
-	r := {{$tReturn}} (binary.LittleEndian.Uint16(buf[*pos:]))
-	*pos += 2
-	return r
-}
-{{ if not .F31 }}
-func nextUint32(buf []byte, pos *int) {{$tReturn}} {
-	r := {{$tReturn}} (binary.LittleEndian.Uint32(buf[*pos:]))
-	*pos += 4
-	return r
-}
-
-func nextUint64(buf []byte, pos *int) {{$tReturn}} {
-	r := {{$tReturn}} (binary.LittleEndian.Uint64(buf[*pos:]))
-	*pos += 8
-	return r
-}
-{{- end}}


### PR DESCRIPTION
# perf(koalabear): unrolled FFT kernels and SIS LimbIterator optimization

## Summary

Six optimizations to KoalaBear FFT kernels and SIS hash targeting the Linea
Vortex prover (`logTwoDegree=6`, degree 64). Validated on AWS r8a (AMD EPYC
9R14, Zen 4, AVX-512). GOGC=off, count=10, benchtime=2s.

| Change | Tier-2 ns/op | Tier-2 allocs | Tier-2 B/op |
|--------|-------------|---------------|-------------|
| (a) Unrolled kernels | **-14.55%** | — | — |
| (b) Inline small-m | **-11.02%** | — | — |
| (c) nbTasks=1 fast path | **-3.95%** | **-63.42%** | **-41.80%** |
| (d) 2x unroll ILP | -1.13% | — | — |
| (e) LimbIterator funcptr | **-2.30%** | **-18.33%** | -3.64% |
| (f) Embed vector | **-2.29%** | **-29.25%** | -2.60% |
| **Cumulative** | **-56%** | **-98%** | **-81%** |

> Fresh per-commit benchstat (single session). Consistent with rolling-baseline
> experiment measurements. Allocation deltas are deterministic. Blanks indicate
> no measurable effect on that metric.

## Changes

### (a) Unrolled kerDIFNP\_64/128 FFT kernels

`field/koalabear/fft/fft.go`

64-element recursive FFT makes ~63 `difFFT` calls. Add `kerDIFNP_64`/`kerDITNP_64`
processing all 6 stages without recursion, following the `kerDIFNP_256` pattern.

```
Tier-2 (VortexHashPathsByRows):
rows_128/sis_hash_only-8     16.47m ± 1%   12.27m ± 0%  -25.49% (p=0.000)
rows_512/sis_hash_only-8     54.83m ± 1%   40.08m ± 1%  -26.90% (p=0.000)
rows_1024/sis_hash_only-8   104.23m ± 2%   74.84m ± 1%  -28.20% (p=0.000)
rows_1280/sis_hash_only-8   127.40m ± 1%   92.75m ± 1%  -27.19% (p=0.000)
geomean                      34.56m         29.53m       -14.55%
```

### (b) Inline small-m stages

`field/koalabear/fft/fft.go`

Inline butterfly + twiddle multiply for stages 2-4 (m=8,4,2) directly in the
kernel, bypassing `innerDIFWithTwiddlesGeneric` dispatch and `(*Vector).Mul`
AVX-512 check on sub-16-element vectors.

```
Tier-2:
rows_128/sis_hash_only-8    12.28m ± 0%   10.38m ± 2%  -15.49% (p=0.000)
rows_512/sis_hash_only-8    40.05m ± 1%   31.53m ± 1%  -21.27% (p=0.000)
rows_1024/sis_hash_only-8   74.48m ± 1%   58.42m ± 1%  -21.57% (p=0.000)
rows_1280/sis_hash_only-8   91.84m ± 1%   71.41m ± 1%  -22.25% (p=0.000)
geomean                     29.42m         26.17m       -11.02%
```

### (c) Inline coset/CardinalityInv scaling for nbTasks=1

`field/koalabear/fft/fft.go`

`Domain.FFT`/`FFTInverse` wrap coset scaling in `parallel.Execute` closures
even for `nbTasks=1`. Escape analysis confirms closures heap-allocate. Add
`if opt.nbTasks <= 1` fast paths.

```
Tier-2:
rows_128/sis_hash_only-8   10.484m ± 1%   9.517m ± 1%  -9.22% (p=0.001)
rows_512/sis_hash_only-8   31.67m ± 10%  29.11m ± 2%   -8.09% (p=0.015)
rows_1024/sis_hash_only-8  58.03m ±  1%  54.08m ± 1%   -6.80% (p=0.000)
rows_1280/sis_hash_only-8  71.70m ±  1%  66.38m ± 1%   -7.43% (p=0.000)
geomean                    26.24m         25.20m        -3.95%
allocs/op geomean          2.844k         1.040k        -63.42%
B/op geomean               5.077Mi        2.955Mi       -41.80%
```

### (d) 2x loop unroll for ILP

`field/koalabear/fft/fft.go`

Process two adjacent blocks simultaneously in stages 2-3 for independent
Montgomery multiply chains. Inspired by Plonky3 `butterflies.rs` ILP pattern.

```
Tier-2:
rows_1024/no_sis_hash_only-8  42.98m ± 1%  41.90m ± 0%  -2.53% (p=0.001)
rows_1024/sis_hash_only-8     54.06m ± 1%  53.06m ± 1%  -1.86% (p=0.000)
rows_1280/sis_hash_only-8     66.65m ± 1%  65.02m ± 0%  -2.45% (p=0.000)
geomean                       25.29m        25.00m       -1.13%
```

### (e) Eliminate function pointer in LimbIterator.NextLimb

`field/koalabear/sis/sis.go`

Replace indirect function pointer (`vr.next`) with `limbSize int` field + branch.
Removes indirect call overhead and eliminates closure that caused heap escape.

```
Tier-2:
rows_128/sis_hash_only-8    9.439m ± 1%   9.129m ± 1%  -3.29% (p=0.001)
rows_512/sis_hash_only-8   28.33m ± 8%   26.93m ± 8%   -4.93% (p=0.009)
rows_1024/sis_hash_only-8  53.33m ± 1%   50.28m ± 0%   -5.72% (p=0.000)
rows_1280/sis_hash_only-8  65.07m ± 1%   61.81m ± 4%   -5.01% (p=0.000)
geomean                    25.01m         24.44m        -2.30%
allocs/op geomean          1.040k         849.6         -18.33%
```

### (f) Embed vector in LimbIterator

`field/koalabear/sis/sis.go`

Replace `ElementIterator` interface with direct `koalabear.Vector` slice.
Return `LimbIterator` by value. Escape analysis confirms `VectorIterator` no
longer escapes to heap.

```
Tier-2:
rows_128/sis_hash_only-8    9.126m ± 2%   8.884m ± 0%  -2.65% (p=0.001)
rows_512/sis_hash_only-8   27.06m ± 2%   25.63m ± 2%   -5.29% (p=0.002)
rows_1024/sis_hash_only-8  50.23m ± 5%   47.25m ± 0%   -5.92% (p=0.000)
rows_1280/sis_hash_only-8  61.84m ± 0%   57.77m ± 0%   -6.57% (p=0.000)
geomean                    24.36m         23.80m        -2.29%
allocs/op geomean          849.6          601.1         -29.25%
```

## Diff shape

```
 field/koalabear/fft/fft.go | 198 ++++++++++++++++++++++++++++++++++----
 field/koalabear/sis/sis.go |  69 +++++++++-------
 2 files changed, 221 insertions(+), 46 deletions(-)
```

## Validation methodology

Benchmarks run via the Linea prover against Vortex KoalaBear commitment
benchmarks:

- **Tier-2**: `BenchmarkVortexHashPathsByRows` filtered to rows 128/512/1024/1280,
  both `no_sis_hash_only` and `sis_hash_only` variants.
- Settings: `GOGC=off`, `-benchmem`, `-count=10`, `-benchtime=2s`.
- Gate: keep if ns/op geomean ≤ -2.0% (p < 0.05) OR allocs/op decreased.
- Noise floor: σ ≈ 1.0%.

### Hardware

| | AWS instance |
|---|---|
| CPU | AMD EPYC 9R14 (Zen 4) |
| Cores | 8 vCPU |
| RAM | 16 GB |
| AVX-512 | Yes |

## Correctness

All existing tests pass:
```bash
go test -short ./field/koalabear/fft/   # FFT property tests (DIF/DIT, coset, inverse)
go test -short ./field/koalabear/sis/   # SIS tests
```

- No security parameter changes.
- No API changes except `NewLimbIterator` returns `LimbIterator` by value
  (callers pass `&it`).
- FFT kernels are mathematically equivalent — same butterfly + twiddle
  sequence, just without recursion overhead.

## Research references

- **Plonky3** (`butterflies.rs`, `radix_2_dit_parallel.rs`): unrolled kernel
  pattern, ILP via manual loop unrolling.
- **Existing `kerDIFNP_256` pattern** in this repo's koalabear FFT: the
  unrolled kernel approach follows the same structure, extended to n=64/128.
  A similar unrolled FFT64 also exists for bls12-377 (`223ce6be1`).

## Overlap with existing branches

- **`perf/p22`** (Gautam Botrel): `9caf92b00` (generalize Compressx16 for
  variable colSize) is **complementary** — extends the companion linea PR's
  Compressx16 batching win to all row counts. `65926fae0` (Poseidon2 -17%)
  attacks the 27% Poseidon2 ceiling. No conflict.
- **`perf/sis_experiments`** (Gautam Botrel): assembly-level FFT/SIS.
  **No Go-level overlap.**

## Parameter sensitivity

FFT changes (a-d) are **degree-64-specific** (`logTwoDegree=6`). Same pattern
applies to `kerDIFNP_512` for `logTwoDegree=9`. SIS changes (e-f) and FFT
fast path (c) are **parameter-independent**.

## Companion PR

A separate PR to `linea-monorepo` optimizes the prover-side Vortex code
(MulAccByElement, MDHasher buffer, Compressx16 SIMD batching — 4 commits,
-72% LinearCombination ns/op). Those changes work independently without this
gnark-crypto fork. Once this PR merges, bumping the dependency activates the
FFT/SIS wins.

## Future validation

Larger `numCols` benchmarks (per Alexandre's suggestion) would validate
under production memory pressure. Not run here due to 16GB server constraints.
Allocation reductions (-98% SIS allocs) should compound harder under GC pressure.

## How to reproduce

```bash
# From linea-monorepo/prover (with replace directive pointing to this fork):
GOGC=off go test -bench="BenchmarkVortexHashPathsByRows/rows_(128|512|1024)/" \
  -benchmem -count=10 -benchtime=2s -run='^$' ./crypto/vortex/vortex_koalabear/
```

<details>
<summary>Experimentally ruled out (16 iterations)</summary>

| Iter | Idea | Result | Why |
|------|------|--------|-----|
| 10 | Fuse butterfly + twiddle into single loop | +1.0% | Breaks instruction pipelining |
| 13 | Pre-compute cosetTableInv × CardinalityInv | — | N=64 too small |
| 14 | Cache OnCoset/WithNbTasks closures as pkg vars | +3.3% | Prevents compiler closure inlining |
| 15 | Call innerDIFWithTwiddles\_avx512 directly | +2.2% | Compiler already constant-folds |
| 18 | Extend 2x unroll to stage 4 (m=2) | -1.67% | Diminishing returns |
| 19 | Fuse stages 4+5 in kerDIFNP\_64 | +7.1% | Bad codegen from cross-stage fusion |
| 20 | Direct kernel dispatch from Domain.FFT | -0.53% | difFFT dispatch already negligible |
| 21 | Preload twiddles into locals + full unroll | -0.39% | Compiler eliminates bounds checks |
| 23 | Skip byte buffer via ToRegularUint32 | -0.38% | montReduce dominates |
| 24 | Pool k buffer via sync.Pool | -0.77% | B/op -36% but ns/op below threshold |
| 26 | Fused MulAddAssign in SIS InnerHash | +5.3% | Go scalar loses to AVX-512 Mul + Add |

**Key finding:** Never replace separate AVX-512 vector ops with a fused Go
scalar loop. SIMD throughput (16 elements/cycle) dominates over memory savings.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches performance-critical FFT and SIS hashing kernels; while changes should be functionally equivalent, unrolled butterfly/twiddle sequencing and iterator semantics could introduce subtle correctness or boundary bugs if not thoroughly tested.
> 
> **Overview**
> Adds new unrolled small-size FFT kernels (`kerDIFNP_64/128` and `kerDITNP_64/128`) and updates kernel dispatch (via `switch n`) across multiple fields/curves to bypass recursive FFT calls for 64- and 128-point transforms.
> 
> Optimizes SIS hashing limb iteration by making `NewLimbIterator` return a value and storing a concrete vector + limb size (removing interface/func-pointer indirections); callers now pass `&it` into `InnerHash`. For `babybear`/`koalabear` FFTs, adds `nbTasks<=1` fast paths to avoid `parallel.Execute` closure overhead during coset and inverse scaling. Codegen templates are updated to generate the same patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81436319a9259a132e177f9226ec4a76e85cef09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->