### PR TITLE
fix: unregress ExecuteAligned->Execute

### DIFF
--- a/field/babybear/fft/fft.go
+++ b/field/babybear/fft/fft.go
@@ -72,7 +72,7 @@ func (domain *Domain) FFT(a []babybear.Element, decimation Decimation, opts ...O
 			v2 := babybear.Vector(cosetTable[:len(a)])
 			v1.Mul(v1, v2)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v1 := babybear.Vector(a[start:end])
 				v2 := babybear.Vector(cosetTable[start:end])
 				v1.Mul(v1, v2)
@@ -147,7 +147,7 @@ func (domain *Domain) FFTInverse(a []babybear.Element, decimation Decimation, op
 			v := babybear.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v := babybear.Vector(a[start:end])
 				v.ScalarMul(v, &domain.CardinalityInv)
 			}, opt.nbTasks)
@@ -182,7 +182,7 @@ func (domain *Domain) FFTInverse(a []babybear.Element, decimation Decimation, op
 		v.Mul(v, babybear.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
 	} else {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 			v := babybear.Vector(a[start:end])
 			v.Mul(v, babybear.Vector(cosetTableInv[start:end]))
 			v.ScalarMul(v, &domain.CardinalityInv)

--- a/field/babybear/fft/fftext.go
+++ b/field/babybear/fft/fftext.go
@@ -56,7 +56,7 @@ func (domain *Domain) FFTExt(a []fext.E4, decimation Decimation, opts ...Option)
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.MulByElement(va, cosetTable[start:end])
 		}, opt.nbTasks)
@@ -125,7 +125,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 
 	// scale by CardinalityInv
 	if !opt.coset {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.ScalarMulByElement(va, &domain.CardinalityInv)
 		}, opt.nbTasks)
@@ -155,7 +155,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
+	parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 		va := fext.Vector(a[start:end])
 		va.MulByElement(va, cosetTableInv[start:end])
 		va.ScalarMulByElement(va, &domain.CardinalityInv)

--- a/field/koalabear/fft/fft.go
+++ b/field/koalabear/fft/fft.go
@@ -72,7 +72,7 @@ func (domain *Domain) FFT(a []koalabear.Element, decimation Decimation, opts ...
 			v2 := koalabear.Vector(cosetTable[:len(a)])
 			v1.Mul(v1, v2)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v1 := koalabear.Vector(a[start:end])
 				v2 := koalabear.Vector(cosetTable[start:end])
 				v1.Mul(v1, v2)
@@ -147,7 +147,7 @@ func (domain *Domain) FFTInverse(a []koalabear.Element, decimation Decimation, o
 			v := koalabear.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v := koalabear.Vector(a[start:end])
 				v.ScalarMul(v, &domain.CardinalityInv)
 			}, opt.nbTasks)
@@ -182,7 +182,7 @@ func (domain *Domain) FFTInverse(a []koalabear.Element, decimation Decimation, o
 		v.Mul(v, koalabear.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
 	} else {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 			v := koalabear.Vector(a[start:end])
 			v.Mul(v, koalabear.Vector(cosetTableInv[start:end]))
 			v.ScalarMul(v, &domain.CardinalityInv)

--- a/field/koalabear/fft/fftext.go
+++ b/field/koalabear/fft/fftext.go
@@ -56,7 +56,7 @@ func (domain *Domain) FFTExt(a []fext.E4, decimation Decimation, opts ...Option)
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.MulByElement(va, cosetTable[start:end])
 		}, opt.nbTasks)
@@ -125,7 +125,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 
 	// scale by CardinalityInv
 	if !opt.coset {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.ScalarMulByElement(va, &domain.CardinalityInv)
 		}, opt.nbTasks)
@@ -155,7 +155,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
+	parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 		va := fext.Vector(a[start:end])
 		va.MulByElement(va, cosetTableInv[start:end])
 		va.ScalarMulByElement(va, &domain.CardinalityInv)

--- a/internal/generator/field/template/fft/fft.go.tmpl
+++ b/internal/generator/field/template/fft/fft.go.tmpl
@@ -67,7 +67,7 @@ func (domain *Domain) FFT(a []{{ .FF }}.Element, decimation Decimation, opts ...
 			v2 := {{ .FF }}.Vector(cosetTable[:len(a)])
 			v1.Mul(v1, v2)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v1 := {{ .FF }}.Vector(a[start:end])
 				v2 := {{ .FF }}.Vector(cosetTable[start:end])
 				v1.Mul(v1, v2)
@@ -183,7 +183,7 @@ func (domain *Domain) FFTInverse(a []{{ .FF }}.Element, decimation Decimation, o
 			v := {{ .FF }}.Vector(a)
 			v.ScalarMul(v, &domain.CardinalityInv)
 		} else {
-			parallel.Execute(len(a), func(start, end int) {
+			parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 				v := {{ .FF }}.Vector(a[start:end])
 				v.ScalarMul(v, &domain.CardinalityInv)
 			}, opt.nbTasks)
@@ -227,7 +227,7 @@ func (domain *Domain) FFTInverse(a []{{ .FF }}.Element, decimation Decimation, o
 		v.Mul(v, {{ .FF }}.Vector(cosetTableInv[:len(a)]))
 		v.ScalarMul(v, &domain.CardinalityInv)
 	} else {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 16, func(start, end int) {
 			v := {{ .FF }}.Vector(a[start:end])
 			v.Mul(v, {{ .FF }}.Vector(cosetTableInv[start:end]))
 			v.ScalarMul(v, &domain.CardinalityInv)

--- a/internal/generator/field/template/fft/fftext.go.tmpl
+++ b/internal/generator/field/template/fft/fftext.go.tmpl
@@ -53,7 +53,7 @@ func (domain *Domain) FFTExt(a []fext.E4, decimation Decimation, opts ...Option)
 				BuildExpTable(domain.FrMultiplicativeGen, cosetTable)
 			}
 		}
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.MulByElement(va, cosetTable[start:end])
 		}, opt.nbTasks)
@@ -123,7 +123,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 
 	// scale by CardinalityInv
 	if !opt.coset {
-		parallel.Execute(len(a), func(start, end int) {
+		parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 			va := fext.Vector(a[start:end])
 			va.ScalarMulByElement(va, &domain.CardinalityInv)
 		}, opt.nbTasks)
@@ -153,7 +153,7 @@ func (domain *Domain) FFTInverseExt(a []fext.E4, decimation Decimation, opts ...
 			utils.BitReverse(cosetTableInv)
 		}
 	}
-	parallel.Execute(len(a), func(start, end int) {
+	parallel.ExecuteAligned(len(a), 4, func(start, end int) {
 		va := fext.Vector(a[start:end])
 		va.MulByElement(va, cosetTableInv[start:end])
 		va.ScalarMulByElement(va, &domain.CardinalityInv)


### PR DESCRIPTION
# Description

Commit ee52ec4ee5b619a8044f085b68e8c42c45f5e2a9 regressed to using Execute instead of ExecuteAligned for small-field FFT ops.

ExecuteAligned ensures that the chunks in Execute align to the AVX word size to ensure we don't have many small tails where we use non-vectorized operations and only possibly last chunk uses non-vectorized operations for the remaining tail.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Existing tests.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance-focused change: swaps `parallel.Execute` for `parallel.ExecuteAligned` with fixed alignments, which should not affect numerical results but could impact scheduling/throughput on edge sizes.
> 
> **Overview**
> Restores aligned parallel chunking for BabyBear/KoalaBear FFT and extension-field FFT operations by replacing `parallel.Execute` with `parallel.ExecuteAligned`.
> 
> This ensures per-task ranges align to vector widths (alignment `16` for base-field vector ops, `4` for `E4` extension ops) when scaling by coset tables and `CardinalityInv`, reducing non-vectorized tail work in multi-threaded FFT paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f468377128c9006d4ad8c4a9924cc8dcc111eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->