### PR TITLE
fix: prevent small subgroup public keys

### DIFF
--- a/ecc/bls12-377/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-377/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bls12-377/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls12-377/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bls12-377/twistededwards/eddsa/marshal.go
+++ b/ecc/bls12-377/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bls12-381/bandersnatch/eddsa/eddsa_test.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bls12-381/bandersnatch/eddsa/marshal.go
+++ b/ecc/bls12-381/bandersnatch/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bls12-381/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls12-381/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bls12-381/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls12-381/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bls12-381/twistededwards/eddsa/marshal.go
+++ b/ecc/bls12-381/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bls24-315/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-315/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bls24-315/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls24-315/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bls24-315/twistededwards/eddsa/marshal.go
+++ b/ecc/bls24-315/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bls24-317/twistededwards/eddsa/eddsa.go
+++ b/ecc/bls24-317/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bls24-317/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bls24-317/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bls24-317/twistededwards/eddsa/marshal.go
+++ b/ecc/bls24-317/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bn254/twistededwards/eddsa/eddsa.go
+++ b/ecc/bn254/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -129,8 +141,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -185,9 +198,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bn254/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bn254/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bn254/twistededwards/eddsa/marshal.go
+++ b/ecc/bn254/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bw6-633/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-633/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -138,8 +150,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -194,9 +207,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bw6-633/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bw6-633/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bw6-633/twistededwards/eddsa/marshal.go
+++ b/ecc/bw6-633/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/ecc/bw6-761/twistededwards/eddsa/eddsa.go
+++ b/ecc/bw6-761/twistededwards/eddsa/eddsa.go
@@ -19,6 +19,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -46,6 +48,16 @@ type PrivateKey struct {
 type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
+}
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
 }
 
 // GenerateKey generates a public and private key pair.
@@ -138,8 +150,9 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -194,9 +207,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/ecc/bw6-761/twistededwards/eddsa/eddsa_test.go
+++ b/ecc/bw6-761/twistededwards/eddsa/eddsa_test.go
@@ -128,6 +128,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/ecc/bw6-761/twistededwards/eddsa/marshal.go
+++ b/ecc/bw6-761/twistededwards/eddsa/marshal.go
@@ -22,6 +22,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -51,8 +63,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -80,17 +92,38 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -158,8 +191,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr

--- a/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/eddsa.go.tmpl
@@ -12,6 +12,8 @@ import (
 )
 
 var errNotOnCurve = errors.New("point not on curve")
+var errNotInSubgroup = errors.New("point not in subgroup")
+var errIdentity = errors.New("identity point")
 var errHashNeeded = errors.New("hFunc cannot be nil. We need a hash for Fiat-Shamir")
 
 const (
@@ -40,6 +42,17 @@ type Signature struct {
 	R twistededwards.PointAffine
 	S [sizeFr]byte
 }
+
+func validatePublicKeyPoint(p *twistededwards.PointAffine) error {
+	if p.IsZero() {
+		return errIdentity
+	}
+	if !p.IsInSubGroup() {
+		return errNotInSubgroup
+	}
+	return nil
+}
+
 
 
 // GenerateKey generates a public and private key pair.
@@ -152,13 +165,14 @@ func (privKey *PrivateKey) Sign(message []byte, hFunc hash.Hash) ([]byte, error)
 	// blindingFactorBigInt = h(randomness_source||message)[:sizeFr]
 	var blindingFactorBigInt big.Int
 
-// randSrc = privKey.randSrc || msg (-> message = MSB message .. LSB message)
+	// randSrc = privKey.randSrc || msg (-> message = MSB message .. LSB message)
 	randSrc := make([]byte, 32+len(message))
 	copy(randSrc, privKey.randSrc[:])
 	copy(randSrc[32:], message)
 
-	// randBytes = H(randSrc)
-	blindingFactorBytes := blake2b.Sum512(randSrc[:]) // TODO ensures that the hash used to build the key and the one used here is the same
+	// randBytes = H(randSrc). PrivateKey.SetBytes checks the serialized
+	// scalar pruning and public-key binding before randSrc is used here.
+	blindingFactorBytes := blake2b.Sum512(randSrc[:])
 	blindingFactorBigInt.SetBytes(blindingFactorBytes[:sizeFr])
 
 	// compute R = randScalar*Base
@@ -213,9 +227,9 @@ func (pub *PublicKey) Verify(sigBin, message []byte, hFunc hash.Hash) (bool, err
 
 	curveParams := twistededwards.GetEdwardsCurve()
 
-	// verify that pubKey and R are on the curve
-	if !pub.A.IsOnCurve() {
-		return false, errNotOnCurve
+	// verify that pubKey is a non-identity point in the prime-order subgroup
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return false, err
 	}
 
 	// Deserialize the signature

--- a/internal/generator/edwards/eddsa/template/eddsa.test.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/eddsa.test.go.tmpl
@@ -122,6 +122,101 @@ func TestNoZeros(t *testing.T) {
 	})
 }
 
+func TestRejectSmallSubgroupForgery(t *testing.T) {
+	cp := twistededwards.GetEdwardsCurve()
+
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+	if !pub.A.IsOnCurve() {
+		t.Fatal("test public key should be on curve")
+	}
+	if pub.A.IsInSubGroup() {
+		t.Fatal("test public key should not be in the prime-order subgroup")
+	}
+
+	var sig Signature
+	sig.R.ScalarMultiplication(&cp.Base, big.NewInt(1))
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	verified, err := pub.Verify(sig.Bytes(), []byte("forged message"), sha256.New())
+	if err == nil && verified {
+		t.Fatal("Verify accepted a forged signature under a small-subgroup public key")
+	}
+}
+
+func TestRejectSmallSubgroupEncoding(t *testing.T) {
+	var pub PublicKey
+	pub.A.Y.SetOne().Neg(&pub.A.Y)
+
+	var decodedPub PublicKey
+	if _, err := decodedPub.SetBytes(pub.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup public key")
+	}
+
+	var sig Signature
+	sig.R.Set(&pub.A)
+	big.NewInt(1).FillBytes(sig.S[:])
+
+	var decodedSig Signature
+	if _, err := decodedSig.SetBytes(sig.Bytes()); err == nil {
+		t.Fatal("SetBytes accepted a small-subgroup signature R")
+	}
+}
+
+func TestPrivateKeyDeserializationChecksPublicKeyAndScalar(t *testing.T) {
+	src := rand.NewSource(0)
+	r := rand.New(src) //#nosec G404 weak rng is fine here
+
+	privKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPrivKey, err := GenerateKey(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKeyBin := privKey.Bytes()
+
+	t.Run("public_key_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		copy(tampered[:sizeFr], otherPrivKey.PublicKey.Bytes())
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("scalar_mismatch", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[sizeFr+1] ^= 1
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errPublicKeyMismatch {
+			t.Fatalf("expected errPublicKeyMismatch, got %v", err)
+		}
+	})
+
+	t.Run("invalid_scalar_pruning", func(t *testing.T) {
+		tampered := append([]byte(nil), privKeyBin...)
+		tampered[2*sizeFr-1] |= 1
+
+		var bScalar big.Int
+		bScalar.SetBytes(tampered[sizeFr : 2*sizeFr])
+		cp := twistededwards.GetEdwardsCurve()
+		var pub twistededwards.PointAffine
+		pub.ScalarMultiplication(&cp.Base, &bScalar)
+		pubBin := pub.Bytes()
+		copy(tampered[:sizeFr], pubBin[:])
+
+		var decoded PrivateKey
+		if _, err := decoded.SetBytes(tampered); err != errInvalidScalar {
+			t.Fatalf("expected errInvalidScalar, got %v", err)
+		}
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	src := rand.NewSource(0)

--- a/internal/generator/edwards/eddsa/template/marshal.go.tmpl
+++ b/internal/generator/edwards/eddsa/template/marshal.go.tmpl
@@ -14,6 +14,18 @@ var errWrongSize = errors.New("wrong size buffer")
 var errSBiggerThanRMod = errors.New("s >= r_mod")
 var errRBiggerThanPMod = errors.New("r >= p_mod")
 var errZero = errors.New("zero value")
+var errPublicKeyMismatch = errors.New("public key does not match scalar")
+var errInvalidScalar = errors.New("invalid scalar")
+
+func validatePrivateScalar(scalar *[sizeFr]byte) error {
+	if scalar[sizeFr-1]&0x07 != 0 {
+		return errInvalidScalar
+	}
+	if scalar[0]&0x80 != 0 || scalar[0]&0x40 == 0 {
+		return errInvalidScalar
+	}
+	return nil
+}
 
 // Bytes returns the binary representation of the public key
 // follows https://tools.ietf.org/html/rfc8032#section-3.1
@@ -43,8 +55,8 @@ func (pk *PublicKey) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !pk.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pk.A); err != nil {
+		return n, err
 	}
 	return n, nil
 }
@@ -72,17 +84,39 @@ func (privKey *PrivateKey) SetBytes(buf []byte) (int, error) {
 	if len(buf) < sizePrivateKey {
 		return n, io.ErrShortBuffer
 	}
-	if _, err := privKey.PublicKey.A.SetBytes(buf[:sizeFr]); err != nil {
+	var pub PublicKey
+	if _, err := pub.A.SetBytes(buf[:sizeFr]); err != nil {
 		return 0, err
 	}
 	n += sizeFr
-	if !privKey.PublicKey.A.IsOnCurve() {
-		return n, errNotOnCurve
+	if err := validatePublicKeyPoint(&pub.A); err != nil {
+		return n, err
 	}
-	subtle.ConstantTimeCopy(1, privKey.scalar[:], buf[sizeFr:2*sizeFr])
+
+	var scalar [sizeFr]byte
+	subtle.ConstantTimeCopy(1, scalar[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr
-	subtle.ConstantTimeCopy(1, privKey.randSrc[:], buf[2*sizeFr:])
-	n += sizeFr
+	if err := validatePrivateScalar(&scalar); err != nil {
+		return n, err
+	}
+
+
+	var bScalar big.Int
+	bScalar.SetBytes(scalar[:])
+	curveParams := twistededwards.GetEdwardsCurve()
+	var expectedPub twistededwards.PointAffine
+	expectedPub.ScalarMultiplication(&curveParams.Base, &bScalar)
+	if !expectedPub.Equal(&pub.A) {
+		return n, errPublicKeyMismatch
+	}
+
+	var randSrc [32]byte
+	subtle.ConstantTimeCopy(1, randSrc[:], buf[2*sizeFr:])
+	n += 32
+
+	privKey.PublicKey = pub
+	privKey.scalar = scalar
+	privKey.randSrc = randSrc
 	return n, nil
 }
 
@@ -149,8 +183,8 @@ func (sig *Signature) SetBytes(buf []byte) (int, error) {
 		return 0, err
 	}
 	n += sizeFr
-	if !sig.R.IsOnCurve() {
-		return n, errNotOnCurve
+	if !sig.R.IsInSubGroup() {
+		return n, errNotInSubgroup
 	}
 	subtle.ConstantTimeCopy(1, sig.S[:], buf[sizeFr:2*sizeFr])
 	n += sizeFr


### PR DESCRIPTION
# Description

Enforce subgroup check during signature verification. Also hardens deserialization. Add corresponding tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

Please describe the benchmarks that you ran to verify your changes.

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cryptographic signature verification and key deserialization; incorrect checks could break valid signatures or leave forgery paths open, though the intent is a security hardening fix with new tests.
> 
> **Overview**
> Hardens **twisted Edwards EdDSA** across all supported curves against **small-subgroup public keys** and lax binary decoding.
> 
> **Verification** now requires the public key to be a **non-identity** point in the **prime-order subgroup** (`validatePublicKeyPoint`), not merely on-curve. **Signature `R`** deserialization uses **`IsInSubGroup`** instead of **`IsOnCurve`**.
> 
> **`PublicKey` / `PrivateKey` `SetBytes`** apply the same subgroup rules. **`PrivateKey.SetBytes`** additionally enforces **RFC 8032 scalar pruning**, verifies **`publicKey == scalar × Base`**, and only then copies **`randSrc`**—rejecting mismatched or invalid serialized keys.
> 
> Matching **generator templates** and **regression tests** cover forged signatures under small-subgroup keys, rejected encodings, and tampered private-key blobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54453fb3f5ae448dcad57cea15fd754e8f3f50c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->