### PR TITLE
fix: plookup check folding

### DIFF
--- a/ecc/bls12-377/fr/permutation/permutation.go
+++ b/ecc/bls12-377/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-377/fr/plookup/plookup_test.go
+++ b/ecc/bls12-377/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bls12-377/fr/plookup/table.go
+++ b/ecc/bls12-377/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bls12-381/fr/permutation/permutation.go
+++ b/ecc/bls12-381/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls12-381/fr/plookup/plookup_test.go
+++ b/ecc/bls12-381/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bls12-381/fr/plookup/table.go
+++ b/ecc/bls12-381/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bls24-315/fr/permutation/permutation.go
+++ b/ecc/bls24-315/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-315/fr/plookup/plookup_test.go
+++ b/ecc/bls24-315/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bls24-315/fr/plookup/table.go
+++ b/ecc/bls24-315/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bls24-317/fr/permutation/permutation.go
+++ b/ecc/bls24-317/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bls24-317/fr/plookup/plookup_test.go
+++ b/ecc/bls24-317/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bls24-317/fr/plookup/table.go
+++ b/ecc/bls24-317/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bn254/fr/permutation/permutation.go
+++ b/ecc/bn254/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bn254/fr/plookup/plookup_test.go
+++ b/ecc/bn254/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bn254/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bn254/fr/plookup/table.go
+++ b/ecc/bn254/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bw6-633/fr/permutation/permutation.go
+++ b/ecc/bw6-633/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-633/fr/plookup/plookup_test.go
+++ b/ecc/bw6-633/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
+	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bw6-633/fr/plookup/table.go
+++ b/ecc/bw6-633/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/ecc/bw6-761/fr/permutation/permutation.go
+++ b/ecc/bw6-761/fr/permutation/permutation.go
@@ -38,16 +38,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -157,17 +157,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -175,7 +175,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -196,7 +196,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -213,19 +213,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -233,10 +233,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -248,7 +248,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -272,17 +272,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -295,13 +295,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -312,12 +312,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -328,7 +328,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/ecc/bw6-761/fr/plookup/plookup_test.go
+++ b/ecc/bw6-761/fr/plookup/plookup_test.go
@@ -6,11 +6,16 @@
 package plookup
 
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -106,6 +111,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/ecc/bw6-761/fr/plookup/table.go
+++ b/ecc/bw6-761/fr/plookup/table.go
@@ -87,15 +87,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -109,8 +109,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -137,16 +137,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -162,6 +154,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -205,6 +211,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 

--- a/internal/generator/permutation/template/permutation.go.tmpl
+++ b/internal/generator/permutation/template/permutation.go.tmpl
@@ -31,16 +31,16 @@ type Proof struct {
 
 	// commitments of t1 & t2, the permuted vectors, and z, the accumulation
 	// polynomial
-	t1, t2, z kzg.Digest
+	ComT1, ComT2, ComZ kzg.Digest
 
 	// commitment to the quotient polynomial
-	q kzg.Digest
+	ComQ kzg.Digest
 
 	// opening proofs of t1, t2, z, q (in that order)
-	batchedProof kzg.BatchOpeningProof
+	BatchedProof kzg.BatchOpeningProof
 
 	// shifted opening proof of z
-	shiftedProof kzg.OpeningProof
+	ShiftedProof kzg.OpeningProof
 }
 
 // evaluateAccumulationPolynomialBitReversed returns the accumulation polynomial in Lagrange basis.
@@ -150,17 +150,17 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	d.FFTInverse(ct2, fft.DIF)
 	utils.BitReverse(ct1)
 	utils.BitReverse(ct2)
-	proof.t1, err = kzg.Commit(ct1, pk)
+	proof.ComT1, err = kzg.Commit(ct1, pk)
 	if err != nil {
 		return proof, err
 	}
-	proof.t2, err = kzg.Commit(ct2, pk)
+	proof.ComT2, err = kzg.Commit(ct2, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive challenge for z
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return proof, err
 	}
@@ -168,7 +168,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	// compute Z and commit it
 	cz := evaluateAccumulationPolynomialBitReversed(t1, t2, epsilon)
 	d.FFTInverse(cz, fft.DIT)
-	proof.z, err = kzg.Commit(cz, pk)
+	proof.ComZ, err = kzg.Commit(cz, pk)
 	if err != nil {
 		return proof, err
 	}
@@ -189,7 +189,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 	lsNum := evaluateSecondPartNumReverse(lz, d)
 
 	// derive challenge used for the folding
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return proof, err
 	}
@@ -206,19 +206,19 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	// get the quotient and commit it
 	d.FFTInverse(lsNum, fft.DIT, fft.OnCoset())
-	proof.q, err = kzg.Commit(lsNum, pk)
+	proof.ComQ, err = kzg.Commit(lsNum, pk)
 	if err != nil {
 		return proof, err
 	}
 
 	// derive the evaluation challenge
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return proof, err
 	}
 
 	// compute the opening proofs
-	proof.batchedProof, err = kzg.BatchOpenSinglePoint(
+	proof.BatchedProof, err = kzg.BatchOpenSinglePoint(
 		[][]fr.Element{
 			ct1,
 			ct2,
@@ -226,10 +226,10 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 			lsNum,
 		},
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
 		eta,
 		hFunc,
@@ -241,7 +241,7 @@ func Prove(pk kzg.ProvingKey, t1, t2 []fr.Element) (Proof, error) {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &d.Generator)
-	proof.shiftedProof, err = kzg.Open(
+	proof.ShiftedProof, err = kzg.Open(
 		cz,
 		shiftedEta,
 		pk,
@@ -265,17 +265,17 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	fs := fiatshamir.NewTranscript(hFunc, "epsilon", "omega", "eta")
 
 	// derive the challenges
-	epsilon, err := deriveRandomness(fs, "epsilon", &proof.t1, &proof.t2)
+	epsilon, err := deriveRandomness(fs, "epsilon", &proof.ComT1, &proof.ComT2)
 	if err != nil {
 		return err
 	}
 
-	omega, err := deriveRandomness(fs, "omega", &proof.z)
+	omega, err := deriveRandomness(fs, "omega", &proof.ComZ)
 	if err != nil {
 		return err
 	}
 
-	eta, err := deriveRandomness(fs, "eta", &proof.q)
+	eta, err := deriveRandomness(fs, "eta", &proof.ComQ)
 	if err != nil {
 		return err
 	}
@@ -288,13 +288,13 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 		Sub(&rhs, &one)
 	a.Sub(&eta, &one)
 	l0.Div(&rhs, &a)
-	rhs.Mul(&rhs, &proof.batchedProof.ClaimedValues[3])
-	a.Sub(&epsilon, &proof.batchedProof.ClaimedValues[1]).
-		Mul(&a, &proof.shiftedProof.ClaimedValue)
-	b.Sub(&epsilon, &proof.batchedProof.ClaimedValues[0]).
-		Mul(&b, &proof.batchedProof.ClaimedValues[2])
+	rhs.Mul(&rhs, &proof.BatchedProof.ClaimedValues[3])
+	a.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[1]).
+		Mul(&a, &proof.ShiftedProof.ClaimedValue)
+	b.Sub(&epsilon, &proof.BatchedProof.ClaimedValues[0]).
+		Mul(&b, &proof.BatchedProof.ClaimedValues[2])
 	lhs.Sub(&a, &b)
-	a.Sub(&proof.batchedProof.ClaimedValues[2], &one).
+	a.Sub(&proof.BatchedProof.ClaimedValues[2], &one).
 		Mul(&a, &l0).
 		Mul(&a, &omega)
 	lhs.Add(&a, &lhs)
@@ -305,12 +305,12 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 	// check the opening proofs
 	err = kzg.BatchVerifySinglePoint(
 		[]kzg.Digest{
-			proof.t1,
-			proof.t2,
-			proof.z,
-			proof.q,
+			proof.ComT1,
+			proof.ComT2,
+			proof.ComZ,
+			proof.ComQ,
 		},
-		&proof.batchedProof,
+		&proof.BatchedProof,
 		eta,
 		hFunc,
 		vk,
@@ -321,7 +321,7 @@ func Verify(vk kzg.VerifyingKey, proof Proof) error {
 
 	var shiftedEta fr.Element
 	shiftedEta.Mul(&eta, &proof.g)
-	err = kzg.Verify(&proof.z, &proof.shiftedProof, shiftedEta, vk)
+	err = kzg.Verify(&proof.ComZ, &proof.ShiftedProof, shiftedEta, vk)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/plookup/template/plookup.test.go.tmpl
+++ b/internal/generator/plookup/template/plookup.test.go.tmpl
@@ -1,9 +1,14 @@
 import (
+	"crypto/sha256"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/permutation"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/kzg"
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
 
 func TestLookupVector(t *testing.T) {
@@ -99,6 +104,85 @@ func TestLookupTable(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLookupTableCommitmentBinding(t *testing.T) {
+
+	kzgSrs, err := kzg.NewSRS(64, big.NewInt(13))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimedTable := make([]fr.Vector, 3)
+	fTable := make([]fr.Vector, 3)
+	for i := range 3 {
+		claimedTable[i] = make(fr.Vector, 8)
+		fTable[i] = make(fr.Vector, 7)
+		for j := range 8 {
+			claimedTable[i][j].SetUint64(uint64(1000 + 17*i + j))
+		}
+		for j := range 7 {
+			fTable[i][j].SetUint64(uint64(i + j + 1))
+		}
+	}
+
+	proof, err := ProveLookupTables(kzgSrs.Pk, fTable, claimedTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbRows := len(proof.fs)
+	comms := make([]*kzg.Digest, 2*nbRows)
+	for i := range nbRows {
+		comms[i] = &proof.fs[i]
+		comms[nbRows+i] = &proof.ts[i]
+	}
+	lambda, err := deriveRandomness(fiatshamir.NewTranscript(sha256.New(), "lambda"), "lambda", comms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nbColumns := int(fft.NewDomain(uint64(max(len(fTable[0])+1, len(claimedTable[0])))).Cardinality)
+	foldedf := foldRows(fTable, nbColumns, lambda)
+	foldedt := make(fr.Vector, nbColumns)
+	copy(foldedt, foldedf)
+	foldedtSorted := make(fr.Vector, nbColumns)
+	copy(foldedtSorted, foldedt)
+	sort.Sort(foldedtSorted)
+
+	proof.permutationProof, err = permutation.Prove(kzgSrs.Pk, foldedt, foldedtSorted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof.foldedProof, err = ProveLookupVector(kzgSrs.Pk, foldedf[:len(foldedf)-1], foldedt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = VerifyLookupTables(kzgSrs.Vk, proof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v, got %v", ErrFoldedCommitment, err)
+	}
+
+	validProof, err := ProveLookupTables(kzgSrs.Pk, fTable, foldRowsAsTableForTest(fTable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validProof.foldedProof.t.Set(&validProof.foldedProof.f)
+	err = VerifyLookupTables(kzgSrs.Vk, validProof)
+	if err != ErrFoldedCommitment {
+		t.Fatalf("expected %v after mutating folded table commitment, got %v", ErrFoldedCommitment, err)
+	}
+}
+
+func foldRowsAsTableForTest(rows []fr.Vector) []fr.Vector {
+	table := make([]fr.Vector, len(rows))
+	for i := range rows {
+		table[i] = make(fr.Vector, len(rows[i])+1)
+		copy(table[i], rows[i])
+		table[i][len(table[i])-1].Set(&rows[i][len(rows[i])-1])
+	}
+	return table
 }
 
 func BenchmarkPlookup(b *testing.B) {

--- a/internal/generator/plookup/template/table.go.tmpl
+++ b/internal/generator/plookup/template/table.go.tmpl
@@ -80,15 +80,15 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	_nbColumns := max(len(f[0])+1, len(t[0]))
 	d := fft.NewDomain(uint64(_nbColumns))
 	nbColumns := d.Cardinality
-	lfs := make([][]fr.Element, nbRows)
-	cfs := make([][]fr.Element, nbRows)
-	lts := make([][]fr.Element, nbRows)
-	cts := make([][]fr.Element, nbRows)
+	lfs := make([]fr.Vector, nbRows)
+	cfs := make([]fr.Vector, nbRows)
+	lts := make([]fr.Vector, nbRows)
+	cts := make([]fr.Vector, nbRows)
 
 	for i := range nbRows {
 
-		cfs[i] = make([]fr.Element, nbColumns)
-		lfs[i] = make([]fr.Element, nbColumns)
+		cfs[i] = make(fr.Vector, nbColumns)
+		lfs[i] = make(fr.Vector, nbColumns)
 		copy(cfs[i], f[i])
 		copy(lfs[i], f[i])
 		for j := len(f[i]); j < int(nbColumns); j++ {
@@ -102,8 +102,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 			return proof, err
 		}
 
-		cts[i] = make([]fr.Element, nbColumns)
-		lts[i] = make([]fr.Element, nbColumns)
+		cts[i] = make(fr.Vector, nbColumns)
+		lts[i] = make(fr.Vector, nbColumns)
 		copy(cts[i], t[i])
 		copy(lts[i], t[i])
 		for j := len(t[i]); j < int(d.Cardinality); j++ {
@@ -130,16 +130,8 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	if err != nil {
 		return proof, err
 	}
-	foldedf := make(fr.Vector, nbColumns)
-	foldedt := make(fr.Vector, nbColumns)
-	for i := range int(nbColumns) {
-		for j := nbRows - 1; j >= 0; j-- {
-			foldedf[i].Mul(&foldedf[i], &lambda).
-				Add(&foldedf[i], &lfs[j][i])
-			foldedt[i].Mul(&foldedt[i], &lambda).
-				Add(&foldedt[i], &lts[j][i])
-		}
-	}
+	foldedf := foldRows(lfs, int(nbColumns), lambda)
+	foldedt := foldRows(lts, int(nbColumns), lambda)
 
 	// generate a proof of permutation of the foldedt and sort(foldedt)
 	foldedtSorted := make(fr.Vector, nbColumns)
@@ -155,6 +147,20 @@ func ProveLookupTables(pk kzg.ProvingKey, f, t []fr.Vector) (ProofLookupTables, 
 	proof.foldedProof, err = ProveLookupVector(pk, foldedf[:len(foldedf)-1], foldedt)
 
 	return proof, err
+}
+
+func foldRows(rows []fr.Vector, nbColumns int, lambda fr.Element) fr.Vector {
+	folded := make(fr.Vector, nbColumns)
+	for i := range nbColumns {
+		for j := len(rows) - 1; j >= 0; j-- {
+			v := rows[j][len(rows[j])-1]
+			if i < len(rows[j]) {
+				v = rows[j][i]
+			}
+			folded[i].Mul(&folded[i], &lambda).Add(&folded[i], &v)
+		}
+	}
+	return folded
 }
 
 // VerifyLookupTables verifies that a ProofLookupTables proof is correct.
@@ -198,6 +204,12 @@ func VerifyLookupTables(vk kzg.VerifyingKey, proof ProofLookupTables) error {
 
 	// check that the folded commitment of the fs correspond to foldedProof.f
 	if !comf.Equal(&proof.foldedProof.f) {
+		return ErrFoldedCommitment
+	}
+	if !comt.Equal(&proof.permutationProof.ComT1) {
+		return ErrFoldedCommitment
+	}
+	if !proof.foldedProof.t.Equal(&proof.permutationProof.ComT2) {
 		return ErrFoldedCommitment
 	}
 


### PR DESCRIPTION
# Description

1. `VerifyLookupTables` recomputes the folded commitments `comf` and `comt` from the public table commitments `proof.fs` and `proof.ts`, but it only checks the folded **f** commitment:

   ```go
   if !comf.Equal(&proof.foldedProof.f) { return ErrFoldedCommitment }
   err = permutation.Verify(vk, proof.permutationProof)
   return VerifyLookupVector(vk, proof.foldedProof)
   ```
   (table.go:210-221)

2. There is **no check** that the folded commitment derived from the public table commitments (`comt`, **unsorted**) matches the **unsorted** folded table commitment inside the permutation proof (`proof.permutationProof.t1`), nor that the **sorted** folded table commitment used by the inner lookup proof (`proof.foldedProof.t`) matches the permutation proof’s sorted commitment (`proof.permutationProof.t2`). The verifier only calls `permutation.Verify` on the proof’s internal commitments, which are independent of `proof.ts`.
3. The prover fully controls `proof.foldedProof` and `proof.permutationProof`, while `proof.ts` are the public commitments to the claimed table. Because these are not tied together, a prover can choose any table `t'` that makes the inner lookup proof succeed and still present unrelated commitments `proof.ts` for a different table `t`.
4. This violates the intended lookup-table binding: the verifier accepts a proof that *f is in t* even when f is only in a different table `t'`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [ ] TestLookupTableCommitmentBinding

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a cryptographic verifier fix: incorrect binding previously allowed accepting lookups against a table different from public commitments. Permutation proof field renames are a breaking API change for direct struct access.
> 
> **Overview**
> Fixes a **soundness gap** in multi-row `VerifyLookupTables`: the verifier now ties public `proof.ts` folding to the inner proofs, not only `proof.fs` to `foldedProof.f`.
> 
> **`VerifyLookupTables`** additionally requires `comt` (folded from `proof.ts`) to match `permutationProof.ComT1` and `foldedProof.t` to match `permutationProof.ComT2`, so permutation and vector lookup cannot use a different table than the committed `ts` rows.
> 
> **Proving path:** row folding is centralized in **`foldRows`**, which pads short rows with the last column value (aligned with commitment padding). **`permutation.Proof`** commitment/opening fields are renamed to exported **`ComT1`**, **`ComT2`**, **`ComZ`**, **`ComQ`**, **`BatchedProof`**, **`ShiftedProof`** for cross-package checks.
> 
> **`TestLookupTableCommitmentBinding`** (per curve) asserts tampered permutation/lookup sub-proofs fail with **`ErrFoldedCommitment`**. Changes are mirrored in generators and all affected ECC `fr` packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4141ddde030ebcf05b53f0986f75a4db0b0230df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->