### PR TITLE
fix: subgroup membership test in shplonk

### DIFF
--- a/ecc/bls12-377/fflonk/fflonk_test.go
+++ b/ecc/bls12-377/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bls12377.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bls12-377/fflonk/marshal.go
+++ b/ecc/bls12-377/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls12377.NoSubgroupChecks())

--- a/ecc/bls12-377/fflonk/marshal.go
+++ b/ecc/bls12-377/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls12377.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls12377.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls12377.Decoder)) (int64, error) {
+
+	dec := bls12377.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls12377.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls12377.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls12377.Encoder)) (int64, error) {
+
+	enc := bls12377.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bls12-377/shplonk/marshal.go
+++ b/ecc/bls12-377/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls12377.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls12377.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls12377.Decoder)) (int64, error) {
+
+	dec := bls12377.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls12377.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls12377.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls12377.Encoder)) (int64, error) {
+
+	enc := bls12377.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bls12-377/shplonk/marshal.go
+++ b/ecc/bls12-377/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls12377.NoSubgroupChecks())

--- a/ecc/bls12-377/shplonk/shplonk.go
+++ b/ecc/bls12-377/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bls12377.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bls12377.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bls12-377/shplonk/shplonk_test.go
+++ b/ecc/bls12-377/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bls12-381/fflonk/fflonk_test.go
+++ b/ecc/bls12-381/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bls12381.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bls12-381/fflonk/marshal.go
+++ b/ecc/bls12-381/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls12381.NoSubgroupChecks())

--- a/ecc/bls12-381/fflonk/marshal.go
+++ b/ecc/bls12-381/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls12381.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls12381.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls12381.Decoder)) (int64, error) {
+
+	dec := bls12381.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls12381.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls12381.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls12381.Encoder)) (int64, error) {
+
+	enc := bls12381.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bls12-381/shplonk/marshal.go
+++ b/ecc/bls12-381/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls12381.NoSubgroupChecks())

--- a/ecc/bls12-381/shplonk/marshal.go
+++ b/ecc/bls12-381/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls12381.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls12381.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls12381.Decoder)) (int64, error) {
+
+	dec := bls12381.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls12381.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls12381.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls12381.Encoder)) (int64, error) {
+
+	enc := bls12381.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bls12-381/shplonk/shplonk.go
+++ b/ecc/bls12-381/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bls12381.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bls12381.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bls12-381/shplonk/shplonk_test.go
+++ b/ecc/bls12-381/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bls24-315/fflonk/fflonk_test.go
+++ b/ecc/bls24-315/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bls24315.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bls24-315/fflonk/marshal.go
+++ b/ecc/bls24-315/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls24315.NoSubgroupChecks())

--- a/ecc/bls24-315/fflonk/marshal.go
+++ b/ecc/bls24-315/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls24315.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls24315.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls24315.Decoder)) (int64, error) {
+
+	dec := bls24315.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls24315.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls24315.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls24315.Encoder)) (int64, error) {
+
+	enc := bls24315.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bls24-315/shplonk/marshal.go
+++ b/ecc/bls24-315/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls24315.NoSubgroupChecks())

--- a/ecc/bls24-315/shplonk/marshal.go
+++ b/ecc/bls24-315/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls24315.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls24315.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls24315.Decoder)) (int64, error) {
+
+	dec := bls24315.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls24315.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls24315.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls24315.Encoder)) (int64, error) {
+
+	enc := bls24315.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bls24-315/shplonk/shplonk.go
+++ b/ecc/bls24-315/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bls24315.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bls24315.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bls24-315/shplonk/shplonk_test.go
+++ b/ecc/bls24-315/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bls24-317/fflonk/fflonk_test.go
+++ b/ecc/bls24-317/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bls24317 "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bls24317.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bls24-317/fflonk/marshal.go
+++ b/ecc/bls24-317/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls24317.NoSubgroupChecks())

--- a/ecc/bls24-317/fflonk/marshal.go
+++ b/ecc/bls24-317/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls24317.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls24317.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls24317.Decoder)) (int64, error) {
+
+	dec := bls24317.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls24317.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls24317.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls24317.Encoder)) (int64, error) {
+
+	enc := bls24317.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bls24-317/shplonk/marshal.go
+++ b/ecc/bls24-317/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bls24317.NoSubgroupChecks())

--- a/ecc/bls24-317/shplonk/marshal.go
+++ b/ecc/bls24-317/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bls24317.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bls24317.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bls24317.Decoder)) (int64, error) {
+
+	dec := bls24317.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bls24317.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bls24317.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bls24317.Encoder)) (int64, error) {
+
+	enc := bls24317.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bls24-317/shplonk/shplonk.go
+++ b/ecc/bls24-317/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bls24317.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bls24317.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bls24-317/shplonk/shplonk_test.go
+++ b/ecc/bls24-317/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bn254/fflonk/fflonk_test.go
+++ b/ecc/bn254/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bn254.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bn254/fflonk/marshal.go
+++ b/ecc/bn254/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bn254.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bn254.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bn254.Decoder)) (int64, error) {
+
+	dec := bn254.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bn254.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bn254.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bn254.Encoder)) (int64, error) {
+
+	enc := bn254.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bn254/fflonk/marshal.go
+++ b/ecc/bn254/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bn254.NoSubgroupChecks())

--- a/ecc/bn254/shplonk/marshal.go
+++ b/ecc/bn254/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bn254.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bn254.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bn254.Decoder)) (int64, error) {
+
+	dec := bn254.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bn254.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bn254.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bn254.Encoder)) (int64, error) {
+
+	enc := bn254.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bn254/shplonk/marshal.go
+++ b/ecc/bn254/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bn254.NoSubgroupChecks())

--- a/ecc/bn254/shplonk/shplonk.go
+++ b/ecc/bn254/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bn254.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bn254.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bn254/shplonk/shplonk_test.go
+++ b/ecc/bn254/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bw6-633/fflonk/fflonk_test.go
+++ b/ecc/bw6-633/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bw6633 "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bw6633.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bw6-633/fflonk/marshal.go
+++ b/ecc/bw6-633/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bw6633.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bw6633.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bw6633.Decoder)) (int64, error) {
+
+	dec := bw6633.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bw6633.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bw6633.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bw6633.Encoder)) (int64, error) {
+
+	enc := bw6633.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bw6-633/fflonk/marshal.go
+++ b/ecc/bw6-633/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bw6633.NoSubgroupChecks())

--- a/ecc/bw6-633/shplonk/marshal.go
+++ b/ecc/bw6-633/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bw6633.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bw6633.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bw6633.Decoder)) (int64, error) {
+
+	dec := bw6633.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bw6633.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bw6633.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bw6633.Encoder)) (int64, error) {
+
+	enc := bw6633.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bw6-633/shplonk/marshal.go
+++ b/ecc/bw6-633/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bw6633.NoSubgroupChecks())

--- a/ecc/bw6-633/shplonk/shplonk.go
+++ b/ecc/bw6-633/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bw6633.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bw6633.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bw6-633/shplonk/shplonk_test.go
+++ b/ecc/bw6-633/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/ecc/bw6-761/fflonk/fflonk_test.go
+++ b/ecc/bw6-761/fflonk/fflonk_test.go
@@ -6,13 +6,16 @@
 package fflonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +27,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := bw6761.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/ecc/bw6-761/fflonk/marshal.go
+++ b/ecc/bw6-761/fflonk/marshal.go
@@ -14,13 +14,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bw6761.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bw6761.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bw6761.Decoder)) (int64, error) {
+
+	dec := bw6761.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -35,7 +47,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bw6761.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bw6761.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bw6761.Encoder)) (int64, error) {
+
+	enc := bw6761.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/ecc/bw6-761/fflonk/marshal.go
+++ b/ecc/bw6-761/fflonk/marshal.go
@@ -17,8 +17,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bw6761.NoSubgroupChecks())

--- a/ecc/bw6-761/shplonk/marshal.go
+++ b/ecc/bw6-761/shplonk/marshal.go
@@ -13,7 +13,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := bw6761.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, bw6761.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*bw6761.Decoder)) (int64, error) {
+
+	dec := bw6761.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -33,7 +45,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := bw6761.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, bw6761.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*bw6761.Encoder)) (int64, error) {
+
+	enc := bw6761.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/ecc/bw6-761/shplonk/marshal.go
+++ b/ecc/bw6-761/shplonk/marshal.go
@@ -16,8 +16,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, bw6761.NoSubgroupChecks())

--- a/ecc/bw6-761/shplonk/shplonk.go
+++ b/ecc/bw6-761/shplonk/shplonk.go
@@ -22,6 +22,7 @@ var (
 	ErrVerifyOpeningProof     = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -183,6 +184,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]bw6761.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !bw6761.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/ecc/bw6-761/shplonk/shplonk_test.go
+++ b/ecc/bw6-761/shplonk/shplonk_test.go
@@ -6,6 +6,7 @@
 package shplonk
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"math/rand"
@@ -50,6 +51,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {

--- a/internal/generator/fflonk/template/fflonk.test.go.tmpl
+++ b/internal/generator/fflonk/template/fflonk.test.go.tmpl
@@ -1,11 +1,14 @@
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/fr"
 	"github.com/consensys/gnark-crypto/ecc/{{ .Name }}/kzg"
+	"github.com/consensys/gnark-crypto/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,6 +20,44 @@ func init() {
 	const srsSize = 600
 	bAlpha = new(big.Int).SetInt64(42) // randomise ?
 	testSrs, _ = kzg.NewSRS(ecc.NextPowerOfTwo(srsSize), bAlpha)
+}
+
+func TestSerialization(t *testing.T) {
+
+	_, _, g, _ := {{ .CurvePackage }}.Generators()
+	var proof OpeningProof
+	proof.SOpeningProof.W.Set(&g)
+	proof.SOpeningProof.WPrime.Set(&g)
+	proof.SOpeningProof.ClaimedValues = make([][]fr.Element, 3)
+	for i := range proof.SOpeningProof.ClaimedValues {
+		proof.SOpeningProof.ClaimedValues[i] = make([]fr.Element, i+2)
+		for j := range proof.SOpeningProof.ClaimedValues[i] {
+			proof.SOpeningProof.ClaimedValues[i][j].MustSetRandom()
+		}
+	}
+	proof.ClaimedValues = make([][][]fr.Element, 2)
+	for i := range proof.ClaimedValues {
+		proof.ClaimedValues[i] = make([][]fr.Element, 3)
+		for j := range proof.ClaimedValues[i] {
+			proof.ClaimedValues[i][j] = make([]fr.Element, i+j+1)
+			for k := range proof.ClaimedValues[i][j] {
+				proof.ClaimedValues[i][j][k].MustSetRandom()
+			}
+		}
+	}
+
+	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestFflonk(t *testing.T) {

--- a/internal/generator/fflonk/template/marshal.go.tmpl
+++ b/internal/generator/fflonk/template/marshal.go.tmpl
@@ -10,8 +10,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, {{ .CurvePackage }}.NoSubgroupChecks())

--- a/internal/generator/fflonk/template/marshal.go.tmpl
+++ b/internal/generator/fflonk/template/marshal.go.tmpl
@@ -7,13 +7,25 @@ import (
 // ReadFrom decodes OpeningProof data from reader.
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := {{ .CurvePackage }}.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, {{ .CurvePackage }}.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*{{ .CurvePackage }}.Decoder)) (int64, error) {
+
+	dec := {{ .CurvePackage }}.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.SOpeningProof.W,
 		&proof.SOpeningProof.WPrime,
-		proof.SOpeningProof.ClaimedValues,
-		proof.ClaimedValues,
+		&proof.SOpeningProof.ClaimedValues,
+		&proof.ClaimedValues,
 	}
 
 	for _, v := range toDecode {
@@ -28,7 +40,18 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 // WriteTo writes binary encoding of OpeningProof.
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := {{ .CurvePackage }}.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, {{ .CurvePackage }}.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*{{ .CurvePackage }}.Encoder)) (int64, error) {
+
+	enc := {{ .CurvePackage }}.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.SOpeningProof.W,

--- a/internal/generator/shplonk/template/marshal.go.tmpl
+++ b/internal/generator/shplonk/template/marshal.go.tmpl
@@ -9,8 +9,9 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	return proof.readFrom(r)
 }
 
-// UnsafeReadFrom decodes OpeningProof data from reader without checking
-// that points are in the correct subgroup.
+// UnsafeReadFrom decodes OpeningProof data from reader without validating
+// decoded points. Callers must validate the proof before use, for example with
+// BatchVerify.
 func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
 
 	return proof.readFrom(r, {{ .CurvePackage }}.NoSubgroupChecks())

--- a/internal/generator/shplonk/template/marshal.go.tmpl
+++ b/internal/generator/shplonk/template/marshal.go.tmpl
@@ -6,7 +6,19 @@ import (
 
 func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 
-	dec := {{ .CurvePackage }}.NewDecoder(r)
+	return proof.readFrom(r)
+}
+
+// UnsafeReadFrom decodes OpeningProof data from reader without checking
+// that points are in the correct subgroup.
+func (proof *OpeningProof) UnsafeReadFrom(r io.Reader) (int64, error) {
+
+	return proof.readFrom(r, {{ .CurvePackage }}.NoSubgroupChecks())
+}
+
+func (proof *OpeningProof) readFrom(r io.Reader, options ...func(*{{ .CurvePackage }}.Decoder)) (int64, error) {
+
+	dec := {{ .CurvePackage }}.NewDecoder(r, options...)
 
 	toDecode := []any{
 		&proof.W,
@@ -21,12 +33,23 @@ func (proof *OpeningProof) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	return dec.BytesRead(), nil
-}   
+}
 
 // WriteTo writes binary encoding of a OpeningProof
 func (proof *OpeningProof) WriteTo(w io.Writer) (int64, error) {
 
-	enc := {{ .CurvePackage }}.NewEncoder(w)
+	return proof.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of OpeningProof to w without point compression.
+func (proof *OpeningProof) WriteRawTo(w io.Writer) (int64, error) {
+
+	return proof.writeTo(w, {{ .CurvePackage }}.RawEncoding())
+}
+
+func (proof *OpeningProof) writeTo(w io.Writer, options ...func(*{{ .CurvePackage }}.Encoder)) (int64, error) {
+
+	enc := {{ .CurvePackage }}.NewEncoder(w, options...)
 
 	toEncode := []any{
 		&proof.W,

--- a/internal/generator/shplonk/template/shplonk.go.tmpl
+++ b/internal/generator/shplonk/template/shplonk.go.tmpl
@@ -15,6 +15,7 @@ var (
 	ErrVerifyOpeningProof    = errors.New("can't verify batch opening proof")
 	ErrInvalidNumberOfDigests = errors.New("number of digests should be equal to the number of polynomials")
 	ErrPairingCheck           = errors.New("pairing product is not 1")
+	ErrNotInSubgroup          = errors.New("proof or digest is not in the correct subgroup")
 )
 
 // OpeningProof KZG proof for opening (fᵢ)_{i} at a different points (xᵢ)_{i}.
@@ -176,6 +177,13 @@ func BatchVerify(proof OpeningProof, digests []kzg.Digest, points [][]fr.Element
 	}
 	if len(digests) != len(points) {
 		return ErrInvalidNumberOfPoints
+	}
+
+	pointsToCheck := make([]{{ .CurvePackage }}.G1Affine, 0, len(digests)+2)
+	pointsToCheck = append(pointsToCheck, digests...)
+	pointsToCheck = append(pointsToCheck, proof.W, proof.WPrime)
+	if !{{ .CurvePackage }}.IsInSubGroupBatchG1(pointsToCheck) {
+		return ErrNotInSubgroup
 	}
 
 	// transcript

--- a/internal/generator/shplonk/template/shplonk.test.go.tmpl
+++ b/internal/generator/shplonk/template/shplonk.test.go.tmpl
@@ -1,4 +1,5 @@
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
@@ -44,6 +45,17 @@ func TestSerialization(t *testing.T) {
 	}
 
 	t.Run("opening proof round trip", testutils.SerializationRoundTrip(&proof))
+	t.Run("opening proof raw round trip", testutils.SerializationRoundTripRaw(&proof))
+	t.Run("opening proof unsafe raw round trip", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := proof.WriteRawTo(&buf)
+		require.NoError(t, err)
+
+		var reconstructed OpeningProof
+		_, err = reconstructed.UnsafeReadFrom(&buf)
+		require.NoError(t, err)
+		require.Equal(t, proof, reconstructed)
+	})
 }
 
 func TestOpening(t *testing.T) {


### PR DESCRIPTION
# Description

Small issue where in Shplonk we didn't check inputs to be in subgroup.

Now, I also added unsafe reader to deserialize corresponding proofs without doing explicit subgroup checks (which well be deferred to Verify method). But I kept the old safe way as well (which is the default anyway).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes shplonk proof verification to enforce G1 subgroup membership on attacker-controlled points—a security-sensitive fix; `UnsafeReadFrom` shifts subgroup checks to callers and misuse could reintroduce invalid-point acceptance.
> 
> **Overview**
> **Shplonk `BatchVerify`** now rejects proofs when any polynomial digest or proof G1 points (`W`, `WPrime`) fail a batched subgroup check, returning **`ErrNotInSubgroup`** before the Fiat–Shamir / pairing path runs.
> 
> Across **fflonk** and **shplonk** on every supported curve, **`OpeningProof`** marshaling is extended with **`UnsafeReadFrom`** (decode via `NoSubgroupChecks()`, documented for use only when verification will follow) and **`WriteRawTo`** (uncompressed points). Shared **`readFrom` / `writeTo`** helpers take encoder/decoder options; decoding nested **`ClaimedValues`** slices now passes pointers so unmarshaling populates the proof correctly.
> 
> Generator templates and tests add **`TestSerialization`** (standard, raw, and unsafe raw round-trips) plus extra shplonk serialization subtests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98ffcf5210a307630efde9e3e911b80fff47364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->