### PR TITLE
fix(fp2): handle (non-QR, 0) input in Fp² Sqrt across all curves

### DIFF
--- a/ecc/bls12-377/internal/fptower/e2.go
+++ b/ecc/bls12-377/internal/fptower/e2.go
@@ -210,6 +210,30 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott §6.3 has an unstated precondition x.A1 != 0:
+	// for x.A1 == 0 with x.A0 a non-residue in Fp the inner Fp.Sqrt fails
+	// silently and the final SqrtAndInverse goes through zero, returning
+	// (0, 0) for what is in fact a square in Fp². Its true sqrt is
+	// (0, sqrt(x.A0 / β)) where β = u² is the Fp² QNR. Handle the
+	// purely-real branch explicitly.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var aOverBeta fp.Element
+		// β = -5: aOverBeta = x.A0 / β = -x.A0 / 5
+		var beta fp.Element
+		beta.SetUint64(5)
+		beta.Neg(&beta)
+		aOverBeta.Inverse(&beta)
+		aOverBeta.Mul(&aOverBeta, &x.A0)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fp.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/ecc/bls12-377/internal/fptower/e2_test.go
+++ b/ecc/bls12-377/internal/fptower/e2_test.go
@@ -357,6 +357,25 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Aardal Algorithm 3
+	// and Scott §6.3 formulas both have an unstated precondition that
+	// a.A1 != 0; for x = (a, 0) with a non-QR in Fp the algorithms
+	// silently returned (0, 0) instead of the true sqrt (0, sqrt(a/β))
+	// where β = u² is the Fp² QNR.
+	properties.Property("[BLS12-377] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[BLS12-377] cube(cbrt) should leave an element invariant", prop.ForAll(
 		func(a *E2) bool {
 			var b, c, d E2

--- a/ecc/bls12-381/internal/fptower/e2.go
+++ b/ecc/bls12-381/internal/fptower/e2.go
@@ -210,9 +210,22 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // on Intel and Cortex-M4" by Aardal et al.
 // https://eprint.iacr.org/2024/1563.pdf (algo 3)
 func (z *E2) Sqrt(a *E2) *E2 {
+	// Aardal Algorithm 3 has an unstated precondition a.A1 != 0:
+	// for a.A1 == 0 with a.A0 a non-residue in Fp the inner ExpBySqrtPp1o4 yields
+	// δ = -a.A0, then x0 = a.A0 + δ = 0 cascades to (0, 0). But (a.A0, 0) is
+	// always a square in Fp² for nonzero a.A0 (Euler), with sqrt (0, sqrt(a.A0/β))
+	// where β = u² is the Fp² QNR. Handle the purely-real branch explicitly.
 	if a.A1.IsZero() {
-		z.A0.Sqrt(&a.A0)
-		z.A1.SetZero()
+		if a.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&a.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var aOverBeta fp.Element
+		// β = -1 (CoordExtRoot = -1, or default 0): aOverBeta = -a
+		aOverBeta.Neg(&a.A0)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
 		return z
 	}
 

--- a/ecc/bls12-381/internal/fptower/e2_test.go
+++ b/ecc/bls12-381/internal/fptower/e2_test.go
@@ -368,6 +368,25 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Aardal Algorithm 3
+	// and Scott §6.3 formulas both have an unstated precondition that
+	// a.A1 != 0; for x = (a, 0) with a non-QR in Fp the algorithms
+	// silently returned (0, 0) instead of the true sqrt (0, sqrt(a/β))
+	// where β = u² is the Fp² QNR.
+	properties.Property("[BLS12-381] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[BLS12-381] cube(cbrt) should leave an element invariant", prop.ForAll(
 		func(a *E2) bool {
 			var b, c, d E2

--- a/ecc/bls24-315/internal/fptower/e2.go
+++ b/ecc/bls24-315/internal/fptower/e2.go
@@ -194,6 +194,26 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott §6.3 has an unstated precondition x.A1 != 0: for x.A1 == 0 with
+	// x.A0 a non-residue in Fp the inner Fp.Sqrt fails silently and the
+	// final Div goes through zero, returning a wrong root. But (x.A0, 0) is
+	// always a square in Fp² for nonzero x.A0 (Euler). For bls24-315 we have
+	// u² = 13 so β = 13, and the true sqrt is (0, sqrt(x.A0 / 13)).
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var beta, aOverBeta fp.Element
+		beta.SetUint64(13)
+		aOverBeta.Inverse(&beta)
+		aOverBeta.Mul(&aOverBeta, &x.A0)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fp.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/ecc/bls24-315/internal/fptower/e2_test.go
+++ b/ecc/bls24-315/internal/fptower/e2_test.go
@@ -339,6 +339,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Scott §6.3 formula
+	// has an unstated precondition x.A1 != 0; for x = (a, 0) with a non-QR
+	// in Fp the inner Fp.Sqrt failed silently and the function returned
+	// a wrong root. Since this curve's E2 is hand-written (not generated
+	// from the tower template), the template-level regression does not
+	// cover it; we add a curve-local property here.
+	properties.Property("[BLS24-315] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[BLS24-315] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a *E2) bool {
 			var b, c E2

--- a/ecc/bls24-317/internal/fptower/e2.go
+++ b/ecc/bls24-317/internal/fptower/e2.go
@@ -205,9 +205,22 @@ var sqrtExp1, sqrtExp2 big.Int
 // on Intel and Cortex-M4" by Aardal et al.
 // https://eprint.iacr.org/2024/1563.pdf (algo 3)
 func (z *E2) Sqrt(a *E2) *E2 {
+	// Aardal Algorithm 3 has an unstated precondition a.A1 != 0: for
+	// a.A1 == 0 with a.A0 a non-residue in Fp the inner ExpBySqrtPp1o4
+	// yields δ = -a.A0, then x0 = a.A0 + δ = 0 cascades to (0, 0). But
+	// (a.A0, 0) is always a square in Fp² for nonzero a.A0 (Euler). For
+	// bls24-317 we have u² = -1 so β = -1, and the true sqrt is
+	// (0, sqrt(-a.A0)).
 	if a.A1.IsZero() {
-		z.A0.Sqrt(&a.A0)
-		z.A1.SetZero()
+		if a.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&a.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var aOverBeta fp.Element
+		aOverBeta.Neg(&a.A0)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
 		return z
 	}
 

--- a/ecc/bls24-317/internal/fptower/e2_test.go
+++ b/ecc/bls24-317/internal/fptower/e2_test.go
@@ -340,6 +340,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. Aardal et al. Algorithm 3
+	// has an unstated precondition a.A1 != 0; for a = (a0, 0) with a0
+	// non-QR in Fp it cascades to (0, 0). Since this curve's E2 is
+	// hand-written (not generated from the tower template), the
+	// template-level regression does not cover it; we add a curve-local
+	// property here.
+	properties.Property("[BLS24-317] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[BLS24-317] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a *E2) bool {
 			var b, c E2

--- a/ecc/bn254/internal/fptower/e2.go
+++ b/ecc/bn254/internal/fptower/e2.go
@@ -210,9 +210,22 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // on Intel and Cortex-M4" by Aardal et al.
 // https://eprint.iacr.org/2024/1563.pdf (algo 3)
 func (z *E2) Sqrt(a *E2) *E2 {
+	// Aardal Algorithm 3 has an unstated precondition a.A1 != 0:
+	// for a.A1 == 0 with a.A0 a non-residue in Fp the inner ExpBySqrtPp1o4 yields
+	// δ = -a.A0, then x0 = a.A0 + δ = 0 cascades to (0, 0). But (a.A0, 0) is
+	// always a square in Fp² for nonzero a.A0 (Euler), with sqrt (0, sqrt(a.A0/β))
+	// where β = u² is the Fp² QNR. Handle the purely-real branch explicitly.
 	if a.A1.IsZero() {
-		z.A0.Sqrt(&a.A0)
-		z.A1.SetZero()
+		if a.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&a.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var aOverBeta fp.Element
+		// β = -1 (CoordExtRoot = -1, or default 0): aOverBeta = -a
+		aOverBeta.Neg(&a.A0)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
 		return z
 	}
 

--- a/ecc/bn254/internal/fptower/e2_test.go
+++ b/ecc/bn254/internal/fptower/e2_test.go
@@ -366,6 +366,25 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Aardal Algorithm 3
+	// and Scott §6.3 formulas both have an unstated precondition that
+	// a.A1 != 0; for x = (a, 0) with a non-QR in Fp the algorithms
+	// silently returned (0, 0) instead of the true sqrt (0, sqrt(a/β))
+	// where β = u² is the Fp² QNR.
+	properties.Property("[BN254] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[BN254] cube(cbrt) should leave an element invariant", prop.ForAll(
 		func(a *E2) bool {
 			var b, c, d E2

--- a/field/babybear/extensions/e2.go
+++ b/field/babybear/extensions/e2.go
@@ -204,6 +204,26 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott's formula divides by 2·y0 at the end; for x.A1 == 0 with x.A0
+	// a non-residue in Fp the inner Fp.Sqrt silently fails and the
+	// division becomes 0/0, returning (0, 0) for any base-field
+	// non-residue. Handle the purely-real branch explicitly: with
+	// u² = β, sqrt((a, 0)) is either (sqrt_fp(a), 0) or (0, sqrt_fp(a/β))
+	// depending on which of a, a/β is a square in Fp.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var beta, aOverBeta fr.Element
+		beta.SetUint64(11)
+		aOverBeta.Div(&x.A0, &beta)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fr.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/field/babybear/extensions/e2_test.go
+++ b/field/babybear/extensions/e2_test.go
@@ -341,6 +341,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Scott §6.3 formula
+	// divides by 2·y0 at the end; for x = (a, 0) with a non-QR in Fp the
+	// inner Fp.Sqrt returned 0 and the function fell through to 0/0,
+	// producing (0, 0) regardless of the actual square root. The fix
+	// special-cases x.A1 == 0 and looks for an E2 root of the form (0, b)
+	// with β·b² = a.
+	properties.Property("[babybear] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fr.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genFr(),
+	))
+
 	properties.Property("[babybear] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a E2) bool {
 			var b, c E2

--- a/field/goldilocks/extensions/e2.go
+++ b/field/goldilocks/extensions/e2.go
@@ -204,6 +204,26 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott's formula divides by 2·y0 at the end; for x.A1 == 0 with x.A0
+	// a non-residue in Fp the inner Fp.Sqrt silently fails and the
+	// division becomes 0/0, returning (0, 0) for any base-field
+	// non-residue. Handle the purely-real branch explicitly: with
+	// u² = β, sqrt((a, 0)) is either (sqrt_fp(a), 0) or (0, sqrt_fp(a/β))
+	// depending on which of a, a/β is a square in Fp.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var beta, aOverBeta fr.Element
+		beta.SetUint64(7)
+		aOverBeta.Div(&x.A0, &beta)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fr.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/field/goldilocks/extensions/e2_test.go
+++ b/field/goldilocks/extensions/e2_test.go
@@ -332,6 +332,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Scott §6.3 formula
+	// divides by 2·y0 at the end; for x = (a, 0) with a non-QR in Fp the
+	// inner Fp.Sqrt returned 0 and the function fell through to 0/0,
+	// producing (0, 0) regardless of the actual square root. The fix
+	// special-cases x.A1 == 0 and looks for an E2 root of the form (0, b)
+	// with β·b² = a.
+	properties.Property("[goldilocks] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fr.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genFr(),
+	))
+
 	properties.Property("[goldilocks] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a E2) bool {
 			var b, c E2

--- a/field/koalabear/extensions/e2.go
+++ b/field/koalabear/extensions/e2.go
@@ -204,6 +204,26 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott's formula divides by 2·y0 at the end; for x.A1 == 0 with x.A0
+	// a non-residue in Fp the inner Fp.Sqrt silently fails and the
+	// division becomes 0/0, returning (0, 0) for any base-field
+	// non-residue. Handle the purely-real branch explicitly: with
+	// u² = β, sqrt((a, 0)) is either (sqrt_fp(a), 0) or (0, sqrt_fp(a/β))
+	// depending on which of a, a/β is a square in Fp.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var beta, aOverBeta fr.Element
+		beta.SetUint64(3)
+		aOverBeta.Div(&x.A0, &beta)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fr.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/field/koalabear/extensions/e2_test.go
+++ b/field/koalabear/extensions/e2_test.go
@@ -341,6 +341,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Scott §6.3 formula
+	// divides by 2·y0 at the end; for x = (a, 0) with a non-QR in Fp the
+	// inner Fp.Sqrt returned 0 and the function fell through to 0/0,
+	// producing (0, 0) regardless of the actual square root. The fix
+	// special-cases x.A1 == 0 and looks for an E2 root of the form (0, b)
+	// with β·b² = a.
+	properties.Property("[koalabear] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fr.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genFr(),
+	))
+
 	properties.Property("[koalabear] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a E2) bool {
 			var b, c E2

--- a/internal/generator/field/template/extensions/e2.go.tmpl
+++ b/internal/generator/field/template/extensions/e2.go.tmpl
@@ -197,6 +197,32 @@ func (z *E2) Exp(x E2, k *big.Int) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott's formula divides by 2·y0 at the end; for x.A1 == 0 with x.A0
+	// a non-residue in Fp the inner Fp.Sqrt silently fails and the
+	// division becomes 0/0, returning (0, 0) for any base-field
+	// non-residue. Handle the purely-real branch explicitly: with
+	// u² = β, sqrt((a, 0)) is either (sqrt_fp(a), 0) or (0, sqrt_fp(a/β))
+	// depending on which of a, a/β is a square in Fp.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var beta, aOverBeta fr.Element
+	    {{- if eq .FF "koalabear"}}
+		beta.SetUint64(3)
+	    {{- else if eq .FF "babybear"}}
+		beta.SetUint64(11)
+	    {{- else if eq .FF "goldilocks"}}
+		beta.SetUint64(7)
+	    {{- end}}
+		aOverBeta.Div(&x.A0, &beta)
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fr.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/internal/generator/field/template/extensions/e2_test.go.tmpl
+++ b/internal/generator/field/template/extensions/e2_test.go.tmpl
@@ -337,6 +337,26 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Scott §6.3 formula
+	// divides by 2·y0 at the end; for x = (a, 0) with a non-QR in Fp the
+	// inner Fp.Sqrt returned 0 and the function fell through to 0/0,
+	// producing (0, 0) regardless of the actual square root. The fix
+	// special-cases x.A1 == 0 and looks for an E2 root of the form (0, b)
+	// with β·b² = a.
+	properties.Property("[{{.FF}}] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fr.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genFr(),
+	))
+
 	properties.Property("[{{.FF}}] neg(E2) == neg(E2.A0, E2.A1)", prop.ForAll(
 		func(a E2) bool {
 			var b, c E2

--- a/internal/generator/tower/template/fq12over6over2/fq2.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/fq2.go.tmpl
@@ -208,10 +208,32 @@ w := b[i]
 // on Intel and Cortex-M4" by Aardal et al.
 // https://eprint.iacr.org/2024/1563.pdf (algo 3)
 func (z *E2) Sqrt(a *E2) *E2 {
+    // Aardal Algorithm 3 has an unstated precondition a.A1 != 0:
+    // for a.A1 == 0 with a.A0 a non-residue in Fp the inner ExpBySqrtPp1o4 yields
+    // δ = -a.A0, then x0 = a.A0 + δ = 0 cascades to (0, 0). But (a.A0, 0) is
+    // always a square in Fp² for nonzero a.A0 (Euler), with sqrt (0, sqrt(a.A0/β))
+    // where β = u² is the Fp² QNR. Handle the purely-real branch explicitly.
     if a.A1.IsZero() {
-        z.A0.Sqrt(&a.A0)
+        if a.A0.Legendre() >= 0 {
+            z.A0.Sqrt(&a.A0)
             z.A1.SetZero()
             return z
+        }
+        var aOverBeta fp.Element
+        {{- if eq .Curve.G2.CoordExtRoot -5 }}
+        // β = -5: aOverBeta = a / β = -a / 5
+        var beta fp.Element
+        beta.SetUint64(5)
+        beta.Neg(&beta)
+        aOverBeta.Inverse(&beta)
+        aOverBeta.Mul(&aOverBeta, &a.A0)
+        {{- else }}
+        // β = -1 (CoordExtRoot = -1, or default 0): aOverBeta = -a
+        aOverBeta.Neg(&a.A0)
+        {{- end }}
+        z.A0.SetZero()
+        z.A1.Sqrt(&aOverBeta)
+        return z
     }
 
     var delta, x0, x1, t0, t1 fp.Element
@@ -254,6 +276,35 @@ func (z *E2) Sqrt(a *E2) *E2 {
 // finite fields: Tricks of the Trade" by Michael Scott
 // https://eprint.iacr.org/2020/1497.pdf (Sec. 6.3)
 func (z *E2) Sqrt(x *E2) *E2 {
+	// Scott §6.3 has an unstated precondition x.A1 != 0:
+	// for x.A1 == 0 with x.A0 a non-residue in Fp the inner Fp.Sqrt fails
+	// silently and the final SqrtAndInverse goes through zero, returning
+	// (0, 0) for what is in fact a square in Fp². Its true sqrt is
+	// (0, sqrt(x.A0 / β)) where β = u² is the Fp² QNR. Handle the
+	// purely-real branch explicitly.
+	if x.A1.IsZero() {
+		if x.A0.Legendre() >= 0 {
+			z.A0.Sqrt(&x.A0)
+			z.A1.SetZero()
+			return z
+		}
+		var aOverBeta fp.Element
+		{{- if eq .Curve.G2.CoordExtRoot -5 }}
+		// β = -5: aOverBeta = x.A0 / β = -x.A0 / 5
+		var beta fp.Element
+		beta.SetUint64(5)
+		beta.Neg(&beta)
+		aOverBeta.Inverse(&beta)
+		aOverBeta.Mul(&aOverBeta, &x.A0)
+		{{- else }}
+		// β = -1: aOverBeta = -x.A0
+		aOverBeta.Neg(&x.A0)
+		{{- end }}
+		z.A0.SetZero()
+		z.A1.Sqrt(&aOverBeta)
+		return z
+	}
+
 	var x0, x1 fp.Element
 	x.norm(&x0)
 	x0.Sqrt(&x0)

--- a/internal/generator/tower/template/fq12over6over2/tests/fq2.go.tmpl
+++ b/internal/generator/tower/template/fq12over6over2/tests/fq2.go.tmpl
@@ -366,6 +366,25 @@ func TestE2Ops(t *testing.T) {
 		genA,
 	))
 
+	// Regression test for the silent failure of E2.Sqrt on purely-real
+	// inputs whose Fp coordinate is a non-residue. The Aardal Algorithm 3
+	// and Scott §6.3 formulas both have an unstated precondition that
+	// a.A1 != 0; for x = (a, 0) with a non-QR in Fp the algorithms
+	// silently returned (0, 0) instead of the true sqrt (0, sqrt(a/β))
+	// where β = u² is the Fp² QNR.
+	properties.Property("[{{ toUpper $Name }}] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
+		func(a fp.Element) bool {
+			var x, root, sq E2
+			x.A0.Set(&a)
+			// (a, 0) is always an E2-square for a != 0: either a is QR in
+			// Fp, or a/β is (since β is itself a non-residue).
+			root.Sqrt(&x)
+			sq.Square(&root)
+			return sq.Equal(&x)
+		},
+		genfp,
+	))
+
 	properties.Property("[{{ toUpper $Name }}] cube(cbrt) should leave an element invariant", prop.ForAll(
 		func(a *E2) bool {
 			var b, c, d E2


### PR DESCRIPTION
Adj-Rodríguez Algorithm 8 (ePrint 2012/685, §V-A), Scott §6.3 (ePrint 2020/1497), and Aardal et al. Algorithm 3 (ePrint 2024/1563) all share an unstated precondition that x.A1 != 0. For input (a, 0) with a a non-residue in Fp the Sqrt routines silently return (0, 0) (Aardal / Scott-with-SqrtAndInverse) or a junk root (plain Scott §6.3) instead of the true sqrt.

But (a, 0) is always a square in Fp² for any nonzero a ∈ Fp (Euler: a^((q²-1)/2) = (a^(q-1))^((q+1)/2) = 1). The correct root is (0, sqrt(a/β)) where β = u² is the Fp² QNR; one of {a, a/β} is always a QR in Fp because β is itself a non-residue.

Add a purely-real-input guard at the top of each Sqrt that dispatches on Legendre(a.A0) and emits the correct root. Apply to:

  - internal/generator/field/template/extensions/e2.go.tmpl (covers babybear, goldilocks, koalabear; β-by-name)
  - internal/generator/tower/template/fq12over6over2/fq2.go.tmpl in both the {{if .Curve.Fp.SqrtQ3Mod4}} (Aardal) and {{else}} (Scott §6.3) branches; covers bn254, bls12-381, bls12-377
  - ecc/bls24-315/internal/fptower/e2.go (β = 13, hand-written)
  - ecc/bls24-317/internal/fptower/e2.go (β = -1, hand-written)

secp256r1 was already correct (uses Adj-Rodríguez Algorithm 9, which has the explicit α = -1 branch).

Adds a regression property test in both test templates exercising Sqrt((non-QR, 0)) over fr/fp inputs.

Fixes #844.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] **Template-level regression test** added in `internal/generator/field/template/extensions/e2_test.go.tmpl` and `internal/generator/tower/template/fq12over6over2/tests/fq2.go.tmpl`:
  ```go
  properties.Property("[…] square(sqrt) should be invariant for purely-real inputs", prop.ForAll(
      func(a fp.Element) bool {
          var x, root, sq E2
          x.A0.Set(&a)
          root.Sqrt(&x)
          sq.Square(&root)
          return sq.Equal(&x)
      },
      genfp,
  ))
  ```
  Propagated by `go generate ./...` to `e2_test.go` for all generated curves and field extensions.
- [x] **Empirical probe** on each previously-affected curve before and after the fix. Pre-fix: `Sqrt((non_QR, 0))` returned `(0, 0)` or a junk root (verified by squaring); post-fix: returns a valid non-zero root with `Sqrt(x)² == x`. Tested with non-residues 2 (BLS12-381, BLS24-317), 3 (BN254), 5 (BLS12-377), and 13 (BLS24-315).
- [x] **Existing test suite** passes without regression:
  ```bash
  go test -short ./ecc/bn254/... ./ecc/bls12-377/... ./ecc/bls12-381/... \
                 ./ecc/bls24-315/... ./ecc/bls24-317/... ./ecc/secp256r1/... \
                 ./field/babybear/extensions/... ./field/goldilocks/extensions/... \
                 ./field/koalabear/extensions/...
  ```
  All packages pass; no FAILures across the broader curve test suites.

# How has this been benchmarked?

Ran `BenchmarkE2Sqrt` (`-bench=BenchmarkE2Sqrt -benchmem -count=5`) on each affected curve before and after the fix. The new guard only fires for the purely-real-input edge case (~1/p probability for random inputs), so the existing benchmark — which squares a random `E2` element and Sqrt's it — never exercises the new branch. As expected, hot-path performance is unchanged within run-to-run noise.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (the purely-real-input invariant and the `a/β` derivation are documented in code comments at every fix site)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates (regenerated all generated files via `go generate ./...`; only templates and hand-written non-generated files are direct edits)
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (n/a — this is a leaf-library change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Correctness fix in core Fp² square-root math used by multiple curves; wrong roots would break dependent crypto, though scope is a rare edge case with new property tests.
> 
> **Overview**
> Fixes **Fp² `E2.Sqrt`** when the input is purely real `(a, 0)` and `a` is a **non-residue in Fp**. Scott §6.3 and Aardal Algorithm 3 both assume `A1 ≠ 0`; without that, the old code could return **`(0, 0)`** or a junk root instead of a valid square root in the extension field.
> 
> Each affected implementation now **special-cases `A1 == 0`**: if `Legendre(a) ≥ 0`, take **`(sqrt(a), 0)`**; otherwise take **`(0, sqrt(a/β))`** with **β = u²** (curve-specific: e.g. **−1**, **−5**, **13**, or **3/7/11** for STARK fields). Changes land in **generator templates** (`e2.go.tmpl`, `fq2.go.tmpl`) and **regenerated or hand-written** `e2.go` for BN254, BLS12-377/381, BLS24-315/317, and babybear/goldilocks/koalabear extensions.
> 
> Adds a **property test** that `Sqrt((a,0))` squared equals `(a,0)` for random base-field `a`, propagated through the test templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9afbbb8928765102e71273bd3fbd3264392e4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->