### PR TITLE
fix: KZG MPC setup consistency

### DIFF
--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bls12-377/kzg/kzg_test.go
+++ b/ecc/bls12-377/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bls12-377/kzg/mpcsetup.go
+++ b/ecc/bls12-377/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bls12-381/kzg/kzg_test.go
+++ b/ecc/bls12-381/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bls12-381/kzg/mpcsetup.go
+++ b/ecc/bls12-381/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bls24-315/kzg/kzg_test.go
+++ b/ecc/bls24-315/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls24-315/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bls24-315/kzg/mpcsetup.go
+++ b/ecc/bls24-315/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bls24-317/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bls24-317/kzg/kzg_test.go
+++ b/ecc/bls24-317/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bls24-317/kzg/mpcsetup.go
+++ b/ecc/bls24-317/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bn254/kzg/kzg_test.go
+++ b/ecc/bn254/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bn254/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bn254/kzg/mpcsetup.go
+++ b/ecc/bn254/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bw6-633/kzg/kzg_test.go
+++ b/ecc/bw6-633/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bw6-633/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bw6-633/kzg/mpcsetup.go
+++ b/ecc/bw6-633/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -93,7 +93,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/ecc/bw6-761/kzg/kzg_test.go
+++ b/ecc/bw6-761/kzg/kzg_test.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/mpcsetup"
 	"github.com/consensys/gnark-crypto/utils"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
@@ -78,6 +79,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/ecc/bw6-761/kzg/mpcsetup.go
+++ b/ecc/bw6-761/kzg/mpcsetup.go
@@ -119,6 +119,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -129,13 +132,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -85,7 +85,7 @@ func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
 	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
 
 	_, _, g1, _ := curve.Generators()
-	for i := 1; i < len(next.srs.Pk.G1); i++ {
+	for i := 2; i < len(next.srs.Pk.G1); i++ {
 		next.srs.Pk.G1[i] = g1
 	}
 

--- a/internal/generator/kzg/template/kzg.test.go.tmpl
+++ b/internal/generator/kzg/template/kzg.test.go.tmpl
@@ -13,6 +13,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr/fft"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/mpcsetup"
 
 	"github.com/consensys/gnark-crypto/utils/testutils"
 )
@@ -70,6 +71,25 @@ func TestMpcSetup(t *testing.T) {
 		require.NoError(t, prev.Verify(&p))
 		prev = p
 	}
+}
+
+func TestMpcSetupRejectsInconsistentG1Monomials(t *testing.T) {
+	prev := InitializeSetup(srsSize)
+	next := InitializeSetup(srsSize)
+
+	var contribution fr.Element
+	contribution.SetUint64(2)
+	challenge := prev.hash()
+	next.challenge = challenge
+	next.proof = mpcsetup.UpdateValues(&contribution, append([]byte("KZG Setup"), challenge...), 0, &next.srs.Vk.G2[1])
+	mpcsetup.UpdateMonomialsG1(next.srs.Pk.G1, &contribution)
+
+	_, _, g1, _ := curve.Generators()
+	for i := 1; i < len(next.srs.Pk.G1); i++ {
+		next.srs.Pk.G1[i] = g1
+	}
+
+	require.Error(t, prev.Verify(&next))
 }
 
 func TestToLagrangeG1(t *testing.T) {

--- a/internal/generator/kzg/template/mpcsetup.go.tmpl
+++ b/internal/generator/kzg/template/mpcsetup.go.tmpl
@@ -112,6 +112,9 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	if len(s.srs.Pk.G1) != len(next.srs.Pk.G1) {
 		return errors.New("different domain sizes")
 	}
+	if len(next.srs.Pk.G1) < 2 {
+		return errors.New("domain size must be at least 2")
+	}
 
 	if !next.srs.Vk.G2[1].IsInSubGroup() {
 		return errors.New("[x]₂ representation not in subgroup")
@@ -122,13 +125,16 @@ func (s *MpcSetup) Verify(next *MpcSetup) error {
 	}
 
 	if err := next.proof.Verify(append([]byte("KZG Setup"), challenge...), 0, mpcsetup.ValueUpdate{
+		Previous: s.srs.Pk.G1[1],
+		Next:     next.srs.Pk.G1[1],
+	}, mpcsetup.ValueUpdate{
 		Previous: s.srs.Vk.G2[1],
 		Next:     next.srs.Vk.G2[1],
 	}); err != nil {
 		return err
 	}
 
-	return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
+	return mpcsetup.SameRatioMany(next.srs.Pk.G1, next.srs.Vk.G2[:])
 }
 
 func (s *MpcSetup) Seal(beaconChallenge []byte) SRS {


### PR DESCRIPTION
# Description

1) **Invariant established by contribution path:** `Contribute` scales **both** `Vk.G2[1]` and all `Pk.G1` monomials with the same secret contribution.

   ```go
   s.proof = mpcsetup.UpdateValues(..., &s.srs.Vk.G2[1])
   mpcsetup.UpdateMonomialsG1(s.srs.Pk.G1, &contribution)
   ```
   (file: `ecc/bn254/kzg/mpcsetup.go`)

2) **Verification only checks the G2 update proof:** `Verify` checks subgroup membership for `next.srs.Pk.G1` but never proves they were updated by the same contribution. It only verifies the update proof against `Vk.G2[1]`, then calls `SameRatioMany` on the **previous** SRS (`s`), not `next`.

   ```go
   if err := next.proof.Verify(... ValueUpdate{
       Previous: s.srs.Vk.G2[1],
       Next:     next.srs.Vk.G2[1],
   }); err != nil { ... }

   return mpcsetup.SameRatioMany(s.srs.Pk.G1, s.srs.Vk.G2[:])
   ```
   (file: `ecc/bn254/kzg/mpcsetup.go`)

3) **Attacker-controlled inputs reach this check:** transcripts are deserialized via `MpcSetup.ReadFrom`, which populates `next.srs.Pk.G1` and `next.srs.Vk.G2[1]` from the stream without enforcing the G1/G2 consistency invariant.

   ```go
   s.srs.Pk.G1 = make([]curve.G1Affine, N)
   for i := range N - 1 { dec.Decode(&s.srs.Pk.G1[i+1]) }
   dec.Decode(&s.srs.Vk.G2[1])
   ```
   (file: `ecc/bn254/kzg/mpcsetup.go`)

4) **Broken property:** a malicious participant can publish a transcript where `Pk.G1` is replaced with arbitrary subgroup points while keeping a valid G2 update proof. `Verify` accepts the transcript, yet the SRS no longer represents a single secret $\alpha$, so KZG’s binding and completeness guarantees no longer apply.


----

Though the impact is that the generated SRS is malformed. In case of at least one honest contribution we still cannot have proof forgery.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [x] TestMpcSetupRejectsInconsistentG1Monomials

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes trusted SRS transcript verification for KZG MPC setup; incorrect logic could accept malformed SRS or reject valid ceremonies.
> 
> **Overview**
> **Tightens KZG MPC setup verification** so a deserialized contribution cannot pass checks with a valid G2 update proof but arbitrary `Pk.G1` monomials.
> 
> In `MpcSetup.Verify`, the update proof now covers **`[x]₁` as well as `[x]₂`** (`ValueUpdate` on `Pk.G1[1]` and `Vk.G2[1]`). **`SameRatioMany` is run on the next transcript’s SRS** (`next.srs.Pk.G1` / `next.srs.Vk.G2`) instead of the previous state, and contributions with fewer than two G1 points are rejected.
> 
> The same logic is applied across all supported curves via **`internal/generator/kzg` templates**, with **`TestMpcSetupRejectsInconsistentG1Monomials`** asserting that tampered higher monomials fail verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f895fb0760856b1dbe54508f24fb8e98c1a8aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->